### PR TITLE
New plans copy edits

### DIFF
--- a/content/articles/new-plans-for-bronze.markdown
+++ b/content/articles/new-plans-for-bronze.markdown
@@ -1,6 +1,6 @@
 ---
-title: Switching to a current plan from Bronze plan
-excerpt: Overview of the current plans compared to the legacy Bronze plan.
+title: Switching to a newer plan from Bronze plan
+excerpt: Overview of the newer plans compared to the legacy Bronze plan.
 categories:
 - Account
 ---

--- a/content/articles/new-plans-for-bronze.markdown
+++ b/content/articles/new-plans-for-bronze.markdown
@@ -5,9 +5,9 @@ categories:
 - Account
 ---
 
-# I'm a Bronze customer, what do the new plans mean for me?
+# I'm a Bronze customer. What do the new plans mean for me?
 
-As an existing Bronze customer you will not have access to new features in DNSimple as they are released. If you are an individual, you may want to consider switching to the Personal plan. If you run or manage domains on behalf of a business you may want to consider upgrading to either the Professional or Business plan.
+As an existing Bronze customer, you won't have access to new features in DNSimple as they're released. Individuals should consider switching to the Personal plan. If you run or manage domains on behalf of a business, you should consider upgrading to either the Professional or Business plan.
 
 New plans include several new features, such as:
 
@@ -17,8 +17,8 @@ New plans include several new features, such as:
 
 New plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
 
-For the majority of you, the Personal plan will provide greater benefits to you with very little change in your monthly cost. The Personal plan costs $5 per month and includes up to 5 domains. After 5 domains you will only pay $0.50 per domain per month for additional domains. This means that if you are currently a Bronze customers you can add 3 additional domains into your account by switching to the Personal plan, with no change in your monthly fee (or a $2 per month additional cost if you are on the old $3 per month Bronze plan).
+For the majority of you, the Personal plan will provide greater benefits with minor changes in your monthly cost. The Personal plan costs $5 per month and includes up to 5 domains. After 5 domains, you'll pay $0.50 per domain per month. If you're a Bronze customer, you can add 3 domains to your account by switching to the Personal plan, with no change in your monthly fee (or a $2 per month additional cost if you're on the old $3 per month Bronze plan).
 
-Professional and Business plans come with added benefits that help improve domain and DNS management for business customers, such as the new Team feature, which allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can also protect yourself with our SLA.
+Professional and Business plans come with added benefits tailored to business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can protect yourself with our SLA.
 
-And if you switch to an yearly plan, you'll get 2 months for free!
+If you switch to a yearly plan, we'll give you two months free. 

--- a/content/articles/new-plans-for-bronze.markdown
+++ b/content/articles/new-plans-for-bronze.markdown
@@ -17,7 +17,7 @@ Current plans include several features, such as:
 
 Current plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
 
-For the majority of you, the Personal plan will provide greater benefits with only minor changes to your monthly cost. It costs $5 per month and includes up to 5 domains. After 5 domains, you'll pay $0.50 per domain per month. If you're a Bronze customer, you can add 3 domains to your account by switching to the Personal plan, with no change in your monthly fee (or a $2 per month additional cost if you're on the old $3 per month Bronze plan).
+For the majority of you, the Personal plan will provide greater benefits with only minor changes to your monthly cost. The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you're a Bronze customer, you can add 3 domains to your account by switching to the Personal plan, with no change in your monthly fee (or a $2 per month additional cost if you're on the old $3 per month Bronze plan).
 
 Professional and Business plans come with added benefits tailored to business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can protect yourself with our SLA.
 

--- a/content/articles/new-plans-for-bronze.markdown
+++ b/content/articles/new-plans-for-bronze.markdown
@@ -19,6 +19,6 @@ Current plans also benefit from [reduced whois privacy prices](https://blog.dnsi
 
 For the majority of you, the Personal plan will provide greater benefits with only minor changes to your monthly cost. The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you're a Bronze customer, you can add 3 domains to your account by switching to the Personal plan, with no change in your monthly fee (or a $2 per month additional cost if you're on the old $3 per month Bronze plan).
 
-Professional and Business plans come with added benefits tailored to business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can protect yourself with our SLA.
+Professional and Business plans come with added benefits tailored to business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. You can also protect yourself with our SLA on the Professional and Business plans. 
 
-If you switch to a yearly plan, we'll give you two months free. 
+As an added bonus, if you switch to a yearly plan, we'll give you two months free. 

--- a/content/articles/new-plans-for-bronze.markdown
+++ b/content/articles/new-plans-for-bronze.markdown
@@ -9,13 +9,13 @@ categories:
 
 As an existing Bronze customer, you won't have access to new features in DNSimple as they're released. Individuals should consider switching to the Personal plan. If you run or manage domains on behalf of a business, you should consider upgrading to either the Professional or Business plan.
 
-Current plans include several features, such as:
+Newer plans include several features, such as:
 
 - [Let's Encrypt integration](/articles/letsencrypt/)
 - [CAA records](/articles/manage-caa-record/)
 - [DNSSEC](/articles/dnssec/)
 
-Current plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
+Newer plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
 
 For the majority of you, the Personal plan will provide greater benefits with only minor changes to your monthly cost. The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you're a Bronze customer, you can add 3 domains to your account by switching to the Personal plan, with no change in your monthly fee (or a $2 per month additional cost if you're on the old $3 per month Bronze plan).
 

--- a/content/articles/new-plans-for-bronze.markdown
+++ b/content/articles/new-plans-for-bronze.markdown
@@ -1,23 +1,23 @@
 ---
-title: Switching to a new plan from Bronze plan
-excerpt: Overview of the new plans compared to the legacy Bronze plan.
+title: Switching to a current plan from Bronze plan
+excerpt: Overview of the current plans compared to the legacy Bronze plan.
 categories:
 - Account
 ---
 
-# I'm a Bronze customer. What do the new plans mean for me?
+# I'm a Bronze customer. What do the newer plans mean for me?
 
 As an existing Bronze customer, you won't have access to new features in DNSimple as they're released. Individuals should consider switching to the Personal plan. If you run or manage domains on behalf of a business, you should consider upgrading to either the Professional or Business plan.
 
-New plans include several new features, such as:
+Current plans include several features, such as:
 
 - [Let's Encrypt integration](/articles/letsencrypt/)
 - [CAA records](/articles/manage-caa-record/)
 - [DNSSEC](/articles/dnssec/)
 
-New plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
+Current plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
 
-For the majority of you, the Personal plan will provide greater benefits with minor changes in your monthly cost. The Personal plan costs $5 per month and includes up to 5 domains. After 5 domains, you'll pay $0.50 per domain per month. If you're a Bronze customer, you can add 3 domains to your account by switching to the Personal plan, with no change in your monthly fee (or a $2 per month additional cost if you're on the old $3 per month Bronze plan).
+For the majority of you, the Personal plan will provide greater benefits with only minor changes to your monthly cost. It costs $5 per month and includes up to 5 domains. After 5 domains, you'll pay $0.50 per domain per month. If you're a Bronze customer, you can add 3 domains to your account by switching to the Personal plan, with no change in your monthly fee (or a $2 per month additional cost if you're on the old $3 per month Bronze plan).
 
 Professional and Business plans come with added benefits tailored to business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can protect yourself with our SLA.
 

--- a/content/articles/new-plans-for-gold.markdown
+++ b/content/articles/new-plans-for-gold.markdown
@@ -19,6 +19,6 @@ Current plans also benefit from [reduced whois privacy prices](https://blog.dnsi
 
 If you manage a personal portfolio of domains, you may be able to save money by switching to the Personal plan. The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you have 11 domains, you could save $8 off your monthly bill by switching to the Personal plan. If you have 20 domains, you could save $0.50 each month.
 
-Professional and Business plans come with added benefits that help improve domain and DNS management for business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. You can also protect yourself with our SLA on the Professional and Business plans.
+Professional and Business plans come with added benefits tailored to business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. You can also protect yourself with our SLA on the Professional and Business plans. 
 
 As an added bonus, if you switch to a yearly plan, we'll give you two months free. 

--- a/content/articles/new-plans-for-gold.markdown
+++ b/content/articles/new-plans-for-gold.markdown
@@ -9,13 +9,13 @@ categories:
 
 As an existing Gold customer, you won't have access to new features in DNSimple as they're released. If you run or manage domains on behalf of a business, you should consider upgrading to either the Professional or Business plan. Individuals should consider switching to the Personal plan.
 
-Current plans include several features, such as:
+Newer plans include several features, such as:
 
 - [Let's Encrypt integration](/articles/letsencrypt/)
 - [CAA records](/articles/manage-caa-record/)
 - [DNSSEC](/articles/dnssec/)
 
-Current plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
+Newer plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
 
 If you manage a personal portfolio of domains, you may be able to save money by switching to the Personal plan. The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you have 11 domains, you could save $8 off your monthly bill by switching to the Personal plan. If you have 20 domains, you could save $0.50 each month.
 

--- a/content/articles/new-plans-for-gold.markdown
+++ b/content/articles/new-plans-for-gold.markdown
@@ -19,6 +19,6 @@ Current plans also benefit from [reduced whois privacy prices](https://blog.dnsi
 
 If you manage a personal portfolio of domains, you may be able to save money by switching to the Personal plan. The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you have 11 domains, you could save $8 off your monthly bill by switching to the Personal plan. If you have 20 domains, you could save $0.50 each month.
 
-Professional and Business plans come with added benefits that help improve domain and DNS management for business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can protect yourself with our SLA.
+Professional and Business plans come with added benefits that help improve domain and DNS management for business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. You can also protect yourself with our SLA on the Professional and Business plans.
 
 As an added bonus, if you switch to a yearly plan, we'll give you two months free. 

--- a/content/articles/new-plans-for-gold.markdown
+++ b/content/articles/new-plans-for-gold.markdown
@@ -1,6 +1,6 @@
 ---
-title: Switching to a current plan from Gold plan
-excerpt: Overview of the current plans compared to the legacy Gold plan.
+title: Switching to a newer plan from Gold plan
+excerpt: Overview of the newer plans compared to the legacy Gold plan.
 categories:
 - Account
 ---

--- a/content/articles/new-plans-for-gold.markdown
+++ b/content/articles/new-plans-for-gold.markdown
@@ -1,24 +1,24 @@
 ---
-title: Switching to a new plan from Gold plan
-excerpt: Overview of the new plans compared to the legacy Gold plan.
+title: Switching to a current plan from Gold plan
+excerpt: Overview of the current plans compared to the legacy Gold plan.
 categories:
 - Account
 ---
 
-# I'm a Gold customer, what do the new plans mean for me?
+# I'm a Gold customer. What do the newer plans mean for me?
 
-As an existing Gold customer you will not have access to new features in DNSimple as they are released. If you are an individual, you may want to consider switching to the Personal plan. If you run or manage domains on behalf of a business you may want to consider upgrading to either the Professional or Business plan.
+As an existing Gold customer, you won't have access to new features in DNSimple as they're released. If you run or manage domains on behalf of a business, you should consider upgrading to either the Professional or Business plan. Individuals should consider switching to the Personal plan.
 
-New plans include several new features, such as:
+Current plans include several features, such as:
 
 - [Let's Encrypt integration](/articles/letsencrypt/)
 - [CAA records](/articles/manage-caa-record/)
 - [DNSSEC](/articles/dnssec/)
 
-New plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
+Current plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
 
-If you are managing a personal portfolio of domains then you may be able to save money on your monthly DNS subscription charges by switching to the new Personal plan. The Personal plan is $5 per month for up to 5 domains and then $0.50 per domain per month thereafter. Thus, if you have 11 domains, you could save $8 off your monthly bill by switching to the Personal plan. If you have 20 domains, you could save $0.50 each month.
+If you manage a personal portfolio of domains, you may be able to save money by switching to the Personal plan. The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you have 11 domains, you could save $8 off your monthly bill by switching to the Personal plan. If you have 20 domains, you could save $0.50 each month.
 
-Professional and Business plans come with added benefits that help improve domain and DNS management for business customers, such as the new Team feature, which allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can also protect yourself with our SLA.
+Professional and Business plans come with added benefits that help improve domain and DNS management for business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can protect yourself with our SLA.
 
-And if you switch to an yearly plan, you'll get 2 months for free!
+As an added bonus, if you switch to a yearly plan, we'll give you two months free. 

--- a/content/articles/new-plans-for-silver.markdown
+++ b/content/articles/new-plans-for-silver.markdown
@@ -1,24 +1,24 @@
 ---
-title: Switching to a new plan from Silver plan
-excerpt: Overview of the new plans compared to the legacy Silver plan.
+title: Switching to a current plan from Silver plan
+excerpt: Overview of the current plans compared to the legacy Silver plan.
 categories:
 - Account
 ---
 
-# I'm a Silver customer, what do the new plans mean for me?
+# I'm a Silver customer. What do the newer plans mean for me?
 
-As an existing Silver customer you will not have access to new features in DNSimple as they are released. If you are an individual, you may want to consider switching to the Personal plan. If you run or manage domains on behalf of a business you may want to consider upgrading to either the Professional or Business plan.
+As an existing Silver customer you won't have access to new features in DNSimple as they're released. If you run or manage domains on behalf of a business, you should consider upgrading to either the Professional or Business plan. Individuals should consider switching to the Personal plan.
 
-New plans include several new features, such as:
+Current plans include several features, such as:
 
 - [Let's Encrypt integration](/articles/letsencrypt/)
 - [CAA records](/articles/manage-caa-record/)
 - [DNSSEC](/articles/dnssec/)
 
-New plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
+Current plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
 
-The Personal plan costs $5 per month and includes up to 5 domains. After 5 domains you will only pay $0.50 per domain per month for additional domains. This means that if you are currently a Silver customer with 4 domains, then switching to the Personal plan will save you $3 each month. If you are a Silver customer with 10 domains, then you will save $0.50 per month.
+The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you're a Silver customer with 4 domains, switching to the Personal plan will save you $3 each month. If you're a Silver customer with 10 domains, you'll save $0.50 per month.
 
-Professional and Business plans come with added benefits that help improve domain and DNS management for business customers, such as the new Team feature, which allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can also protect yourself with our SLA.
+Professional and Business plans come with added benefits to help improve domain and DNS management for business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can protect yourself with our SLA.
 
-And if you switch to an yearly plan, you'll get 2 months for free!
+As an added bonus, if you switch to a yearly plan, we'll give you two months free. 

--- a/content/articles/new-plans-for-silver.markdown
+++ b/content/articles/new-plans-for-silver.markdown
@@ -19,6 +19,6 @@ Current plans also benefit from [reduced whois privacy prices](https://blog.dnsi
 
 The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you're a Silver customer with 4 domains, switching to the Personal plan will save you $3 each month. If you're a Silver customer with 10 domains, you'll save $0.50 per month.
 
-Professional and Business plans come with added benefits to help improve domain and DNS management for business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. You can also protect yourself with our SLA on the Professional and Business plans.
+Professional and Business plans come with added benefits tailored to business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. You can also protect yourself with our SLA on the Professional and Business plans. 
 
 As an added bonus, if you switch to a yearly plan, we'll give you two months free. 

--- a/content/articles/new-plans-for-silver.markdown
+++ b/content/articles/new-plans-for-silver.markdown
@@ -19,6 +19,6 @@ Current plans also benefit from [reduced whois privacy prices](https://blog.dnsi
 
 The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you're a Silver customer with 4 domains, switching to the Personal plan will save you $3 each month. If you're a Silver customer with 10 domains, you'll save $0.50 per month.
 
-Professional and Business plans come with added benefits to help improve domain and DNS management for business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. With the Professional and Business plans, you can protect yourself with our SLA.
+Professional and Business plans come with added benefits to help improve domain and DNS management for business customers. For example, the Team feature allows you to add team members to an account so they can control and manage all aspects of that account. You can also protect yourself with our SLA on the Professional and Business plans.
 
 As an added bonus, if you switch to a yearly plan, we'll give you two months free. 

--- a/content/articles/new-plans-for-silver.markdown
+++ b/content/articles/new-plans-for-silver.markdown
@@ -1,6 +1,6 @@
 ---
-title: Switching to a current plan from Silver plan
-excerpt: Overview of the current plans compared to the legacy Silver plan.
+title: Switching to a newer plan from Silver plan
+excerpt: Overview of the newer plans compared to the legacy Silver plan.
 categories:
 - Account
 ---

--- a/content/articles/new-plans-for-silver.markdown
+++ b/content/articles/new-plans-for-silver.markdown
@@ -9,13 +9,13 @@ categories:
 
 As an existing Silver customer you won't have access to new features in DNSimple as they're released. If you run or manage domains on behalf of a business, you should consider upgrading to either the Professional or Business plan. Individuals should consider switching to the Personal plan.
 
-Current plans include several features, such as:
+Newer plans include several features, such as:
 
 - [Let's Encrypt integration](/articles/letsencrypt/)
 - [CAA records](/articles/manage-caa-record/)
 - [DNSSEC](/articles/dnssec/)
 
-Current plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
+Newer plans also benefit from [reduced whois privacy prices](https://blog.dnsimple.com/2017/10/whois-privacy-price-decrease/).
 
 The Personal plan is $5 per month for up to 5 domains and $0.50 per domain per month thereafter. If you're a Silver customer with 4 domains, switching to the Personal plan will save you $3 each month. If you're a Silver customer with 10 domains, you'll save $0.50 per month.
 

--- a/content/articles/new-plans.markdown
+++ b/content/articles/new-plans.markdown
@@ -91,7 +91,7 @@ Over the last six years we've invested heavily in DDoS protection, Anycast DNS, 
 
 ## Features only on current plans {#newer-plans-only}
 
-Many features are only made available on [current plans](#newer-plans) -  Personal, Professional, Business, and Reseller plans
+Many features are only made available on [current plans](#newer-plans): Personal, Professional, Business, and Reseller plans.
 
 If you see a _newer plan warning_ banner at the top of a support article, it means your account must be subscribed to one of the current plans in order to use the feature. If you're using a legacy plan, such as Bronze, Silver, or Gold, you can upgrade to the appropriate plan, and the feature will immediately be available to you.
 

--- a/content/articles/new-plans.markdown
+++ b/content/articles/new-plans.markdown
@@ -69,9 +69,9 @@ You can click on <label>learn more</label> to get additional information about c
 
 The main difference between legacy plans and current plans is the structure. With legacy plans, we charged you based on how many domains you had in your account. Now, [our plans](https://dnsimple.com/pricing) are based on the features you need. 
 
-The Personal Plan is our most affordable offering, and includes the features necessary for a single person. The Professional and Business Plans include features organizations commonly request, like multi-user accounts and the ability to configure different billing addresses.
+The Personal plan is our most affordable offering, and includes the features necessary for a single person. The Professional and Business plans include features organizations commonly request, like multi-user accounts and the ability to configure different billing addresses.
 
-Plans no longer have domain limits. So even if you have more domains than average on the Personal Plan, you won't have to upgrade to a more expensive plan just to add more. You can stay on the plan that has the features you need, and add as many domains you want.
+Plans no longer have domain limits. So even if you have more domains than average on the Personal plan, you won't have to upgrade to a more expensive plan just to add more. You can stay on the plan that has the features you need, and add as many domains you want.
 
 Each plan includes five domains. We charge a small fee per domain for extra domains, based on the plan. If you have a substantial number of domains, you should consider one of our [reseller plans](https://dnsimple.com/reseller). Reseller plans have a higher monthly cost compared to standard plans, but they have a larger discount on the price-per-domain.
 
@@ -91,16 +91,16 @@ Over the last six years we've invested heavily in DDoS protection, Anycast DNS, 
 
 ## Features only on current plans {#newer-plans-only}
 
-Many new features are only made available on [current plans](#newer-plans) -  Personal, Professional, Business, and Reseller Plans
+Many features are only made available on [current plans](#newer-plans) -  Personal, Professional, Business, and Reseller plans
 
 If you see a _newer plan warning_ banner at the top of a support article, it means your account must be subscribed to one of the current plans in order to use the feature. If you're using a legacy plan, such as Bronze, Silver, or Gold, you can upgrade to the appropriate plan, and the feature will immediately be available to you.
 
 ## Features only on certain tiers of current plans {#newer-plans-some}
 
-Some features are only available on certain plans, based on the level of service. For example, teams and regional records are features that make sense in an organizational context, so they're only available on Professional and Business Plans.
+Some features are only available on certain plans, based on the level of service. For example, teams and regional records are features that make sense in an organizational context, so they're only available on Professional and Business plans.
 
 If you see a _some-plans warning_ banner at the top of a support article, make sure your account is subscribed to the correct plan for that feature.
 
 Some advanced features are only available in higher-tier plans. If you need the feature on a limited number of domains, you may want to [use multiple accounts to segment the business](https://blog.dnsimple.com/2015/12/using-accounts-to-segment-business/).
 
-For example, if you need [vanity name servers](/articles/vanity-nameservers) only on 3-4 domains, create a separate account with these domains, and subscribe  it to the Business Plan. Leave the other domains on a lower plan, such as Professional, and you'll just pay the for the feature on domains where you actually use it.
+For example, if you need [vanity name servers](/articles/vanity-nameservers) only on 3-4 domains, create a separate account with these domains, and subscribe  it to the Business plan. Leave the other domains on a lower plan, such as Professional, and you'll just pay the for the feature on domains where you actually use it.

--- a/content/articles/new-plans.markdown
+++ b/content/articles/new-plans.markdown
@@ -59,7 +59,7 @@ You can check your plan type from your account page. It's immediately visible on
 
 ![](/files/account-plan-info.png)
 
-If you're using a legacy plan, a yellow banner will  appear at the top of screen.
+If you're using a legacy plan, a yellow banner will appear at the top of the screen.
 
 ![](/files/account-plan-legacy.png)
 

--- a/content/articles/new-plans.markdown
+++ b/content/articles/new-plans.markdown
@@ -5,7 +5,7 @@ categories:
 - Account
 ---
 
-# Plans and Legacy Plans
+# Current Plans and Legacy Plans
 
 ### Table of Contents {#toc}
 
@@ -65,7 +65,7 @@ If you're using a legacy plan, a yellow banner will  appear at the top of screen
 
 You can click on <label>learn more</label> to get additional information about current plans and how to upgrade.
 
-## Plans vs Legacy plans
+## Current Plans vs Legacy plans
 
 The main difference between legacy plans and current plans is the structure. With legacy plans, we charged you based on how many domains you had in your account. Now, [our plans](https://dnsimple.com/pricing) are based on the features you need. 
 

--- a/content/articles/new-plans.markdown
+++ b/content/articles/new-plans.markdown
@@ -1,5 +1,5 @@
 ---
-title: Plans and Legacy Plans
+title: Current Plans and Legacy Plans
 excerpt: This article explains the main differences between pre-2015 plans and current plans.
 categories:
 - Account
@@ -65,7 +65,7 @@ If you're using a legacy plan, a yellow banner will  appear at the top of screen
 
 You can click on <label>learn more</label> to get additional information about current plans and how to upgrade.
 
-## Current Plans vs Legacy plans
+## Current plans vs Legacy plans
 
 The main difference between legacy plans and current plans is the structure. With legacy plans, we charged you based on how many domains you had in your account. Now, [our plans](https://dnsimple.com/pricing) are based on the features you need. 
 
@@ -91,16 +91,16 @@ Over the last six years we've invested heavily in DDoS protection, Anycast DNS, 
 
 ## Features only on current plans {#newer-plans-only}
 
-Many new features are only made available on [current plans](#newer-plans) -  Personal, Professional, Business, and Reseller plans
+Many new features are only made available on [current plans](#newer-plans) -  Personal, Professional, Business, and Reseller Plans
 
 If you see a _newer plan warning_ banner at the top of a support article, it means your account must be subscribed to one of the current plans in order to use the feature. If you're using a legacy plan, such as Bronze, Silver, or Gold, you can upgrade to the appropriate plan, and the feature will immediately be available to you.
 
 ## Features only on certain tiers of current plans {#newer-plans-some}
 
-Some features are only available on certain plans, based on the level of service. For example, teams and regional records are features that make sense in an organizational context, so they're only available on Professional and Business plans.
+Some features are only available on certain plans, based on the level of service. For example, teams and regional records are features that make sense in an organizational context, so they're only available on Professional and Business Plans.
 
 If you see a _some-plans warning_ banner at the top of a support article, make sure your account is subscribed to the correct plan for that feature.
 
 Some advanced features are only available in higher-tier plans. If you need the feature on a limited number of domains, you may want to [use multiple accounts to segment the business](https://blog.dnsimple.com/2015/12/using-accounts-to-segment-business/).
 
-For example, if you need [vanity name servers](/articles/vanity-nameservers) only on 3-4 domains, create a separate account with these domains, and subscribe  it to the Business plan. Leave the other domains on a lower plan, such as Professional, and you'll just pay the for the feature on domains where you actually use it.
+For example, if you need [vanity name servers](/articles/vanity-nameservers) only on 3-4 domains, create a separate account with these domains, and subscribe  it to the Business Plan. Leave the other domains on a lower plan, such as Professional, and you'll just pay the for the feature on domains where you actually use it.

--- a/content/articles/new-plans.markdown
+++ b/content/articles/new-plans.markdown
@@ -14,7 +14,7 @@ categories:
 
 ---
 
-In June 2015 [we released one of our largest upgrade to our platform](https://blog.dnsimple.com/2015/06/multiple-accounts-new-plans-and-new-features/), that introduced several new features  like multiple accounts, teams, and regional records. With the release of the multi-account feature, we also changed our plan structure.
+In June 2015 [we released one of our largest upgrades to our platform](https://blog.dnsimple.com/2015/06/multiple-accounts-new-plans-and-new-features/) that introduced several new features, like multiple accounts, teams, and regional records. With the release of the multi-account feature, we also changed our plan structure.
 
 This article explains the main differences between the pre-2015 plans and current plans.
 

--- a/content/articles/new-plans.markdown
+++ b/content/articles/new-plans.markdown
@@ -103,4 +103,4 @@ If you see a _some-plans warning_ banner at the top of a support article, make s
 
 Some advanced features are only available in higher-tier plans. If you need the feature on a limited number of domains, you may want to [use multiple accounts to segment the business](https://blog.dnsimple.com/2015/12/using-accounts-to-segment-business/).
 
-For example, if you need [vanity name servers](/articles/vanity-nameservers) only on 3-4 domains, create a separate account with these domains, and subscribe  it to the Business plan. Leave the other domains on a lower plan, such as Professional, and you'll just pay the for the feature on domains where you actually use it.
+For example, if you need [vanity name servers](/articles/vanity-nameservers) only on 3-4 domains, create a separate account with these domains, and subscribe  it to the Business plan. Leave the other domains on a lower plan, such as Professional, and you'll only pay the for the feature on domains where you actually use it.

--- a/content/articles/new-plans.markdown
+++ b/content/articles/new-plans.markdown
@@ -1,11 +1,11 @@
 ---
-title: New plans and Legacy plans
-excerpt: This article explains the main differences between the pre-2015 plan types and the new types.
+title: Plans and Legacy Plans
+excerpt: This article explains the main differences between pre-2015 plans and current plans.
 categories:
 - Account
 ---
 
-# New plans and Legacy plans
+# Plans and Legacy Plans
 
 ### Table of Contents {#toc}
 
@@ -14,14 +14,14 @@ categories:
 
 ---
 
-In June 2015 [we released one of our largest upgrade to our platform](https://blog.dnsimple.com/2015/06/multiple-accounts-new-plans-and-new-features/), that introduced several new features such as multiple accounts, teams, and regional records. With the release of the multi-account feature we also changed our plans structure.
+In June 2015 [we released one of our largest upgrade to our platform](https://blog.dnsimple.com/2015/06/multiple-accounts-new-plans-and-new-features/), that introduced several new features  like multiple accounts, teams, and regional records. With the release of the multi-account feature, we also changed our plan structure.
 
-This article explains the main differences between the pre-2015 plan types and the new types.
+This article explains the main differences between the pre-2015 plans and current plans.
 
 
 ## Legacy plans
 
-Before the new plans, we had two generations of domain-based plans. They shared the same names, but they were priced a little bit different.
+Before the current plans, we had two generations of domain-based plans. They shared the same names, but were priced differently.
 
 First-generation legacy plans:
 
@@ -38,9 +38,9 @@ Second-generation legacy plans (introduced in 2014):
 - Platinum
 
 
-## Newer plans
+## Current plans
 
-Newer plans are:
+Current plans are:
 
 - Personal
 - Professional
@@ -55,59 +55,52 @@ We also have corresponding reseller plans:
 
 ## Identify the plan type
 
-You can check the plan from your account page. From the account switcher on the top-right of your page, select the account you want to check.
-
-The plan type is immediately visible in the main account page.
+You can check your plan type from your account page. It's immediately visible on the main account page – just select the account you want to check. 
 
 ![](/files/account-plan-info.png)
 
-If you are using a legacy plan, a yellow banner will  appear at the top of screen.
+If you're using a legacy plan, a yellow banner will  appear at the top of screen.
 
 ![](/files/account-plan-legacy.png)
 
-You can click on <label>learn more</label> to get additional information about the new plans and upgrade to a new plan.
+You can click on <label>learn more</label> to get additional information about current plans and how to upgrade.
 
+## Plans vs Legacy plans
 
-## Newer plans vs Legacy plans
+The main difference between legacy plans and current plans is the structure. With legacy plans, we charged you based on how many domains you had in your account. Now, [our plans](https://dnsimple.com/pricing) are based on the features you need. 
 
-The main different between legacy plans and our current plans is the way plans are structured. The legacy plans were strongly based on the number of domains, and you were charged depending on how many domains you had in your account.
+The Personal Plan is our most affordable offering, and includes the features necessary for a single person. The Professional and Business Plans include features organizations commonly request, like multi-user accounts and the ability to configure different billing addresses.
 
-[The new plans](https://dnsimple.com/pricing), instead, are based on the types of features you need. For example, the Personal plan is now our cheapest offering and lacks certain features that are only available on higher-tier plans. Conversely, Professional and Business plans includes features generally requested by organizations such as the ability to share the account with multiple members, or the ability to configure a different billing address.
+Plans no longer have domain limits. So even if you have more domains than average on the Personal Plan, you won't have to upgrade to a more expensive plan just to add more. You can stay on the plan that has the features you need, and add as many domains you want.
 
-Newer plans no longer have domain limits. This means that even if you are a Personal user with a number of domain larger than the average, you no longer need to upgrade to a more expensive plan just to add more domains. You can stay on the plan that has the features you need and add as many domains you want.
+Each plan includes five domains. We charge a small fee per domain for extra domains, based on the plan. If you have a substantial number of domains, you should consider one of our [reseller plans](https://dnsimple.com/reseller). Reseller plans have a higher monthly cost compared to standard plans, but they have a larger discount on the price-per-domain.
 
-Newer plans include 5 domains. For any extra domains we charge a small fee per domain, based on the plan. If you have a very large number of domains, you may consider one of our [reseller plans](https://dnsimple.com/reseller). Reseller plans have a higher monthly cost compared to standard plans, but they have a substantial discount on the price-per-domain.
-
-We also created specific articles to clarify the difference between old plans and new plans:
+We've written a few articles to clarify the difference between old plans and current plans:
 
 - [I'm a Bronze customer](/articles/new-plans-for-bronze)
 - [I'm a Silver customer](/articles/new-plans-for-silver)
 - [I'm a Gold customer](/articles/new-plans-for-gold)
 
-
 ## Price differences
 
-In most cases, the price for newer plans is generally close to the price of second-generation legacy plans. Depending on the number of domains in your account, newer plans may even be less expensive.
+In most cases, the price for current plans is similar to the price of second-generation legacy plans. Depending on the number of domains in your account, current plans may even be less expensive.
 
-When compared to first-generation legacy plans, some customers may notice a larger price increase (especially Gold v1). First-generation plans were introduced in 2010, when the DNSimple infrastructure was an order of magniture simpler (and less expensive to maintain) than today.
+Compared to first-generation legacy plans, some customers may notice a larger price increase (especially Gold v1). We introduced first-generation plans in 2010 when DNSimple's infrastructure was simpler and less expensive to maintain.
 
-Over the last 6 years we have invested heavily in DDoS protection, Anycast DNS, additional infrastructure, and we continue to work to provide advanced features such as easy-to-use SSL certificates and Secondary DNS. Newer plans help DNSimple grow and improve the service for all of our customers.
+Over the last six years we've invested heavily in DDoS protection, Anycast DNS, and additional infrastructure.  We continue working to provide advanced features, like easy-to-use SSL certificates and Secondary DNS. Our current plans improve the service for all our customers, and help DNSimple grow .
 
+## Features only on current plans {#newer-plans-only}
 
-## Features only on newer plans {#newer-plans-only}
+Many new features are only made available on [current plans](#newer-plans) -  Personal, Professional, Business, and Reseller plans
 
-Many new features are only made available to [newer plans](#newer-plans). Specifically: Personal, Professional, Business, and reseller plans.
+If you see a _newer plan warning_ banner at the top of a support article, it means your account must be subscribed to one of the current plans in order to use the feature. If you're using a legacy plan, such as Bronze, Silver, or Gold, you can upgrade to the appropriate plan, and the feature will immediately be available to you.
 
-If you see a _newer plan warning_ banner at the top of a support article, it means your account must be subscribed to one of these plans in order to use the feature. If you are using a legacy plan such as Bronze, Silver, Gold, or Platinum, you can upgrade to the most appropriate plan and the feature will be immediately available to you.
+## Features only on certain tiers of current plans {#newer-plans-some}
 
+Some features are only available on certain plans, based on the level of service. For example, teams and regional records are features that make sense in an organizational context, so they're only available on Professional and Business plans.
 
-## Features only on certain tiers of newer plans {#newer-plans-some}
+If you see a _some-plans warning_ banner at the top of a support article, make sure your account is subscribed to the correct plan for that feature.
 
-Some features are only available on certain new plans, based on the level of service. For example, teams and regional records are features that generally makes sense only in the context of an organizations, therefore they are available only to Professional and Business plans.
+Some advanced features are only available in higher-tier plans. If you need the feature on a limited number of domains, you may want to [use multiple accounts to segment the business](https://blog.dnsimple.com/2015/12/using-accounts-to-segment-business/).
 
-If you see a _some-plans warning_ banner at the top of a support article, make sure your account is subscribed to the appropriate plan in order to use that feature.
-
-Some advanced features are only available in higher plans. If you need the feature only on a limited number of domains, you may want to consider [using multiple accounts to segment the business](https://blog.dnsimple.com/2015/12/using-accounts-to-segment-business/).
-
-For example, if you need [vanity name servers](/articles/vanity-nameservers) only on 3-4 domains, create a separate account with only these domains, and subscribe it to the Business plan. Leave the other domains on a lower plan, such as Professional, and you will only pay the feature for the domains where you actually use it.
-
+For example, if you need [vanity name servers](/articles/vanity-nameservers) only on 3-4 domains, create a separate account with these domains, and subscribe  it to the Business plan. Leave the other domains on a lower plan, such as Professional, and you'll just pay the for the feature on domains where you actually use it.


### PR DESCRIPTION
Adjusted the language to "current" or "newer" to reflect that the plans aren't brand new, but still newer than the legacy plans. I used "current" in the new-plans.markdown, and "newer" in the bronze, silver, and gold articles. 

Happy to change to 'newer' across the board if that's a more accurate description. 

Uniform changes to the bronze, silver, and gold articles for consistency in information. 

Standard changes to tone, active voice, & tightened copy. 
