### PR TITLE
Help to choose between Let's Encrypt or Standard certificates

### DIFF
--- a/content/articles/letsencrypt.markdown
+++ b/content/articles/letsencrypt.markdown
@@ -50,14 +50,14 @@ The table below summarizes the most important differences between Let's Encrypt 
 
 ## Let's Encrypt highlights
 
-As mentioned before, Let's Encrypt is quite different than most traditional certificate authorities. Here are a few relevant information and limitations that you may want to keep in mind, before requesting one of their SSL certificates:
+Let's Encrypt is quite different than most traditional certificate authorities. Here are a few relevant notes and limitations that you may want to keep in mind, before requesting one of their SSL certificates:
 
 - Let's Encrypt only issues [domain-validated](/articles/ssl-certificates-types/) SSL certificates. There is no plan to support OV or EV certificates.
-- Wildcard names are not supported, Let's Encrypt SSL certificates can only include explicit names.
+- Wildcard names are not supported, Let's Encrypt SSL certificates can only include non-wildcard names.
 - A single Let's Encrypt certificate can include up to 100 SAN names.
 - Let's Encrypt certificates have fixed expiration period of 90 days. It's not possible to request a certificate with a longer expiration, therefore it won't be possible to obtain 1-year or [multi-year](/articles/can-multi-year-ssl-certificates) SSL certificates.
-- Although Let's Encrypt is a new authority, their SSL certificates are compatible with major browsers as their root certificate was cross-signed by an older certificate authority. For a complete list of supported platforms check out the [certificate compatibility](https://letsencrypt.org/docs/certificate-compatibility/) page.
-- Let's Encrypt certificates are domain-validated. The most common validation mechanisms are DNS-based and HTTP-based. They don't support traditional [email-based validation](/articles/ssl-certificates-email-validation).
+- Although Let's Encrypt is a new authority, their SSL certificates are compatible with major browsers as their root certificate was cross-signed by an older certificate authority. For a complete list of supported platforms visit the [certificate compatibility](https://letsencrypt.org/docs/certificate-compatibility/) page.
+- Let's Encrypt certificates are domain-validated. The most common validation mechanisms are DNS-based and HTTP-based. They do not support traditional [email-based validation](/articles/ssl-certificates-email-validation).
 - Let's Encrypt is currently [rate-limiting](https://letsencrypt.org/docs/rate-limits/) requests. Make sure to understand their limits before requesting a large number of certificates.
 
 Please note that some Let's Encrypt features may not be currently supported by DNSimple. Check the [limitations](/articles/letsencrypt/#limitations) section to know more about which features are supported.
@@ -71,9 +71,9 @@ The DNSimple Let's Encrypt integration allows you to request an SSL certificate 
 In order to request an SSL certificate with Let's Encrypt, the domains **must be delegated and resolving with DNSimple**. The domain does not need to be registered with DNSimple.
 </note>
 
-The certificate validation is completely automated using a DNS challenge. Once issued, you will receive an email and [webhook notification](https://developer.dnsimple.com/v2/webhooks/), the certificate will then be available to download from your DNSimple account.
+The certificate validation is completely automated using a DNS challenge. Once issued, you will receive an email and [webhook notification](https://developer.dnsimple.com/v2/webhooks/) and the certificate will then be available to download from your DNSimple account.
 
-The certificate expiration is 90 days. If auto-renewal is enabled, the certificate will be automatically renewed before the expiration. If a new validation is necessary, we will automatically re-validate the domain via DNS. Once renewed, you will receive an email and webhook notification.
+The certificate expiration is 90 days. If auto-renewal is enabled, the certificate will automatically renew before the expiration. If a new validation is necessary, we will automatically re-validate the domain via DNS. Once renewed, you will receive an email and webhook notification. You will still need to install the newly issued certificate once renewed.
 
 As suggested by Let's Encrypt, the renewal will happen at any time after 60 days (30 days before expiration).
 
@@ -84,7 +84,7 @@ Although Let's Encrypt certificates can be installed manually, the entire proces
 
 ## Products
 
-Let's Encrypt currently provides only one product. They issue only domain-validated, SAN certificates. Let's Encrypt doesn't support wildcard certificates.
+Let's Encrypt currently provides only one product. They issue only domain-validated, SAN certificates. Let's Encrypt does not support wildcard certificates.
 
 <callout>
 If you are interested in a wildcard certificate, DNSimple [offers wildcard certificates](/articles/ssl-certificates/#standard-wildcard) using a different certificate authority.
@@ -101,9 +101,9 @@ The ability to customize the names associated with a Let's Encrypt certificate d
 
 Let's Encrypt feature support varies based on your DNSimple subscription plan.
 
-Note that not all Let's Encrypt features are currently supported by DNSimple. Some features will be incrementally introduced in the future, others are not supported due to design decisions or limitations imposed by our system.
+Note that not all Let's Encrypt features are currently supported by DNSimple. Some features will be incrementally introduced in the future, while others are not supported due to design decisions or limitations imposed by our system.
 
-- You can request as many certificate as you want, as long as you stay within Let's Encrypt request [rate-limiting](https://letsencrypt.org/docs/rate-limits/).
+- You can request as many certificates as you want, as long as you stay within Let's Encrypt [rate limits](https://letsencrypt.org/docs/rate-limits/).
 - Depending on your plan, you can specify the hostname for the certificate, or it will be defaulted to www/root domain.
 - Depending on your plan, you can specify up to 100 extra hostnames for a single certificate. Remember that Let's Encrypt doesn't support wildcard certificates, and we currently only support subdomains (it's not possible to add names from different domains).
 
@@ -113,12 +113,12 @@ Note that not all Let's Encrypt features are currently supported by DNSimple. So
 - It's currently not possible to provide a custom CSR or private key while requesting a new certificate. The CSR will be generated by DNSimple, based on the domains specified in the certificate order.
 - We only support DNS-based validation. It's not possible to use the HTTP or TLS-SNI challenges.
 - The domain must be resolving with us, as we will automatically create the DNS records required for the validation.
-- We don't currently support the ability to include names from different domains in the same certificate SAN. Instead, we only support same-domain names (subdomains).
+- We do not currently support the ability to include names from different domains in the same certificate SAN. Instead, we only support same-domain names (subdomains).
 
 
 ## Testing
 
-We currently don't support Let's Encrypt in our [sandbox environment](/articles/sandbox). We discourage the use of the production environment for heavy or automated testing purposes, as you may quickly hit Let's Encrypt [rate limits](https://letsencrypt.org/docs/rate-limits/).
+We currently do not support Let's Encrypt in our [sandbox environment](/articles/sandbox). We discourage the use of the production environment for heavy or automated testing purposes, as you may quickly hit Let's Encrypt [rate limits](https://letsencrypt.org/docs/rate-limits/).
 
 If you have specific testing needs, you may want to consider using the Let's Encrypt [staging environment](https://letsencrypt.org/docs/staging-environment/) directly.
 

--- a/content/articles/letsencrypt.markdown
+++ b/content/articles/letsencrypt.markdown
@@ -32,9 +32,25 @@ Let's Encrypt is an innovative certificate authority from several point of views
 - open: the source code of the Let's Encrypt certification authority is completely open source, and available in a [GitHub account](http://github.com/letsencrypt). This is by far the most unique characteristic of this CA.
 
 
+## Differences between Let's Encrypt and Standard SSL certificates
+
+The table below summarizes the most important differences between Let's Encrypt and Standard SSL certificates.
+
+|               | Let's Encrypt | Standard      |
+|---------------+---------------+---------------|
+| Certificate Expiration | 90 days | 1-3 years |
+| Single names | Supported | Supported |
+| Wildcard names | Not Supported | Supported |
+| Multi-domain (SAN) | Supported by default | Supported only by specific products |
+| Max SAN domains | 100 | Depends on the [CA](/articles/what-is-certificate-authority) and product |
+| [Validation type](/articles/ssl-certificates-types/#ssl-certificates-by-validation-level) | DV only | DV, OV, EV |
+| Cost | Free | Depends on the [CA](/articles/what-is-certificate-authority) and product |  
+| Limits | [Per-domain, Per-week limits](https://letsencrypt.org/docs/rate-limits/) | N/A |  
+
+
 ## Let's Encrypt highlights
 
-As mentioned before, Let's Encrypt is quite different than most traditional certificate authorities. Here are a few relevant pieces of information that you may want to keep in mind, before requesting one of their SSL certificates:
+As mentioned before, Let's Encrypt is quite different than most traditional certificate authorities. Here are a few relevant information and limitations that you may want to keep in mind, before requesting one of their SSL certificates:
 
 - Let's Encrypt only issues [domain-validated](/articles/ssl-certificates-types/) SSL certificates. There is no plan to support OV or EV certificates.
 - Wildcard names are not supported, Let's Encrypt SSL certificates can only include explicit names.
@@ -43,6 +59,8 @@ As mentioned before, Let's Encrypt is quite different than most traditional cert
 - Although Let's Encrypt is a new authority, their SSL certificates are compatible with major browsers as their root certificate was cross-signed by an older certificate authority. For a complete list of supported platforms check out the [certificate compatibility](https://letsencrypt.org/docs/certificate-compatibility/) page.
 - Let's Encrypt certificates are domain-validated. The most common validation mechanisms are DNS-based and HTTP-based. They don't support traditional [email-based validation](/articles/ssl-certificates-email-validation).
 - Let's Encrypt is currently [rate-limiting](https://letsencrypt.org/docs/rate-limits/) requests. Make sure to understand their limits before requesting a large number of certificates.
+
+Please note that some Let's Encrypt features may not be currently supported by DNSimple. Check the [limitations](/articles/letsencrypt/#limitations) section to know more about which features are supported.
 
 
 ## Integration

--- a/content/articles/ssl-certificates.markdown
+++ b/content/articles/ssl-certificates.markdown
@@ -65,7 +65,7 @@ The certificate is issued by **Let's Encrypt** and it's free of charge. However,
 The ability to customize the names associated with a Let's Encrypt certificate depends on the plan you are subscribed to.
 </note>
 
-### What's a "Standard" Certificate Authority?
+### What's a "Standard" Certificate Authority? {#standard-certificate}
 
 You may have noticed we used the term _standard_ in our documentation when referring to some specific product types. Let's Encrypt has represented a big shift in the certificate authority field, in terms of offering, pricing, and automation. Traditionally, certificate authorities have been offering yearly certificates, they charged an issuance fee, and the domain validation was generally performed manually via email.
 

--- a/content/articles/standard-vs-letsencrypt.markdown
+++ b/content/articles/standard-vs-letsencrypt.markdown
@@ -1,0 +1,56 @@
+---
+title: Standard vs Let's Encrypt SSL Certificates
+excerpt: This article summarizes the most important DNSimple offering differences between Let's Encrypt and Standard SSL certificates.
+categories:
+- SSL Certificates
+---
+
+# Standard vs Let's Encrypt SSL Certificates
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+<callout>
+In this article we'll use the term _standard_ as described in our [TLS/SSL certificate page](/articles/ssl-certificates#standard-certificate).
+</callout>
+
+## Comparison Let's Encrypt vs Standard SSL certificates
+
+The table below summarizes the most important DNSimple offering differences between Let's Encrypt and Standard SSL certificates. These differences may help you to decide which certificate you need.
+
+<note>
+Please note that the table only reflects the status of the current DNSimple offering. Some features may be available at the Certificate Authority, but currently not supported by DNSimple.
+</note>
+
+|               | Let's Encrypt | Standard      |
+|---------------+---------------+---------------|
+Certificate Expiration | 90 days | 1-3 years
+Single names | Supported | Supported
+Custom Single names | Supported (on certain plans) | Supported
+Wildcard names | Not Supported (by CA) | Supported
+Same-domain multi-names (SAN) | Supported (on certain plans) | Not Supported
+Multi-domains (SAN) | Not Supported | Not Supported
+[Validation type](/articles/ssl-certificates-types/#ssl-certificates-by-validation-level) | DV via DNS only | DV via email only
+Cost | Free | $20-$100
+Custom CSR | Not Supported | Supported
+
+## What is the right certificate for me? {#whichone}
+
+The following list of questions may help you to determine what is the best certificate for you. The answer is based on possible limitations of a specific certificate to fulfill the requirement. This also means that if you combine two or more questions (requirement), the results may conflict each other.
+
+| Requirement | Answer |
+|-------------+--------|
+You want to secure a domain name. | **Let's Encrypt** &middot; **Standard**
+You want to provide a custom CSR | **Standard**
+You want to use a custom private key. | **Standard**
+You want to use a wildcard name. | **Standard**
+You want a longer multi-year expiration. | **Standard**
+You want to fully automate SSL certificate orders without manual intervention. | **Let's Encrypt**
+Your domain is resolving with DNSimple. | **Let's Encrypt** &middot; **Standard**
+Your domain is NOT resolving with DNSimple. | **Standard**
+Your domain is NOT registered but resolving with DNSimple. | **Let's Encrypt** &middot; **Standard**
+Your domain is NOT registered ant NOT resolving with DNSimple. | **Standard**

--- a/content/articles/standard-vs-letsencrypt.markdown
+++ b/content/articles/standard-vs-letsencrypt.markdown
@@ -44,13 +44,13 @@ The following list of questions may help you to determine what is the best certi
 
 | Requirement | Answer |
 |-------------+--------|
-You want to secure a domain name. | **Let's Encrypt** &middot; **Standard**
+You want to secure a domain name. | **Let's Encrypt** or **Standard**
 You want to provide a custom CSR | **Standard**
 You want to use a custom private key. | **Standard**
 You want to use a wildcard name. | **Standard**
 You want a longer multi-year expiration. | **Standard**
 You want to fully automate SSL certificate orders without manual intervention. | **Let's Encrypt**
-Your domain is resolving with DNSimple. | **Let's Encrypt** &middot; **Standard**
+Your domain is resolving with DNSimple. | **Let's Encrypt** or **Standard**
 Your domain is NOT resolving with DNSimple. | **Standard**
-Your domain is NOT registered but resolving with DNSimple. | **Let's Encrypt** &middot; **Standard**
+Your domain is NOT registered but resolving with DNSimple. | **Let's Encrypt** or **Standard**
 Your domain is NOT registered ant NOT resolving with DNSimple. | **Standard**


### PR DESCRIPTION
I created an article to help the customers select which certificate is the best for them. The idea is to link the article in this page:

![screen_shot_2016-11-15_at_12_04_54](https://cloud.githubusercontent.com/assets/5387/20303470/cf9715d8-ab2b-11e6-95d8-23b387708f2b.png)

I wonder what's the best way to render this section here. Is it a table appropriate, or would it be more appropriate to add each question as new heading, and a short explanation as a response?

/cc @dnsimple/dnsimple 