### PR TITLE
Fix invalid sitemap syntax

### DIFF
--- a/content/robots.txt.erb
+++ b/content/robots.txt.erb
@@ -1,1 +1,1 @@
-Sitemap: <%= @items['/sitemap.*'].path %>
+sitemap: <%= @config[:base_url] + @items['/sitemap.*'].path %>


### PR DESCRIPTION
As reported by Google Webmaster Tools.

![screen shot 2016-10-27 at 12 01 05](https://cloud.githubusercontent.com/assets/5387/19763382/13906890-9c3e-11e6-9c15-eebc33fe3fda.png)

As per sitemap specification, it should be an absolute URL.
https://developers.google.com/webmasters/control-crawl-index/docs/robots_txt