### PR TITLE
update_icann_verification

### DIFF
--- a/content/articles/icann-domain-validation.markdown
+++ b/content/articles/icann-domain-validation.markdown
@@ -13,13 +13,15 @@ When you make a change to your registrant's email address or name, you will rece
 
 ![ICANN Verification Email](/files/icann-verification-email.png)
 
-This email will be sent from the address `DNSimple <donotreply@name-services.com>` and will include a link similar to the following:
+This email will be sent from the address `DNSimple <donotreply@name-services.com>` or `donotreply@name-services.com` and will include a link similar to the following:
 
 `http://raa.name-services.com/raaverification/verification.aspx?VerificationCode=A8E3763E-EE70-42DB-A654-20BF560300A00`
+or
+`http://www.enom.com/raaverification/verification.aspx?VerificationCode=AAAAAAAA-1A11-11AA-1A1A-1111111111`
 
 Click the link to verify the registrant email address.
 
-The link must be to `http://raa.name-services.com` - if you receive a verification email and this link is not in the email then please contact support@dnsimple.com, forwarding the email you received.
+The link must be to `http://raa.name-services.com` or `http://www.enom.com/` - if you receive a verification email and this link is not in the email then please contact support@dnsimple.com, forwarding the email you received.
 
 ## Resend verification email
 

--- a/content/articles/icann-domain-validation.markdown
+++ b/content/articles/icann-domain-validation.markdown
@@ -13,10 +13,12 @@ When you make a change to your registrant's email address or name, you will rece
 
 ![ICANN Verification Email](/files/icann-verification-email.png)
 
-This email will be sent from the address `DNSimple <donotreply@name-services.com>` or `donotreply@name-services.com` and will include a link similar to the following:
+This email will be sent from the address `DNSimple <donotreply@name-services.com>` and will include a link similar to the following:
 
 `http://raa.name-services.com/raaverification/verification.aspx?VerificationCode=A8E3763E-EE70-42DB-A654-20BF560300A00`
+
 or
+
 `http://www.enom.com/raaverification/verification.aspx?VerificationCode=AAAAAAAA-1A11-11AA-1A1A-1111111111`
 
 Click the link to verify the registrant email address.

--- a/content/articles/icann-domain-validation.markdown
+++ b/content/articles/icann-domain-validation.markdown
@@ -13,17 +13,14 @@ When you make a change to your registrant's email address or name, you will rece
 
 ![ICANN Verification Email](/files/icann-verification-email.png)
 
-This email will be sent from the address `DNSimple <donotreply@name-services.com>` and will include a link similar to the following:
-
-`http://raa.name-services.com/raaverification/verification.aspx?VerificationCode=A8E3763E-EE70-42DB-A654-20BF560300A00`
-
-or
-
-`http://www.enom.com/raaverification/verification.aspx?VerificationCode=AAAAAAAA-1A11-11AA-1A1A-1111111111`
+This email will be sent from the addresses `DNSimple <donotreply@name-services.com>` or `DNSimple <registrant-verification@ispapi.net>` and will include a link similar to the following:
+- `http://raa.name-services.com/raaverification/verification.aspx?VerificationCode=A8E3763E-EE70-42DB-A654-20BF560300A00`
+- `http://www.enom.com/raaverification/verification.aspx?VerificationCode=AAAAAAAA-1A11-11AA-1A1A-1111111111`
+- `http://registrant-email-verification-ispapi.net/?approve&token=Fsjdklajdfoqewvoieioejrawkjnjasfie&lang=en`
 
 Click the link to verify the registrant email address.
 
-The link must be to `http://raa.name-services.com` or `http://www.enom.com/` - if you receive a verification email and this link is not in the email then please contact support@dnsimple.com, forwarding the email you received.
+The link must be to `http://raa.name-services.com`, `http://www.enom.com`, or `http://registrant-email-verification-ispapi.net` - if you receive a verification email and this link is not in the email then please contact support@dnsimple.com, forwarding the email you received.
 
 ## Resend verification email
 


### PR DESCRIPTION
We have seen several messages come into support for the ICANN verification from donotreply@name-services.com with the link going to http://www.enom.com/raaverification/verification.aspx. This PR addes this information to our support page.

See ticket https://dnsimple.groovehq.com/groove_client/tickets/94018927 as an example.