### PR TITLE
New Heroku SSL urls

### DIFF
--- a/content/articles/domain-apex-heroku.markdown
+++ b/content/articles/domain-apex-heroku.markdown
@@ -56,6 +56,8 @@ These are the steps that you will need to follow to add an ALIAS record that poi
 
 </div>
 
+**Note:** Heroku endpoints can be either `myapp.herokuapp.com` or `myapp.herokudns.com`. You should use `myapp.herokudns.com` [if you are using Heroku SSL](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains) and `myapp.herokuapp.com`if not.
+
 
 ## Setting up your custom domain at Heroku {#set-up-domain-heroku}
 

--- a/content/articles/domain-apex-heroku.markdown
+++ b/content/articles/domain-apex-heroku.markdown
@@ -56,7 +56,7 @@ These are the steps that you will need to follow to add an ALIAS record that poi
 
 </div>
 
-**Note:** Heroku endpoints can be either `myapp.herokuapp.com` or `myapp.herokudns.com`. You should use `myapp.herokudns.com` [if you are using Heroku SSL](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains) and `myapp.herokuapp.com`if not.
+**Note:** Heroku endpoints can be either `myapp.herokuapp.com` or `example.com.herokudns.com`. You should use `example.com.herokudns.com` [if you are using Heroku SSL](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains) and `myapp.herokuapp.com`if not.
 
 
 ## Setting up your custom domain at Heroku {#set-up-domain-heroku}

--- a/content/articles/heroku-error-differentapp.markdown
+++ b/content/articles/heroku-error-differentapp.markdown
@@ -30,7 +30,7 @@ You can experience the same behaviour if the `red-turtle` application belongs to
 1. The application with the custom domain setup is yours
 2. The application with the custom domain setup belongs to someone else
 
-**Note:** Heroku endpoints can be either `myapp.herokuapp.com` or `myapp.herokudns.com`. You should use `myapp.herokudns.com` [if you are using Heroku SSL](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains) and `myapp.herokuapp.com` if not.
+**Note:** Heroku endpoints can be either `myapp.herokuapp.com` or `example.com.herokudns.com`. You should use `example.com.herokudns.com` [if you are using Heroku SSL](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains) and `myapp.herokuapp.com` if not.
 
 ## Solution
 

--- a/content/articles/heroku-error-differentapp.markdown
+++ b/content/articles/heroku-error-differentapp.markdown
@@ -30,6 +30,8 @@ You can experience the same behaviour if the `red-turtle` application belongs to
 1. The application with the custom domain setup is yours
 2. The application with the custom domain setup belongs to someone else
 
+**Note:** Heroku endpoints can be either `myapp.herokuapp.com` or `myapp.herokudns.com`. You should use `myapp.herokudns.com` [if you are using Heroku SSL](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains) and `myapp.herokuapp.com`if not.
+
 ## Solution
 
 ### The application with the custom domain setup is yours

--- a/content/articles/heroku-error-differentapp.markdown
+++ b/content/articles/heroku-error-differentapp.markdown
@@ -30,7 +30,7 @@ You can experience the same behaviour if the `red-turtle` application belongs to
 1. The application with the custom domain setup is yours
 2. The application with the custom domain setup belongs to someone else
 
-**Note:** Heroku endpoints can be either `myapp.herokuapp.com` or `myapp.herokudns.com`. You should use `myapp.herokudns.com` [if you are using Heroku SSL](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains) and `myapp.herokuapp.com`if not.
+**Note:** Heroku endpoints can be either `myapp.herokuapp.com` or `myapp.herokudns.com`. You should use `myapp.herokudns.com` [if you are using Heroku SSL](https://devcenter.heroku.com/articles/custom-domains#view-existing-domains) and `myapp.herokuapp.com` if not.
 
 ## Solution
 

--- a/content/articles/redirect-heroku.markdown
+++ b/content/articles/redirect-heroku.markdown
@@ -77,9 +77,27 @@ In this case, [you cannot use our redirector service](/articles/redirector-https
 In order to redirect using HTTPS, you need to have a certificate that covers both the www and not-www (root domain) host names. You can purchase a single-name certificate for `www` or a wildcard certificates for `*` [to cover the root domain](/articles/ssl-certificate-host name/) with the same certificate.
 </warning>
 
-
 <div class="section-steps" markdown="1">
 ##### To handle the redirect at Heroku {#redirect-https-application}
+##### For Heroku SSL
+
+1.  Add both host names to the Heroku application:
+
+    - `$ heroku domains:add example.com`
+    - `$ heroku domains:add www.example.com`
+
+1. [Order the SSL certificate](https://devcenter.heroku.com/articles/ssl-certificate-dnsimple) and add it to Heroku(https://devcenter.heroku.com/articles/ssl):
+
+    - `$ heroku certs:add server.crt server.key`
+
+1.  Go to the record editor and two DNS records, one for each host name, **pointing to the Heroku SSL endpoint**:
+
+    - Add an [ALIAS record](/articles/alias-record) to point `example.com` to Heroku. Leave the _Name_ of the record empty and set the _Content_ field to the SSL endpoint `encrypted-application.herokudns.com`
+    - Add a [CNAME record](/articles/cname-record) to point `www.example.com` to Heroku. The _Name_ of the record is `www` and the _Content_ field is the SSL endpoint `encrypted-application.herokudns.com`
+
+1.  In your application, intercept the incoming request. If the request host is not the canonical one, redirect the request to the canonical domain. How to perform a redirect depends on the programming language and/or framework your application is developed with.
+
+##### For Heroku SSL endpoint
 
 1.  Add both host names to the Heroku application:
 
@@ -107,12 +125,28 @@ In this case, [you cannot use our redirector service](/articles/redirector-https
 
 <div class="section-steps" markdown="1">
 ##### To handle the redirect at Heroku {#redirect-http2https-application}
+##### For Heroku SSL
 
 1.  Add the host names to the Heroku application:
 
     - `$ heroku domains:add example.com`
 
-1.  [Order the SSL certificate](https://devcenter.heroku.com/articles/ssl-certificate-dnsimple) and install it on Heroku. Heroku will provide you a specific SSL endpoint similar to `encrypted-application.herokussl.com`.
+1.  [Order the SSL certificate](https://devcenter.heroku.com/articles/ssl-certificate-dnsimple) and [install it on Heroku](https://devcenter.heroku.com/articles/ssl). Heroku will provide you a specific SSL endpoint similar to `encrypted-application.herokudns.com`. 
+
+1.  Go to the record editor and a DNS records for the host name, **pointing to the Heroku SSL endpoint**:
+
+    - If the host name is the root domain (e.g. `example.com`): add an [ALIAS record](/articles/alias-record) to point `example.com` to Heroku. Leave the _Name_ of the record empty and set the _Content_ field to the SSL endpoint `encrypted-application.herokudns.com`
+    - If the host name is a subdomain (e.g. `www.example.com`): Add a [CNAME record](/articles/cname-record) to point `www.example.com` to Heroku. The _Name_ of the record is `www` and the _Content_ field is the SSL endpoint `encrypted-application.herokudns.com`
+
+1.  In your application, intercept the incoming request. If the request comes from HTTP, redirect the request to the same domain replacing HTTP with HTTPS. How to perform a redirect depends on the programming language and/or framework your application is developed with.
+
+##### For Heroku SSL endpoint
+
+1.  Add the host names to the Heroku application:
+
+    - `$ heroku domains:add example.com`
+
+1.  [Order the SSL certificate](https://devcenter.heroku.com/articles/ssl-certificate-dnsimple) and install it on Heroku. Heroku will provide you a specific SSL endpoint similar to `encrypted-application.herokussl.com`. 
 
 1.  Go to the record editor and a DNS records for the host name, **pointing to the Heroku SSL endpoint**:
 

--- a/content/articles/redirect-heroku.markdown
+++ b/content/articles/redirect-heroku.markdown
@@ -92,12 +92,12 @@ In order to redirect using HTTPS, you need to have a certificate that covers bot
 
 1.  Go to the record editor and two DNS records, one for each host name, **pointing to the Heroku SSL endpoint**:
 
-    - Add an [ALIAS record](/articles/alias-record) to point `example.com` to Heroku. Leave the _Name_ of the record empty and set the _Content_ field to the SSL endpoint `encrypted-application.herokudns.com`
-    - Add a [CNAME record](/articles/cname-record) to point `www.example.com` to Heroku. The _Name_ of the record is `www` and the _Content_ field is the SSL endpoint `encrypted-application.herokudns.com`
+    - Add an [ALIAS record](/articles/alias-record) to point `example.com` to Heroku. Leave the _Name_ of the record empty and set the _Content_ field to the SSL endpoint `example.com.herokudns.com`
+    - Add a [CNAME record](/articles/cname-record) to point `www.example.com` to Heroku. The _Name_ of the record is `www` and the _Content_ field is the SSL endpoint `www.example.com.herokudns.com`
 
 1.  In your application, intercept the incoming request. If the request host is not the canonical one, redirect the request to the canonical domain. How to perform a redirect depends on the programming language and/or framework your application is developed with.
 
-##### For Heroku SSL endpoint
+##### For Heroku SSL endpoint (legacy)
 
 1.  Add both host names to the Heroku application:
 
@@ -140,7 +140,7 @@ In this case, [you cannot use our redirector service](/articles/redirector-https
 
 1.  In your application, intercept the incoming request. If the request comes from HTTP, redirect the request to the same domain replacing HTTP with HTTPS. How to perform a redirect depends on the programming language and/or framework your application is developed with.
 
-##### For Heroku SSL endpoint
+##### For Heroku SSL endpoint (legacy)
 
 1.  Add the host names to the Heroku application:
 

--- a/content/articles/redirect-heroku.markdown
+++ b/content/articles/redirect-heroku.markdown
@@ -131,12 +131,12 @@ In this case, [you cannot use our redirector service](/articles/redirector-https
 
     - `$ heroku domains:add example.com`
 
-1.  [Order the SSL certificate](https://devcenter.heroku.com/articles/ssl-certificate-dnsimple) and [install it on Heroku](https://devcenter.heroku.com/articles/ssl). Heroku will provide you a specific SSL endpoint similar to `encrypted-application.herokudns.com`. 
+1.  [Order the SSL certificate](https://devcenter.heroku.com/articles/ssl-certificate-dnsimple) and [install it on Heroku](https://devcenter.heroku.com/articles/ssl). Heroku will provide you a specific SSL endpoint similar to `example.com.herokudns.com`. 
 
 1.  Go to the record editor and a DNS records for the host name, **pointing to the Heroku SSL endpoint**:
 
-    - If the host name is the root domain (e.g. `example.com`): add an [ALIAS record](/articles/alias-record) to point `example.com` to Heroku. Leave the _Name_ of the record empty and set the _Content_ field to the SSL endpoint `encrypted-application.herokudns.com`
-    - If the host name is a subdomain (e.g. `www.example.com`): Add a [CNAME record](/articles/cname-record) to point `www.example.com` to Heroku. The _Name_ of the record is `www` and the _Content_ field is the SSL endpoint `encrypted-application.herokudns.com`
+    - If the host name is the root domain (e.g. `example.com`): add an [ALIAS record](/articles/alias-record) to point `example.com` to Heroku. Leave the _Name_ of the record empty and set the _Content_ field to the SSL endpoint `example.com.herokudns.com`
+    - If the host name is a subdomain (e.g. `www.example.com`): Add a [CNAME record](/articles/cname-record) to point `www.example.com` to Heroku. The _Name_ of the record is `www` and the _Content_ field is the SSL endpoint `example.com.herokudns.com`
 
 1.  In your application, intercept the incoming request. If the request comes from HTTP, redirect the request to the same domain replacing HTTP with HTTPS. How to perform a redirect depends on the programming language and/or framework your application is developed with.
 


### PR DESCRIPTION
This PR addresses the issue: https://github.com/dnsimple/dnsimple-support/issues/256

I'm going to move discussion from the issue here, this is the list of pages that has herokuapp.com

- alias-record.markdown
- domain-apex-heroku.markdown
- heroku-error-differentapp.markdown
- heroku-error-ssl.markdown
- redirect-heroku.markdown

Of those pages I have discarded the following:

- alias-record.markdown (herokuapp is mentioned as an example but it is not specific as an heroku setting).
- heroku-error-ssl.markdown (it is already updated with the infomation about the new herokudns endpoint)

I have also updated:

- heroku-error-differentapp.markdown
- domain-apex-heroku.markdown

And I'm undecided on what to do about this one: 

- redirect-heroku.markdown (it's either re-writing with the new Heroku SSL information or just adding a note announcing the availability of it)