### PR TITLE
remove_untrue_statement

### DIFF
--- a/content/articles/cancel-subscription.markdown
+++ b/content/articles/cancel-subscription.markdown
@@ -10,7 +10,7 @@ categories:
 After unsubscribing you will no longer be charged a monthly/yearly fee and your domains will no longer resolve with us. You may resubscribe at any time and your domains will resolve again.
 
 <callout>
-All your domains and records will remain in your account. You will also be able to transfer your domains out of DNSimple.
+All your domains and records will remain in your account.
 </callout>
 
 <div class="section-steps" markdown="1">


### PR DESCRIPTION
Remove the confusing statement about domain transfers when an account is unsubscribed.

Amy, Anthony, and Simone all indicated that a user must be subscribed to a plan in order to transfer a domain in or out. This callout states `All your domains and records will remain in your account. You will also be able to transfer your domains out of DNSimple.` This is not the case according to the afore mentioned persons and should be removed.

This commit will do just that. Remove the offending line to make the support article more accurate.
