### PR TITLE
Fix markdown for links

### DIFF
--- a/content/articles/what-is-tld.markdown
+++ b/content/articles/what-is-tld.markdown
@@ -11,9 +11,7 @@ The term top-level domain, or TLD, refers to the first part of every domain name
 
 There are currently over 1200 TLDs, but not all of them are open for registration. For more information about available and supported TLDs, check the [list of TLDs supported by DNSimple for registration and transfer](https://dnsimple.com/tlds). 
 
-<callout>
 Even if a TLD is not supported for registration or transfer, you can still [add the domain to your account](/articles/adding-domain/) to use DNSimple for the DNS hosting or other domain services such as [purchasing an SSL certificate](https://dnsimple.com/ssl-certificates).
-</callout>
 
 TLDs are generally grouped into 3 different categories:
 

--- a/content/articles/what-is-tld.markdown
+++ b/content/articles/what-is-tld.markdown
@@ -11,9 +11,7 @@ The term top-level domain, or TLD, refers to the first part of every domain name
 
 There are currently over 1200 TLDs, but not all of them are open for registration. For more information about available and supported TLDs, check the [list of TLDs supported by DNSimple for registration and transfer](https://dnsimple.com/tlds). 
 
-<info>
 Even if a TLD is not supported for registration or transfer, you can still [add the domain to your account](/articles/adding-domain/) to use DNSimple for the DNS hosting or other domain services such as [purchasing an SSL certificate](https://dnsimple.com/ssl-certificates).
-</info>
 
 TLDs are generally grouped into 3 different categories:
 

--- a/content/articles/what-is-tld.markdown
+++ b/content/articles/what-is-tld.markdown
@@ -11,7 +11,9 @@ The term top-level domain, or TLD, refers to the first part of every domain name
 
 There are currently over 1200 TLDs, but not all of them are open for registration. For more information about available and supported TLDs, check the [list of TLDs supported by DNSimple for registration and transfer](https://dnsimple.com/tlds). 
 
+<callout>
 Even if a TLD is not supported for registration or transfer, you can still [add the domain to your account](/articles/adding-domain/) to use DNSimple for the DNS hosting or other domain services such as [purchasing an SSL certificate](https://dnsimple.com/ssl-certificates).
+</callout>
 
 TLDs are generally grouped into 3 different categories:
 


### PR DESCRIPTION
Apparently markdown for linking isn't supported in `info` tags.