### PR TITLE
Correct wildcard instructions

### DIFF
--- a/content/articles/email-forwarding.markdown
+++ b/content/articles/email-forwarding.markdown
@@ -47,7 +47,7 @@ In the **To** field enter the email address you would like as the recipient of t
 
 ### Catch-all emails
 
-To create a catch-all address follow the instructions to create an email and enter the following wildcard expression in the **To** field:
+To create a catch-all address follow the instructions to create an email and enter the following wildcard expression in the **From** field:
 
     (.*)
 


### PR DESCRIPTION
This PR is a short one that fixes the instructions on how to create a catch-all address, this is done by simply change the field where the wildcard expression goes that should be in the From field instead of the To field

This came after a customer support request that made me investigate on wildcard to wildcard requests and realizing that the article was not correct.