### PR TITLE
Grammatical changes for CSR

### DIFF
--- a/content/articles/what-is-csr.markdown
+++ b/content/articles/what-is-csr.markdown
@@ -12,9 +12,9 @@ The **Certificate Signing Request** (also **CSR** or **certification request**) 
 The CSR contains information that will be included in your certificate, such as the [common name](/articles/what-is-common-name/) and the company/owner details. It also contains the public key that will be embedded in the certificate.
 
 <info>
-We automatically generates the CSR for you using the information from the contact associated with the certificate, along with an unique public/private encryption key pair. This works for the majority of cases, including all PaaS such as Heroku or Amazon.
+We automatically generate the CSR for you using the information from the contact associated with the certificate along with an unique public/private encryption key pair. This works for the majority of cases, including hosting platforms such as Heroku or Amazon.
 
-The private key associated with the certificate will be available to download, once generated, from your certificate page.
+The private key associated with the certificate will be available to download, once generated; from your certificate page.
 
-If you want to use a custom private key or you have some advanced requirement, you can generate a custom CSR and paste the custom CSR in the certificate purchase page.
+If you want to use a custom private key or have advanced requirements, you can generate a custom CSR to use in the certificate purchase page.
 </info>


### PR DESCRIPTION
Some improved puncutation and removal of PaaS. Not everyone knows what
we may be talking about with PaaS or what it means.

Also simplified the explanation of custom private keys for use in the
CSR request.
