### PR TITLE
Replace "Account sharing"

### DIFF
--- a/content/articles/account-users.markdown
+++ b/content/articles/account-users.markdown
@@ -20,7 +20,7 @@ To have multiple users on one account, you must [be subscribed to an eligible pl
 
 A DNSimple account can be associated with one or more users. When you add a user to an account, they will have full access rights to every resource attached to the account, including domains, contacts, SSL certificates, etc.
 
-All members will also have full-admin access to the account, including the ability to access and change billing information and account details. The user will retain their login credentials and Two-Factor authentication configuration.
+All members will also have full-admin access to the account, including the ability to access and change billing information and account details. The user will retain their login credentials and two-factor authentication configuration.
 
 
 ## Adding members to an account

--- a/content/articles/account-users.markdown
+++ b/content/articles/account-users.markdown
@@ -1,11 +1,11 @@
 ---
-title: Sharing accounts
+title: Multi-User Accounts
 excerpt: How to manage the users on a DNSimple account.
 categories:
 - Account
 ---
 
-# Managing Team Members Sharing One Account
+# Managing Multiple Users on One Account
 
 ### Table of Contents {#toc}
 
@@ -15,12 +15,12 @@ categories:
 ---
 
 <info>
-To share an account with other users, you must [be subscribed to an eligible plan](https://dnsimple.com/pricing).
+To have multiple users on one account, you must [be subscribed to an eligible plan](https://dnsimple.com/pricing).
 </info>
 
-A DNSimple account can be associated with one or more users. When you add a user to an account, the new member will have full access rights on every resource attached to the account, including domains, contacts, SSL certificates, etc.
+A DNSimple account can be associated with one or more users. When you add a user to an account, they will have full access rights to every resource attached to the account, including domains, contacts, SSL certificates, etc.
 
-All members will also have full-admin access to the account, including the ability to access and change billing information and account details. The user will retain their login credentials and 2-factor authentication configuration.
+All members will also have full-admin access to the account, including the ability to access and change billing information and account details. The user will retain their login credentials and Two-Factor authentication configuration.
 
 
 ## Adding members to an account


### PR DESCRIPTION
Deleted all instances of "sharing" in the Multi-User Account article 