### PR TITLE
Link to plans page when mentioning plan reqs

### DIFF
--- a/content/articles/letsencrypt.markdown
+++ b/content/articles/letsencrypt.markdown
@@ -93,7 +93,7 @@ If you are interested in a wildcard certificate, DNSimple [offers wildcard certi
 Single-name certificates can be considered a special type of multi-name certificates, with a single name associated with it. Therefore, Let's Encrypt offering is both a multi-name and single-name.
 
 <note>
-The ability to customize the names associated with a Let's Encrypt certificate depends on the plan you are subscribed to.
+The ability to customize the names associated with a Let's Encrypt certificate depends on the plan you are subscribed to. Please check the [plans and pricing page](https://dnsimple.com/pricing) to view all options.
 </note>
 
 
@@ -104,7 +104,7 @@ Let's Encrypt feature support varies based on your DNSimple subscription plan.
 Note that not all Let's Encrypt features are currently supported by DNSimple. Some features will be incrementally introduced in the future, while others are not supported due to design decisions or limitations imposed by our system.
 
 - You can request as many certificates as you want, as long as you stay within Let's Encrypt [rate limits](https://letsencrypt.org/docs/rate-limits/).
-- Depending on your plan, you can specify the hostname for the certificate, or it will be defaulted to www/root domain.
+- Depending on your plan, you can specify the hostname for the certificate, or it will be defaulted to www/root domain. Please see [plans and pricing page](https://dnsimple.com/pricing) to view all options and change your plan if needed.
 - Depending on your plan, you can specify up to 100 extra hostnames for a single certificate. Remember that Let's Encrypt doesn't support wildcard certificates, and we currently only support subdomains (it's not possible to add names from different domains).
 
 

--- a/content/articles/ssl-certificates.markdown
+++ b/content/articles/ssl-certificates.markdown
@@ -62,7 +62,7 @@ The Let's Encrypt certificate is a **multi-name (SAN)**, **domain-validated cert
 The certificate is issued by **Let's Encrypt** and it's free of charge. However, certain characteristics or requirements of this certificate may make this product unsuitable for you. [Learn more](/articles/letsencrypt#products)
 
 <note>
-The ability to customize the names associated with a Let's Encrypt certificate depends on the plan you are subscribed to.
+The ability to customize the names associated with a Let's Encrypt certificate depends on the plan you are subscribed to. Please check the [plans and pricing page](https://dnsimple.com/pricing) to view all options.
 </note>
 
 ### What's a "Standard" Certificate Authority? {#standard-certificate}


### PR DESCRIPTION
Looking for feedback. I'l love to see how I can make sure when people see the slightly vague wording (depending on your plan type can can or can't do this) we are at least linking them directly where they can see the rules in clear terms and make plan choices depending on their needs