### PR TITLE
Add a little bit more of a hint about yearly email forwards

### DIFF
--- a/content/articles/email-forwarding.markdown
+++ b/content/articles/email-forwarding.markdown
@@ -14,7 +14,7 @@ categories:
 
 ---
 
-Email forwarding can be enabled on a domain-by-domain basis. The cost is $2 per month (or $12 per year if you are on a yearly plan) per domain. The number of messages per month is based on your subscription type:
+Email forwarding can be enabled on a domain-by-domain basis. The cost is $2 per month (or $24 per year if you are on a yearly plan) per domain. The number of messages per month is based on your subscription type:
 
 - Personal plans: up to 1,000 messages forwarded per month per domain.
 - Professional plans: up to 10,000 messages forwarded per month per domain.

--- a/content/articles/email-forwarding.markdown
+++ b/content/articles/email-forwarding.markdown
@@ -14,7 +14,7 @@ categories:
 
 ---
 
-Email forwarding can be enabled on a domain-by-domain basis. The cost is $2 per month per domain. The number of messages per month is based on your subscription type:
+Email forwarding can be enabled on a domain-by-domain basis. The cost is $2 per month (or $12 per year if you are on a yearly plan) per domain. The number of messages per month is based on your subscription type:
 
 - Personal plans: up to 1,000 messages forwarded per month per domain.
 - Professional plans: up to 10,000 messages forwarded per month per domain.


### PR DESCRIPTION
Customers have written in before confused about yearly costs for email forwards and I think we can go a little bit farther to help make it clear we charge for 12 months vs 1 month when you are on a yearly plan when you add an email forward. We may want to look at clarifying this in the app and via the invoicing system to denote a yearly cost vs monthly.