### PR TITLE
Makes steps clear

### DIFF
--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -126,10 +126,9 @@ p + .marker {
 // Sections don't apply to the entire page, they are just part of the article.
 
 .section-steps {
-  margin-bottom: $base-unit;
+  margin: $base-unit 0;
   padding: $base-unit / 2;
-  border-top: 5px solid #eee;
-  border-bottom: 5px solid #eee;
+  border-left: 5px solid #eee;
 
   a {
     text-decoration: underline;


### PR DESCRIPTION
Agreeing with this comment:
<img width="423" alt="screen shot 2016-08-10 at 9 17 36 am" src="https://cloud.githubusercontent.com/assets/80610/17545364/eff2c1ba-5edc-11e6-855d-6a35b681636e.png">

This PR removes the vertical bars and adds an horizontal bar instead like this:
<img width="769" alt="screen shot 2016-08-10 at 9 23 10 am" src="https://cloud.githubusercontent.com/assets/80610/17545385/094ca20c-5edd-11e6-9a8c-a2217beb3785.png">


