### PR TITLE
Fix broken IMG url in /billing-settings article

### DIFF
--- a/content/articles/billing-settings.markdown
+++ b/content/articles/billing-settings.markdown
@@ -38,7 +38,7 @@ It is possible to deliver your invoices to a different email address that the on
 
 1. Update the email and click on <label>Save</label> when you are done.
 
-    ![Change billing email](/files/account-billing-email-update.png)
+    ![Change billing email](/files/account-edit-billing-email-update.png)
 
 </div>
 


### PR DESCRIPTION
Fix broken URL in step 5 of billing settings article:

![img](https://cl.ly/1J1S101j1B0r/Screen%20Shot%202017-05-19%20at%208.41.17%20AM.png)