### PR TITLE
Provide new renewing SSL articles split based on CA

### DIFF
--- a/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
+++ b/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
@@ -13,11 +13,6 @@ There are a few important things you should note about [renewing an SSL certific
 
 All Let's Encrypt SSL certificates, including renewals, are valid for no more than 90 days from their issue date. Thirty days before the certificate expires you will begin receiving renewal notices. If you have not selected the [auto-renewal option](/articles/letsencrypt#auto-renewal), these are the steps to manually renew your Let's Encrypt certificate:
 
-1. Order the SSL certificate renewal
-1. Submit the SSL certificate renewal order
-1. Download the new SSL certificate and **replace the existing certificate on the server**
-
-
 <div class="section-steps" markdown="1">
 ##### To renew a certificate
 

--- a/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
+++ b/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
@@ -5,6 +5,8 @@ categories:
 - SSL Certificates
 ---
 
+# Renewing a Let's Encrypt SSL Certificate
+
 <note>
 There are a few important things you should note about [renewing an SSL certificate](/articles/renewing-ssl-certificate) before continuing with this document.
 </note>

--- a/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
+++ b/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
@@ -1,0 +1,36 @@
+---
+title: Renewing a Let's Encrypt SSL Certificate
+excerpt: Instructions to renew a Let's Encrypt SSL certificate for a domain with DNSimple.
+categories:
+- SSL Certificates
+---
+
+<note>
+There are a few important things you should note about [renewing an SSL certificate](/articles/renewing-ssl-certificate) before continuing with this document.
+</note>
+
+All Let's Encrypt SSL certificates, including renewals, are valid for no more than 90 days from their issue date. Thirty days before the certificate expires you will begin receiving renewal notices. If you have not selected the auto-renewal option, these are the steps to renew your Let's Encrypt certificate:
+
+1. Order the SSL certificate renewal
+1. Configure and submit the new SSL certificate
+1. Download the new SSL certificate and **replace the existing certificate on the server**
+
+
+<div class="section-steps" markdown="1">
+##### To renew a certificate
+
+1.  Log into your DNSimple account.
+1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  Scroll down to the <label>SSL certificates</label> section and find the active SSL certificate. Click <label>Renew</label> to start the renewal.
+
+    ![Renewing a Certificate](/files/certificates-renew-action.png)
+
+    If you can't see the <label>Renew</label> button, the certificate is either expired or not in a state that allows a renewal.
+
+1.  Follow the instructions to order the certificate renewal.
+
+    1.  Check the certificate [common name](/articles/what-is-common-name) matches the one you want to renew.
+    1.  If your plan supports it, add any names you will need using [Subject Alternative Name](/articles/what-is-san).
+    1.  Submit the order.
+
+</div>

--- a/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
+++ b/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
@@ -9,7 +9,7 @@ categories:
 There are a few important things you should note about [renewing an SSL certificate](/articles/renewing-ssl-certificate) before continuing with this document.
 </note>
 
-All Let's Encrypt SSL certificates, including renewals, are valid for no more than 90 days from their issue date. Thirty days before the certificate expires you will begin receiving renewal notices. If you have not selected the auto-renewal option, these are the steps to renew your Let's Encrypt certificate:
+All Let's Encrypt SSL certificates, including renewals, are valid for no more than 90 days from their issue date. Thirty days before the certificate expires you will begin receiving renewal notices. If you have not selected the [auto-renewal option](/articles/letsencrypt#auto-renewal), these are the steps to manually renew your Let's Encrypt certificate:
 
 1. Order the SSL certificate renewal
 1. Configure and submit the new SSL certificate

--- a/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
+++ b/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
@@ -31,7 +31,7 @@ All Let's Encrypt SSL certificates, including renewals, are valid for no more th
 
     1.  Check the certificate [common name](/articles/what-is-common-name) matches the one you want to renew.
     1.  Check the certificate details are accurate.
-    1.  Enable auto-renewal, if you don't want to manually renew it again.
+    1.  Enable auto-renewal, if you want it to be auto-renewed before expiration.
     1.  Submit the order.
 
 </div>

--- a/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
+++ b/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
@@ -12,7 +12,7 @@ There are a few important things you should note about [renewing an SSL certific
 All Let's Encrypt SSL certificates, including renewals, are valid for no more than 90 days from their issue date. Thirty days before the certificate expires you will begin receiving renewal notices. If you have not selected the [auto-renewal option](/articles/letsencrypt#auto-renewal), these are the steps to manually renew your Let's Encrypt certificate:
 
 1. Order the SSL certificate renewal
-1. Configure and submit the new SSL certificate
+1. Submit the SSL certificate renewal order
 1. Download the new SSL certificate and **replace the existing certificate on the server**
 
 
@@ -30,7 +30,8 @@ All Let's Encrypt SSL certificates, including renewals, are valid for no more th
 1.  Follow the instructions to order the certificate renewal.
 
     1.  Check the certificate [common name](/articles/what-is-common-name) matches the one you want to renew.
-    1.  If your plan supports it, add any names you will need using [Subject Alternative Name](/articles/what-is-san).
+    1.  Check the certificate details are accurate.
+    1.  Enable auto-renewal, if you don't want to manually renew it again.
     1.  Submit the order.
 
 </div>

--- a/content/articles/renewing-ssl-certificate.markdown
+++ b/content/articles/renewing-ssl-certificate.markdown
@@ -16,19 +16,6 @@ categories:
 
 DNSimple provides an SSL certificate renewal interface you can use to purchase a renewal for an SSL certificate. Please note that [an SSL certificate renewal is effectively a new SSL certificate purchase](/articles/how-certificate-renewal-works).
 
-All DNSimple SSL certificates, including renewals, are valid for one year from their issue date. Sixty days before the certificate expires you will begin receiving renewal notices.
-
-
-# Steps
-
-These are the steps required in order to successfully renew an existing SSL certificate:
-
-1. [Purchase the SSL certificate renewal](#order)
-1. Configure and submit the new SSL certificate
-1. Validate and approve the new SSL certificate
-1. Download the new SSL certificate and **replace the existing certificate on the server**
-
-
 ## Renewing an SSL certificate {#order}
 
 <note>
@@ -37,28 +24,12 @@ A renewal will not extend your existing certificate expiration date, it will res
 There is no way to extend the expiration of an existing certificate &mdash; [Learn more](/articles/how-certificate-renewal-works)
 </note>
 
-<div class="section-steps" markdown="1">
-##### To renew a certificate
+Our [SSL certificate products](/articles/ssl-certificates#ssl-certificate-products) fall into two major classes for how renewals work:
 
-1.  Log into your DNSimple account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
-1.  Scroll down to the <label>SSL certificates</label> section and find the active SSL certificate. Click <label>Renew</label> to start the renewal.
+- [Standard certificate renewals](/articles/renewing-standard-ssl-certificate)
+- [Let's Encrypt certificate renewals](/articles/renewing-lets-encrypt-ssl-certificate)
 
-    ![Renewing a Certificate](/files/certificates-renew-action.png)
-
-    If you can't see the <label>Renew</label> button, the certificate is either expired or not in a state that allows a renewal.
-
-1.  Follow the instructions to purchase the certificate renewal.
-
-    1.  Check the certificate [common name](/articles/what-is-common-name) matches the one you want to renew.
-    1.  Change the number of years if you want to purchase a certificate for more than 1 year. The [multi-year SSL certificate](/articles/can-multi-year-ssl-certificates) feature is only available to new plans.
-    1.  Leave the CSR option unchecked, unless you really need to provide a [custom CSR](/articles/what-is-csr). The easiest thing to do is to have us automatically generate the CSR (and a new private key to go with it).
-    1.  Submit the order.
-
-    ![Renew a Certificate](/files/dnsimple-certificate-renewal.png)
-
-</div>
-
+Please consult whichever document is correct for your needs.
 
 ## What's next?
 
@@ -66,23 +37,10 @@ Once you purchased the certificate renewal, **you will have to go through the st
 
 These are the same steps you followed after you purchased your original certificate. See [getting started with SSL certificates](/articles/getting-started-ssl-certificates).
 
-You will need to [verify the SSL certificate order](/articles/ssl-certificates-email-validation) again, since a new certificate will be issued.
+For a standard Comodo certificate, you will need to [verify the SSL certificate order](/articles/ssl-certificates-email-validation) again, since a new certificate will be issued.
 
 <warning>
 **If you don't verify the certificate, the renewal is not completed** and browsers will display a security warning when the old certificate expires.
 </warning>
 
 You may have more than 1 certificate for a host name at DNSimple at the same time, so renewing your certificate prior to the expiration date of your current certificate will not affect your operations. Note, however, that you will only be able to install 1 certificate on your server at a time.
-
-
-## New certificate expiration
-
-### Standard certificates
-
-If a certificate is renewed within 60 days from the expiration date, the expiration date of the renewed certificate will be calculated from the expiration of the existing certificate. Therefore, you will not lose any paid days from the previous certificate.
-
-We encourage you to plan the renewal of your certificate at least one week before the expiration, to avoid downtime or issues caused by possible renewal delays.
-
-### Let's Encrypt certificates
-
-The expiration of a Let's Encrypt certificate will be 90 days, from the issuance of the certificate, regardless it's a new purchase or a renewal.

--- a/content/articles/renewing-standard-ssl-certificate.markdown
+++ b/content/articles/renewing-standard-ssl-certificate.markdown
@@ -13,12 +13,6 @@ There are a few important things you should note about [renewing an SSL certific
 
 All standard DNSimple SSL certificates, including renewals, are valid for at least one year from their issue date. Sixty days before the certificate expires you will begin receiving renewal notices. These are the steps to renew your standard certificate:
 
-1. Purchase the SSL certificate renewal
-1. Configure and submit the new SSL certificate
-1. Validate and approve the new SSL certificate
-1. Download the new SSL certificate and **replace the existing certificate on the server**
-
-
 <div class="section-steps" markdown="1">
 ##### To renew a certificate
 

--- a/content/articles/renewing-standard-ssl-certificate.markdown
+++ b/content/articles/renewing-standard-ssl-certificate.markdown
@@ -1,0 +1,44 @@
+---
+title: Renewing a standard SSL Certificate
+excerpt: Instructions to renew a standard SSL certificate for a domain with DNSimple.
+categories:
+- SSL Certificates
+---
+
+<note>
+There are a few important things you should note about [renewing an SSL certificate](/articles/renewing-ssl-certificate) before continuing with this document.
+</note>
+
+All standard DNSimple SSL certificates, including renewals, are valid for at least one year from their issue date. Sixty days before the certificate expires you will begin receiving renewal notices. These are the steps to renew your standard certificate:
+
+1. Purchase the SSL certificate renewal
+1. Configure and submit the new SSL certificate
+1. Validate and approve the new SSL certificate
+1. Download the new SSL certificate and **replace the existing certificate on the server**
+
+
+<div class="section-steps" markdown="1">
+##### To renew a certificate
+
+1.  Log into your DNSimple account.
+1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  Scroll down to the <label>SSL certificates</label> section and find the active SSL certificate. Click <label>Renew</label> to start the renewal.
+
+    ![Renewing a Certificate](/files/certificates-renew-action.png)
+
+    If you can't see the <label>Renew</label> button, the certificate is either expired or not in a state that allows a renewal.
+
+1.  Follow the instructions to purchase the certificate renewal.
+
+    1.  Check the certificate [common name](/articles/what-is-common-name) matches the one you want to renew.
+    1.  Change the number of years if you want to purchase a certificate for more than 1 year. The [multi-year SSL certificate](/articles/can-multi-year-ssl-certificates) feature is only available to new plans.
+    1.  Leave the CSR option unchecked, unless you really need to provide a [custom CSR](/articles/what-is-csr). The easiest thing to do is to have us automatically generate the CSR (and a new private key to go with it).
+    1.  Submit the order.
+
+    ![Renew a Certificate](/files/dnsimple-certificate-renewal.png)
+
+</div>
+
+If a certificate is renewed within 60 days from the expiration date, the expiration date of the renewed certificate will be calculated from the expiration of the existing certificate. Therefore, you will not lose any paid days from the previous certificate.
+
+We encourage you to plan the renewal of your certificate to occur at least one week before the expiration, to avoid downtime or issues caused by possible renewal delays.

--- a/content/articles/renewing-standard-ssl-certificate.markdown
+++ b/content/articles/renewing-standard-ssl-certificate.markdown
@@ -5,6 +5,8 @@ categories:
 - SSL Certificates
 ---
 
+# Renewing a standard SSL Certificate
+
 <note>
 There are a few important things you should note about [renewing an SSL certificate](/articles/renewing-ssl-certificate) before continuing with this document.
 </note>


### PR DESCRIPTION
With this change we introduce a split in the renewing SSL articles based
on whether the certificate is from Let's Encrypt or a traditional CA.

This is in partial fulfillment of #217.