### PR TITLE
update ICANN verification email address

### DIFF
--- a/content/articles/icann-domain-validation.markdown
+++ b/content/articles/icann-domain-validation.markdown
@@ -13,7 +13,7 @@ When you make a change to your registrant's email address or name, you will rece
 
 ![ICANN Verification Email](/files/icann-verification-email.png)
 
-This email will be sent from an `@dnsimple.com` email address and will include a link similar to the following:
+This email will be sent from the address `DNSimple <donotreply@name-services.com>` and will include a link similar to the following:
 
 `http://raa.name-services.com/raaverification/verification.aspx?VerificationCode=A8E3763E-EE70-42DB-A654-20BF560300A00`
 

--- a/content/articles/icann-domain-validation.markdown
+++ b/content/articles/icann-domain-validation.markdown
@@ -19,7 +19,7 @@ This email will be sent from the address `DNSimple <donotreply@name-services.com
 
 Click the link to verify the registrant email address.
 
-The link must be to `http://raa.name-servers.com` - if you receive a verification email and this link is not in the email then please contact support@dnsimple.com, forwarding the email you received.
+The link must be to `http://raa.name-services.com` - if you receive a verification email and this link is not in the email then please contact support@dnsimple.com, forwarding the email you received.
 
 ## What happens when a domain is suspended?
 


### PR DESCRIPTION
The email that ICANN sends from now just has out name but is under name-services. Change this article for now to prevent confusion and discarded emails