### PR TITLE
Clarify information about email address used for notifications

### DIFF
--- a/content/articles/product-expiration-notification.markdown
+++ b/content/articles/product-expiration-notification.markdown
@@ -9,6 +9,8 @@ categories:
 
 The **Product Expiration** email contains the list of products (purchased domains, certificates and whois privacies) expiring within 2 months, grouped by expiration range.
 
+Emails about expiration products will be sent to the account email address. Changes in certificate [validation emails](/articles/ssl-certificates-email-validation/) or domain [contact](/articles/contact-management/) information won't affect your expiration notifications emails.
+
 ![Email](/files/notifications-expiring.png)
 
 There are four expiration ranges: in a day, within a week, a month and 2 months. These ranges cannot be customized.

--- a/content/articles/product-expiring-tomorrow-notification.markdown
+++ b/content/articles/product-expiring-tomorrow-notification.markdown
@@ -9,6 +9,8 @@ categories:
 
 The **Product Expiring Tomorrow** email contains the list of products (purchased domains, certificates and whois privacies) expiring within 24 hours.
 
+Emails about expiration products will be sent to your account email address. Changes in certificate [validation emails](/articles/ssl-certificates-email-validation/) or domain [contact](/articles/contact-management/) information won't affect your expiration notifications emails.
+
 This notification is an important reminder and gives you the latest chance to renew a domain in case you forgot about it for whatever reason.
 
 ![Email](/files/notifications-expiring-tomorrow.png)

--- a/content/articles/product-expiring-tomorrow-notification.markdown
+++ b/content/articles/product-expiring-tomorrow-notification.markdown
@@ -9,7 +9,7 @@ categories:
 
 The **Product Expiring Tomorrow** email contains the list of products (purchased domains, certificates and whois privacies) expiring within 24 hours.
 
-Emails about expiration products will be sent to your account email address. Changes in certificate [validation emails](/articles/ssl-certificates-email-validation/) or domain [contact](/articles/contact-management/) information won't affect your expiration notifications emails.
+Emails about expiration products will be sent to the account email address. Changes in certificate [validation emails](/articles/ssl-certificates-email-validation/) or domain [contact](/articles/contact-management/) information won't affect your expiration notifications emails.
 
 This notification is an important reminder and gives you the latest chance to renew a domain in case you forgot about it for whatever reason.
 


### PR DESCRIPTION
A user assumed we were sending the expiration warnings about certificates to the email used for that certificate validation. 

I've updated this article to clarify the fact that we use the email associated to the account, not the products inside. This will be helpful for our users, and for us to reference when they ask us again.

To review it, 
1. visit: /articles/product-expiring-tomorrow-notification/
2. check the paragraph added is:
> Emails about expiration products will be sent to your account email address. Changes in certificate validation emails or domain contact information won’t affect your expiration notifications emails.

