### PR TITLE
Instant search with autocomplete

### DIFF
--- a/content/autocomplete.html
+++ b/content/autocomplete.html
@@ -41,7 +41,7 @@ title: Search, but instantly!
 <p>This search is powered by <a href="https://www.algolia.com/">Algolia</a>. They provide super fast searching.</p>
 <p>I uploaded manually our <code>search.json</code> and created an index to search on article title and body. This could eventually replace the search on the navigation bar.</p>
 
-<input id="search-input" name="contacts" type="text" placeholder='Search by name' />
+<input id="search-input" name="contacts" type="text" placeholder='Search topics' />
 
 <script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
 <script src="https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js"></script>

--- a/content/autocomplete.html
+++ b/content/autocomplete.html
@@ -1,0 +1,70 @@
+---
+title: Search, but instantly!
+---
+
+<style>
+.aa-input {
+  padding: 4px 6px;
+  border-radius: 3px;
+  border: 1px solid gainsboro;
+}
+
+.algolia-autocomplete {
+  width: 100%;
+}
+.algolia-autocomplete .aa-input, .algolia-autocomplete .aa-hint {
+  width: 100%;
+}
+.algolia-autocomplete .aa-hint {
+  color: #999;
+}
+.algolia-autocomplete .aa-dropdown-menu {
+  width: 100%;
+  background-color: #fff;
+  border: 1px solid #999;
+  border-top: none;
+}
+.algolia-autocomplete .aa-dropdown-menu .aa-suggestion {
+  cursor: pointer;
+  padding: 5px 4px;
+}
+.algolia-autocomplete .aa-dropdown-menu .aa-suggestion.aa-cursor {
+  background-color: #B2D7FF;
+}
+.algolia-autocomplete .aa-dropdown-menu .aa-suggestion em {
+  font-weight: bold;
+  font-style: normal;
+}
+</style>
+
+<h2 style="padding-top: 30px;">👋 Hello, this is autocomplete for this support site</h2>
+<p>This search is powered by <a href="https://www.algolia.com/">Algolia</a>. They provide super fast searching.</p>
+<p>I uploaded manually our <code>search.json</code> and created an index to search on article title and body. This could eventually replace the search on the navigation bar.</p>
+
+<input id="search-input" name="contacts" type="text" placeholder='Search by name' />
+
+<script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
+<script src="https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js"></script>
+
+<!-- Initialize autocomplete menu -->
+<script>
+var client = algoliasearch('VGU6IK1V9Q', '01d3d978d5919e60a0ebf825f6ced843');
+var index = client.initIndex('test_support');
+
+autocomplete('#search-input', { hint: false }, [
+  {
+    source: autocomplete.sources.hits(index, { hitsPerPage: 5 }),
+    displayKey: 'name',
+    templates: {
+      suggestion: function(suggestion) {
+        var index = suggestion._highlightResult.body.value.search(suggestion._highlightResult.body.matchedWords[0]);
+        var body = suggestion._highlightResult.body.value.substring(index - 10, index + 40);
+        return "<span>" + suggestion._highlightResult.title.value + "</span>" +
+          "<span style='font-size: 12px; display: block;'>" + body + "...</span>";
+      }
+    }
+  }
+]).on('autocomplete:selected', function(event, suggestion, dataset) {
+  window.location.href = suggestion.id;
+});
+</script>


### PR DESCRIPTION
This PR is proof of concept to test if we can improve our search in the support site. I have been toying with the idea of using [Algolia](https://www.algolia.com/) for this, and this PR is the result of that.

I have kept everything in one file so it's easy to understand for now. Browse to `/autocomplete` and give it a try

## Search is super fast 🐇 

Feedback is immediate.

![alias](https://user-images.githubusercontent.com/80610/46305797-b5380c80-c5b2-11e8-8d05-623298763dce.gif)

## Typo correction 🙌 

Yes! Yes! Yes! No more searching for _dekim_

![cmame](https://user-images.githubusercontent.com/80610/46305965-37283580-c5b3-11e8-9d5e-401e75551893.gif)

## Extra stuff that I need to figure out

We would have to push the data to Algolia, they seem to have a robust API. I haven't test it. I just dragged and dropped our `search.json` file in their dashboard. They have plenty of analytics if you want to see it.