### PR TITLE
Add screenshots to transfer out explanation

### DIFF
--- a/content/articles/requesting-transfer-code.markdown
+++ b/content/articles/requesting-transfer-code.markdown
@@ -1,13 +1,21 @@
 ---
 title: Requesting a Transfer Code
-excerpt: 
+excerpt: How to request a transfer code to move a domain from DNSimple to a different registrar.
 categories:
 - Domain Transfers
 ---
 
 # Requesting a Transfer Code
 
-To request a transfer code to transfer a domain out of DNSimple, go to your domain's Manage page and click on the Transfer Out link in the Tasks section. This will unlock the domain and email a transfer code to the domain registrant.
+To request a transfer code to transfer a domain out of DNSimple, go to your domain's management page:
+
+![Go to domain's manage page](http://cl.ly/VZlC/get-transfer-code1.jpg)
+
+Once there click on the **Transfer Out** link in the **Tasks** section:
+
+![Find transfer out link](http://cl.ly/VayY/get-transfer-code2.jpg)
+
+This will unlock the domain and email a transfer code to the domain registrant.
 
 If you have requested a domain transfer out and have not received a code then please contact support@dnsimple.com  and include your domain name in the email.
 


### PR DESCRIPTION
I got a customer support request that didn't find the explanation helpful. I shared some screenshots with her and decided that it will be a good idea to include them in the article.
