### PR TITLE
Add a warning against using desired login emails when creating accounts

### DIFF
--- a/content/articles/setting-up-accounts-for-clients.markdown
+++ b/content/articles/setting-up-accounts-for-clients.markdown
@@ -31,7 +31,7 @@ Each customer must have a separate account, otherwise if you add more than one c
 
 ## Creating a separate account for your client
 
-First, you must add another account to your user profile by taking the [following steps](/articles/account-multi/#creating-a-separate-account).
+First, you must add another account to your user profile by taking the [following steps](/articles/account-multi/#creating-a-separate-account). It is important that you do not use an email address that your client will use to login, but rather a group email to which notifications about the account should be addressed.
   
 ## Inviting your client to DNSimple
   

--- a/content/articles/setting-up-accounts-for-clients.markdown
+++ b/content/articles/setting-up-accounts-for-clients.markdown
@@ -31,7 +31,7 @@ Each customer must have a separate account, otherwise if you add more than one c
 
 ## Creating a separate account for your client
 
-First, you must add another account to your user profile by taking the [following steps](/articles/account-multi/#creating-a-separate-account). It is important that you do not use an email address that your client will use to login, but rather a group email to which notifications about the account should be addressed.
+First, you must add another account to your user profile by taking the [following steps](/articles/account-multi/#creating-a-separate-account). It is important that you do not use an email address that your client will use to login, but rather a group email to which notifications about the account should be addressed. Creating an account does not create credentials, but only a container for domains, certificates, and other resources.
   
 ## Inviting your client to DNSimple
   


### PR DESCRIPTION
Right now, there is no indication that there is any importance to the email address used when creating an account, but creating a new account will prevent the creation of login credentials with the same email address. This adds a note to prevent confusion.
