### PR TITLE
Upgrades to Global Site Tag (gtag.js)

### DIFF
--- a/layouts/analytics.html
+++ b/layouts/analytics.html
@@ -1,11 +1,9 @@
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-17301867-5']);
-  _gaq.push(['_trackPageview']);
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-17301867-5"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+  gtag('config', 'UA-17301867-5');
 </script>


### PR DESCRIPTION
We were currently using a legacy version of an analytics script: https://developers.google.com/analytics/devguides/collection/gajs/

In order to connect Google Optimize to the support site, I need to upgrade to the latest, and that's at least Global Site Tag (gtag.js). I have copied and pasted the recommended script from the Google Analytics site. I don't think we do anything fancy in our analytics for the support site, so I assume that I don't need to fix anything else on the configuration.

I was on the fence of installing Google Tag Manager, but I thought that it could be overkill just for the support site at the moment. But I'll be happy to do it if that's the way we want to go.

I tried to extract the google analytics tracking code to a configuration variable, but nanoc was not very helpful and after struggling with that simple task, I decided to leave it in.