### PR TITLE
Add a warning about reissuing Let's Encrypt certificates

### DIFF
--- a/content/articles/reissuing-ssl-certificate.markdown
+++ b/content/articles/reissuing-ssl-certificate.markdown
@@ -24,6 +24,9 @@ Re-issuing an SSL certificate involves creating a new private key along with a n
 In general, re-issuing a new SSL certificate takes from 2 to 5 days. However, [the time frame depends on many factors](/articles/how-long-to-issue-ssl-certificate).
 </note>
 
+<warning>
+This document applies only to standard SSL certificates. Let's Encrypt certificates cannot be reissued at this time. If the situation arises that you would otherwise reissue your Let's Encrypt certificate, we suggest you [order a new Let's Encrypt certificate](/articles/ordering-lets-encrypt-certificate) at this time.
+</warning>
 
 ## Why should I re-issue my certificate?
 

--- a/content/articles/reissuing-ssl-certificate.markdown
+++ b/content/articles/reissuing-ssl-certificate.markdown
@@ -26,6 +26,8 @@ In general, re-issuing a new SSL certificate takes from 2 to 5 days. However, [t
 
 <warning>
 This document applies only to standard SSL certificates. Let's Encrypt certificates cannot be reissued at this time. If the situation arises that you would otherwise reissue your Let's Encrypt certificate, we suggest you [order a new Let's Encrypt certificate](/articles/ordering-lets-encrypt-certificate) at this time.
+
+Please note that there are [rate limits](https://letsencrypt.org/docs/rate-limits/) in place with Let's Encrypt, so be sure to request a new certificate only when absolutely necessary or you may be unable to request other certificates.
 </warning>
 
 ## Why should I re-issue my certificate?


### PR DESCRIPTION
Right now, we do not support reissuing Let's Encrypt certificates. Instead, this document suggests customers order a new certificate.

This is related to #217