### PR TITLE
Simple guide to point apex domain to github pages

### DIFF
--- a/content/articles/github-pages.markdown
+++ b/content/articles/github-pages.markdown
@@ -1,6 +1,6 @@
 ---
 title: GitHub Pages
-excerpt:
+excerpt: How to point your root or apex domain to GitHub Pages using DNSimple.
 categories:
 - Services
 ---


### PR DESCRIPTION
I put the article under a new category (_GitHub and DNSimple_) that mimics the _Heroku and DNSimple_ one. But it may be better to put it under the _Services_ category.
