### PR TITLE
Merge "Advanced DNS" category into "DNS"

### DIFF
--- a/content/articles/dnssec-support.markdown
+++ b/content/articles/dnssec-support.markdown
@@ -2,7 +2,7 @@
 title: DNSSEC Support
 excerpt: We currently support DS records for registered domains with DNS elsewhere, and we are examining the possibility of adding DNSSEC support to our authoritative name servers in the future.
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # DNSSEC Support

--- a/content/articles/ds-records-changing-dns.markdown
+++ b/content/articles/ds-records-changing-dns.markdown
@@ -2,9 +2,8 @@
 title: Managing DS Records when changing DNS
 excerpt: This article explains what you should do if you use DNSSEC and change DNS services
 categories:
-- Domains
 - Domain Transfers
-- Advanced DNS
+- DNS
 ---
 
 # Managing DS Records When Changing DNS

--- a/content/articles/ipv6-support.markdown
+++ b/content/articles/ipv6-support.markdown
@@ -2,7 +2,7 @@
 title: IPv6 Domain Resolution
 excerpt: 
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # IPv6 Domain Resolution

--- a/content/articles/master-slave-support.markdown
+++ b/content/articles/master-slave-support.markdown
@@ -2,7 +2,7 @@
 title: Master/Slave DNS Support 
 excerpt: 
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # Master/Slave DNS Support

--- a/content/articles/reverse-dns.markdown
+++ b/content/articles/reverse-dns.markdown
@@ -2,7 +2,7 @@
 title: Do you support Reverse DNS (i.e. PTR records)?
 excerpt: 
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # Do you support Reverse DNS (i.e. PTR records)?

--- a/content/articles/secondary-dns-provider-dns-made-easy.markdown
+++ b/content/articles/secondary-dns-provider-dns-made-easy.markdown
@@ -2,7 +2,7 @@
 title: Secondary DNS with DNSMadeEasy
 excerpt: Secondary DNS can be complicated to set up. We've simplified things with provider specific settings for DNSMadeEasy.
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # Secondary DNS configuration with DNSMadeEasy

--- a/content/articles/secondary-dns-provider-easy-dns.markdown
+++ b/content/articles/secondary-dns-provider-easy-dns.markdown
@@ -2,7 +2,7 @@
 title: Secondary DNS with EasyDNS
 excerpt: Secondary DNS can be complicated to set up. We've simplified things with provider specific settings for EasyDNS.
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # Secondary DNS configuration with EasyDNS

--- a/content/articles/secondary-dns.markdown
+++ b/content/articles/secondary-dns.markdown
@@ -2,7 +2,7 @@
 title: Secondary DNS
 excerpt: This page provides information about secondary DNS configuration with DNSimple.
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # Secondary DNS

--- a/content/articles/url-redirect-ssl.markdown
+++ b/content/articles/url-redirect-ssl.markdown
@@ -1,8 +1,8 @@
 ---
 title: Can a URL record redirect requests over SSL?
-excerpt: Welcome to DNSimple. This page is about our URL record and SSL. Hosted DNS has never been this easy.
+excerpt:
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # Can a URL record redirect requests over SSL?

--- a/content/articles/what-minimum-time-to-live.markdown
+++ b/content/articles/what-minimum-time-to-live.markdown
@@ -2,7 +2,7 @@
 title: What is the minimum time-to-live provided by DNSimple?
 excerpt: 
 categories:
-- Advanced DNS
+- DNS
 ---
 
 # What is the minimum time-to-live provided by DNSimple?


### PR DESCRIPTION
It's not clear the boundary between the two. We don't really need two
categories here.

@dnsimple/dnsimple any objection?