### PR TITLE
Removes Sass gem in favor of Sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'kramdown'
 gem 'mime-types'
 gem 'nokogiri'
 gem 'rouge'
-gem 'sass'
+gem 'sassc'
 gem 'systemu'
 gem 'thin', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,11 +120,9 @@ GEM
       configure-s3-website (= 2.3.0)
       dotenv (~> 1.0)
       thor (~> 0.18)
-    sass (3.6.0)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
     shellany (0.0.1)
     slow_enumerator_tools (1.1.0)
     systemu (2.6.5)
@@ -153,9 +151,9 @@ DEPENDENCIES
   rake
   rouge
   s3_website
-  sass
+  sassc
   systemu
   thin
 
 BUNDLED WITH
-   1.16.1
+   1.16.5


### PR DESCRIPTION
Fixes #362. Removes the `sass` gem in favor of the `sassc` gem.

## Verification steps

1. `bundle`
1. `nanoc live`
1. Browse a few random pages, everything should look as usual.
