### PR TITLE
Deleting avatar references on support site

### DIFF
--- a/content/articles/account-multi.markdown
+++ b/content/articles/account-multi.markdown
@@ -52,4 +52,4 @@ Switching account context is very simple. Select the account you'd like to use f
 
   ![Switch account](/files/account-switcher.jpg)
 
-The new selected account name will appear on the top navigation bar, next to the avatar for your user.
+The new selected account name will appear on the navigation bar.

--- a/content/articles/adding-domain.markdown
+++ b/content/articles/adding-domain.markdown
@@ -13,8 +13,8 @@ When adding a domain to your account, you can choose to register, transfer or ju
 ##### To add a domain
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab
+1.  If you have more than one account, select the relevant one.
+1.  On the header, click the <label>Domains</label> tab
 1.  Click <label>Add Domain</label>.
 1.  Choose the flow that makes more sense to your scenario.
 </div>

--- a/content/articles/adding-subdomain.markdown
+++ b/content/articles/adding-subdomain.markdown
@@ -13,13 +13,14 @@ A subdomain is, technically speaking, a DNS record for a hostname that belongs t
 ##### To add a subdomain
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header, click the <label>Domains</label> tab.
+1.  Locate the relevant domain and click on the name to access the domain page.
 1.  Click on the <label>DNS</label> tab (or quickly jump to the DNS records for that domain by clicking the button in the top right).
 
     ![DNS Tab](/files/example-domain-manage.jpg)
 
-1.  From there, simply click the green <label>Add</label> drop-down menu, and select the type of record you wish to create. [`A`, `ALIAS`, and `CNAME` records](/articles/differences-between-a-cname-alias-url) will all create a new subdomain.
+1.  From there, click the <label>Add record</label> drop-down button, and select the type of record you wish to create. [`A`, `ALIAS`, and `CNAME` records](/articles/differences-between-a-cname-alias-url) will all create a new subdomain.
 
     ![Custom Records](/files/example-domain-dns.jpg)
 

--- a/content/articles/changing-domain-contact.markdown
+++ b/content/articles/changing-domain-contact.markdown
@@ -30,14 +30,14 @@ If you want to assign a new contact to one of your domains, create the new conta
 ##### To change the contact information
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Contacts</label> tab, then click <label>New Contact</label>.
+1.  If you have more than one account, select the relevant one.
+1.  On the header, click the <label>Contacts</label> tab, then click <label>New Contact</label>.
 
     ![Add contact](/files/change-contact-1.jpg)
 
 1.  Fill in the form with the new contact information and press <label>Add contact</label>.
 1.  Now that you have a new contact, go to your domain page.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 
     ![Domain Page link](/files/domains-domain-link.png)
 
@@ -58,8 +58,7 @@ If you want to change an existing contact information, simply update the contact
 ##### To change the contact information
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Contacts</label> tab, locate the contact you want to change and click <label>Edit</label>.
+1.  On the header click the <label>Contacts</label> tab, locate the contact you want to change and click <label>Edit</label>.
 
     ![Edit contact data](/files/edit-existing-contact-1.jpg)
 

--- a/content/articles/delegating-dnsimple-registered.markdown
+++ b/content/articles/delegating-dnsimple-registered.markdown
@@ -13,8 +13,8 @@ Swithing the name servers to DNSimple will cause the domain to resolve using the
 ##### To change the name servers to DNSimple
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 
     ![Domain Page link](/files/domains-domain-link.png)
 

--- a/content/articles/deleting-domain.markdown
+++ b/content/articles/deleting-domain.markdown
@@ -15,8 +15,8 @@ You should not delete an active domain registered or resolved with DNSimple.
 ##### To delete a domain
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  On the tabs to the left, click <label>Settings</label>.
 
     ![Admin tab](/files/settings-tab.png)

--- a/content/articles/domain-auto-renewal.markdown
+++ b/content/articles/domain-auto-renewal.markdown
@@ -36,8 +36,8 @@ By default, newly registered domains are set to auto-renew, but if you have turn
 ##### To enable auto-renewal for a domain
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Check the <label>Auto-renew this domain before it expires</label> checkbox on the "Registration" status card
 
     ![Auto-renewal checkbox](/files/enable-auto-renewal.png)
@@ -57,7 +57,7 @@ If you would like to turn off auto-renewal for a domain, you should follow these
 ##### To disable auto-renewal for a domain
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
+1.  If you have more than one account, select the relevant one.
 1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain 
 1.  Uncheck the <label>Auto-renew this domain before it expires</label> checkbox on the registration status card
 

--- a/content/articles/installing-ssl-certificate.markdown
+++ b/content/articles/installing-ssl-certificate.markdown
@@ -23,8 +23,8 @@ We've created a certificate installation wizard which is accessible from the mai
 ##### To go to the SSL certificate page
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Select the SSL Certificates tab and click on the relevant certificate.
 
     ![SSL certificate page link](/files/domain-view-ssl-certificate-link.png)

--- a/content/articles/ordering-lets-encrypt-certificate.markdown
+++ b/content/articles/ordering-lets-encrypt-certificate.markdown
@@ -44,7 +44,7 @@ The order is the first step into getting an SSL certificate. It will create an S
 ##### To order a certificate
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
+1.  If you have more than one account, select the relevant one.
 1.  If the domain is not already in your account, follow the instructions to [add a domain for domain services](/articles/adding-domain) and add any records to it before [delegating to our name servers](/articles/delegating-dnsimple-hosted).
 1.  If the domain is already in your account, on the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Select the SSL Certificates tab and click <label>Get an SSL Certificate</label> to start the order.

--- a/content/articles/ordering-standard-certificate.markdown
+++ b/content/articles/ordering-standard-certificate.markdown
@@ -46,7 +46,7 @@ The order is the first step into getting an SSL certificate. It will create an S
 ##### To order a certificate
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
+1.  If you have more than one account, select the relevant one.
 1.  If the domain is not already in your account, follow the instructions to [add a domain without transferring it](/articles/adding-domain).
 1.  If the domain is already in your account, on the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Select the SSL Certificates tab and click <label>Get an SSL Certificate</label> to start the order.

--- a/content/articles/registering-domain.markdown
+++ b/content/articles/registering-domain.markdown
@@ -11,7 +11,7 @@ categories:
 ##### To register a new domain
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
+1.  If you have more than one account, select the relevant one.
 1.  On the top-nav menu click the <label>Domains</label> tab
 1.  Click <label>Register a Domain</label>.
 1.  Fill out the domain name.

--- a/content/articles/reissuing-ssl-certificate.markdown
+++ b/content/articles/reissuing-ssl-certificate.markdown
@@ -49,7 +49,7 @@ Re-issuing a certificate is not a fully automated process. Requests have to be m
 ##### To start a new certificate re-issue request
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
+1.  If you have more than one account, select the relevant one.
 1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the <label>Active SSL Certificate</label> list and click on the certificate.
 

--- a/content/articles/renewing-domain.markdown
+++ b/content/articles/renewing-domain.markdown
@@ -13,8 +13,8 @@ By default, newly registered domains are set to auto-renew, but if you have turn
 ##### To renew a domain
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Select the <label>Renew domain</label> link from the registration status card
 
     ![Renew domain link](/files/renew-domain.jpg)

--- a/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
+++ b/content/articles/renewing-lets-encrypt-ssl-certificate.markdown
@@ -17,8 +17,8 @@ All Let's Encrypt SSL certificates, including renewals, are valid for no more th
 ##### To renew a certificate
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the <label>SSL certificates</label> section and find the active SSL certificate. Click <label>Renew</label> to start the renewal.
 
     ![Renewing a Certificate](/files/certificates-renew-action.png)

--- a/content/articles/renewing-standard-ssl-certificate.markdown
+++ b/content/articles/renewing-standard-ssl-certificate.markdown
@@ -23,8 +23,8 @@ These are the steps to renew your standard certificate:
 ##### To renew a certificate
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the <label>SSL certificates</label> section and find the active SSL certificate. Click <label>Renew</label> to start the renewal.
 
     ![Renewing a Certificate](/files/certificates-renew-action.png)

--- a/content/articles/setting-name-servers.markdown
+++ b/content/articles/setting-name-servers.markdown
@@ -26,8 +26,8 @@ Pointing the name servers to another provider will cause the domain to resolve u
 ##### To point the name servers to another provider
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 
     ![Domain Page link](/files/domains-domain-link.png)
 

--- a/content/articles/ssl-certificates-email-validation.markdown
+++ b/content/articles/ssl-certificates-email-validation.markdown
@@ -104,8 +104,8 @@ If the approver is not in this list or you need time to configure one of those e
 ##### To select a validation email for a previously purchased certificate
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the <label>Active SSL Certificate</label> list and click on the certificate.
 
     ![](/files/dnsimple-ssl-pagelink-purchased.png)
@@ -145,8 +145,8 @@ If you haven't received the validation email, for example because the email conf
 ##### To resend the validation email
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the <label>Active SSL Certificate</label> list and click on the certificate.
 
     ![](/files/dnsimple-ssl-pagelink-submitted.png)

--- a/content/articles/ssl-certificates.markdown
+++ b/content/articles/ssl-certificates.markdown
@@ -86,8 +86,8 @@ If the domain is not in your DNSimple account because you just joined DNSimple o
 ##### To go to the SSL certificate section
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down the page until you see the <label>SSL certificates</label> section.
 </div>
 

--- a/content/articles/transferring-domain-away.markdown
+++ b/content/articles/transferring-domain-away.markdown
@@ -40,8 +40,8 @@ The transfer code is sent to the email listed as registrant (owner) for the doma
 ##### To prepare the domain for transfer out
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 
 1.  Go to the registration section and click <label>Transfer Out</label>
 

--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -33,8 +33,8 @@ When you enable the service the first time, the service cost will be charged on 
 ##### Enable WHOIS Privacy from the domain list {#enable-whois-domain-list}
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab. Locate the relevant domain and look for the _shield_ icon. That icon will indicate whether the WHOIS Privacy protection service is enabled for the domain:
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab. Locate the relevant domain and look for the _shield_ icon. That icon will indicate whether the WHOIS Privacy protection service is enabled for the domain:
 
     ![Whois privacy in domain list](/files/whoisprivacy-domain-list.png)
 
@@ -56,8 +56,8 @@ When you enable the service the first time, the service cost will be charged on 
 ##### Enable WHOIS Privacy from the domain page {#enable-whois-domain-page}
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the _Contact_ card. It will display information about whether the WHOIS Privacy service is enabled.
 
     ![WHOIS Privacy card](/files/whoisprivacy-domain-card-disabled.png)
@@ -88,8 +88,8 @@ Once you disable the WHOIS Privacy protection the contact details of your domain
 ##### Disable WHOIS Privacy from the domain list {#disable-whois-domain-list}
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab. Locate the relevant domain and look for the _shield_ icon. That icon will indicate whether the WHOIS Privacy protection service is enabled for the domain:
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab. Locate the relevant domain and look for the _shield_ icon. That icon will indicate whether the WHOIS Privacy protection service is enabled for the domain:
 
     ![Whois privacy in domain list](/files/whoisprivacy-domain-list.png)
 
@@ -107,8 +107,8 @@ Once you disable the WHOIS Privacy protection the contact details of your domain
 ##### Disable WHOIS Privacy from the domain page {#disable-whois-domain-page}
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the _Contact_ card. It will display information about whether the WHOIS Privacy service is enabled.
 
     ![WHOIS Privacy card](/files/whoisprivacy-domain-card-enabled.png)
@@ -127,8 +127,8 @@ While we will send an email reminder when the WHOIS Privacy on a domain is due t
 
 <div class="section-steps" markdown="1">
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top-nav menu click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the _Contact_ card.
 
     ![WHOIS Privacy card](/files/whoisprivacy-domain-card-enabled.png)

--- a/content/articles/zone-files.markdown
+++ b/content/articles/zone-files.markdown
@@ -31,8 +31,8 @@ Importing a zone file won't delete or replace the existing domain's records.
 ##### How to import records from zone file
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top menu click on the <label>Domains</label> tab.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click on the <label>Domains</label> tab.
 1.  Locate the relevant domain and click on the name to access the domain page.
 1.  Go to the settings section by clicking the <label>Settings</label> link on the left.
 1.  Click on the <label>Import from a zone file</label> link inside the zones card.
@@ -61,8 +61,8 @@ The non-standard records like [ALIAS](/articles/alias-record) and [POOL](/articl
 ##### How to export your domain's records to a zone file
 
 1.  Log into DNSimple with your user credentials.
-1.  Click on your avatar on the top-right, and on the drop-down menu select the account.
-1.  On the top menu click on the <label>Domains</label> tab.
+1.  If you have more than one account, select the relevant one.
+1.  On the header click on the <label>Domains</label> tab.
 1.  Locate the relevant domain and click on the name to access the domain page.
 1.  Go to the settings section by clicking the <label>Settings</label> link on the left.
 1.  Click on the <label>Export to a zone file</label> link inside the zones card.


### PR DESCRIPTION
We don't use an avatar in the App since we updated the header, but we were still using the avatar and its drop-down menu as a reference to select the user account. 

In the process of creating the new header we learnt only around 3% of our users have more than one account, so the sentence to select the account now is conditional.

_Before_
![image](https://user-images.githubusercontent.com/413249/48497464-7396b480-e834-11e8-9bb0-91a192f8c854.png)


_After_
![image](https://user-images.githubusercontent.com/413249/48497420-5f52b780-e834-11e8-8fcb-f6245a67788f.png)

Closes #386 
