### PR TITLE
Upgrades to the latest FontAwesome

### DIFF
--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -46,22 +46,22 @@ h2 {
     margin-left: -2.5rem;
     padding-top: 0.1rem;
     font-size: 16px;
-    font-family: "Font Awesome 5 Free";
-    font-weight: 900;
     line-height: 140%;
     color: $gray-600;
   }
 }
 
-.marker-info:before {
-  content: "\f05a";
+.marker-info{
+  &:before {
+    @include font-awesome("\f05a");
+  }
 }
 
 .marker-tip {
   box-shadow: -6px 0 0 0 $green;
 
   &:before {
-    content: "\f00c";
+    @include font-awesome("\f00c");
   }
 }
 
@@ -69,7 +69,7 @@ h2 {
   box-shadow: -6px 0 0 0 $yellow;
 
   &:before {
-    content: "\f071";
+    @include font-awesome("\f071");
   }
 }
 
@@ -77,7 +77,7 @@ h2 {
   box-shadow: -6px 0 0 0 $orange;
 
   &:before {
-    content: "\f06a";
+    @include font-awesome("\f06a");
     color: $orange;
   }
 }
@@ -98,9 +98,7 @@ h2 {
 #toc {
   &:before {
     margin-right: 10px;
-    content: "\f02e";
-    font-family: "Font Awesome 5 Free";
-    font-weight: 900;
+    @include font-awesome("\f02e");
   }
 }
 
@@ -123,9 +121,7 @@ h2 {
     &:first-child {
       &:before {
         margin-right: 10px;
-        content: "\f085";
-        font-family: "Font Awesome 5 Free";
-        font-weight: 900;
+        @include font-awesome("\f085");
       }
     }
   }
@@ -143,9 +139,7 @@ h2 {
 
   h4:before,
   h5:before {
-    font-family: "Font Awesome 5 Free";
-    font-weight: 900;
-    content: "\f0a4";
+    @include font-awesome("\f0a4");
     margin-right: 5px;
   }
 }
@@ -165,9 +159,7 @@ h2 {
   }
 
   h4:before {
-    font-family: "Font Awesome 5 Free";
-    font-weight: 900;
-    content: "\f059";
+    @include font-awesome("\f059");
     margin-right: 5px;
   }
 }
@@ -243,8 +235,6 @@ input.form-control.search-query {
   &:before {
     margin-right: 10px;
     color: #dddddd;
-    content: "\f054";
-    font-family: "Font Awesome 5 Free";
-    font-weight: 900;
+    @include font-awesome("\f054");
   }
 }

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -46,7 +46,8 @@ h2 {
     margin-left: -2.5rem;
     padding-top: 0.1rem;
     font-size: 16px;
-    font-family: FontAwesome;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
     line-height: 140%;
     color: $gray-600;
   }
@@ -98,7 +99,8 @@ h2 {
   &:before {
     margin-right: 10px;
     content: "\f02e";
-    font-family: FontAwesome;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
   }
 }
 
@@ -122,7 +124,8 @@ h2 {
       &:before {
         margin-right: 10px;
         content: "\f085";
-        font-family: FontAwesome;
+        font-family: "Font Awesome 5 Free";
+        font-weight: 900;
       }
     }
   }
@@ -140,7 +143,8 @@ h2 {
 
   h4:before,
   h5:before {
-    font-family: FontAwesome;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
     content: "\f0a4";
     margin-right: 5px;
   }
@@ -161,7 +165,8 @@ h2 {
   }
 
   h4:before {
-    font-family: FontAwesome;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
     content: "\f059";
     margin-right: 5px;
   }
@@ -239,6 +244,7 @@ input.form-control.search-query {
     margin-right: 10px;
     color: #dddddd;
     content: "\f054";
-    font-family: FontAwesome;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
   }
 }

--- a/content/assets/css/_mixins.scss
+++ b/content/assets/css/_mixins.scss
@@ -21,3 +21,9 @@
   background-image: -o-linear-gradient($deg, $startColor, $endColor); // Opera 11.10
   background-image: linear-gradient($deg, $startColor, $endColor); // Standard, IE10
 }
+
+@mixin font-awesome($unicode) {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  content: $unicode;
+}

--- a/content/assets/css/_template.scss
+++ b/content/assets/css/_template.scss
@@ -60,9 +60,7 @@ h5 {
   color: $gray-500;
   &:before {
     margin-right: 8px;
-    content: "\f35d";
-    font-family: "Font Awesome 5 Free";
-    font-weight: 900;
+    @include font-awesome("\f35d");
   }
   &:hover {
     text-decoration: none;

--- a/content/assets/css/_template.scss
+++ b/content/assets/css/_template.scss
@@ -59,9 +59,10 @@ h5 {
   padding-top: $base-unit / 4;
   color: $gray-500;
   &:before {
-    margin-right: 10px;
-    content: "\f08e";
-    font-family: FontAwesome;
+    margin-right: 8px;
+    content: "\f35d";
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
   }
   &:hover {
     text-decoration: none;

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -13,7 +13,7 @@
 
   <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
   <link rel="stylesheet" type="text/css" href="/assets/css/style.css">
-  <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.css">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.1/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
   <!--[if lt IE 9]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->


### PR DESCRIPTION
This PR upgrades this site to the latest FontAwesome.

# Preview

I double checked each icon. Here's how they render now:

<img width="396" alt="screen shot 2019-02-11 at 11 08 49 am" src="https://user-images.githubusercontent.com/80610/52557186-f9ec7380-2dee-11e9-8555-060bb9ec8a35.png">
<img width="139" alt="screen shot 2019-02-11 at 11 05 53 am" src="https://user-images.githubusercontent.com/80610/52557187-f9ec7380-2dee-11e9-8426-2aad14082948.png">
<img width="463" alt="screen shot 2019-02-11 at 11 05 57 am" src="https://user-images.githubusercontent.com/80610/52557188-fa850a00-2dee-11e9-91ef-6fda06e56293.png">
<img width="186" alt="screen shot 2019-02-11 at 11 06 01 am" src="https://user-images.githubusercontent.com/80610/52557189-fa850a00-2dee-11e9-9579-117f6c3cd14d.png">
<img width="288" alt="screen shot 2019-02-11 at 11 06 45 am" src="https://user-images.githubusercontent.com/80610/52557191-fa850a00-2dee-11e9-98c5-483445b96f02.png">
<img width="439" alt="screen shot 2019-02-11 at 11 08 01 am" src="https://user-images.githubusercontent.com/80610/52557192-fb1da080-2dee-11e9-841f-5a14cd815a63.png">

# 🤝 Verification steps

1. The top nav bar should show an icon for the search and another for navigating to the app
1. Navigate to a category page. You should see the correct icons.
1. http://localhost:3000/articles/subscription-renewals/ should show the correct table-of-content icons as well as different alerts.
