### PR TITLE
Explain .it extended attributes

### DIFF
--- a/content/articles/domains-it.markdown
+++ b/content/articles/domains-it.markdown
@@ -1,33 +1,33 @@
 ---
-title: .IT Domains
-excerpt: This article explains the requirements for .IT domain names.
+title: .it Domains
+excerpt: This article explains the requirements for .it domain names.
 categories:
 - Domains
 ---
 
-# .IT Domain Names
+# .it Domain Names
 
 * TOC
 {:toc}
 
 ---
 
-This article explains the requirements for .IT domain names.
+This article explains the requirements for .it domain names.
 
 ## Requirements
 
-To register an .IT (Italy) domain you must meet one of the following criteria:
+To register an .it (Italy) domain you must meet one of the following criteria:
 
-1. In possession of the citizenship or resident in a country belonging to the European Union (in the case of registration for natural persons).
+1. In possession of citizenship or residency in a country belonging to the European Union (in the case of registration for natural persons).
 1. Established in a country belonging to the European Union (in the case of registration for other organizations).
 
 Please make sure the Registrant contact you associate to the domain during the registration meets this requirement, otherwise the registration will be rejected by the registry.
 
-## Additional Information and Agreements
+## Additional information and agreements
 
 When registering an .it domain, you must provide more details about the domain registrant, as well as explicitly agreeing to additional agreements of the .it registry.
 
-### Taxpayer number for .IT domain registrations (registration code)
+### Taxpayer number for .it domain registrations (registration code)
 
 Italian and foreign natural persons – if the Registrant is an Italian natural person, it's their _Codice Fiscale_; for foreigners it must contain a document number.
 

--- a/content/articles/domains-it.markdown
+++ b/content/articles/domains-it.markdown
@@ -18,36 +18,36 @@ This article explains the requirements for .IT domain names.
 
 To register an .IT (Italy) domain you must meet one of the following criteria:
 
-1. In possession of the citizenship or resident in a country belonging to the European Union (in the case of registration for natural persons)
-1. Established in a country belonging to the European Union (in the case of registration for other organizations)
+1. In possession of the citizenship or resident in a country belonging to the European Union (in the case of registration for natural persons).
+1. Established in a country belonging to the European Union (in the case of registration for other organizations).
 
 Please make sure the Registrant contact you associate to the domain during the registration meets this requirement, otherwise the registration will be rejected by the registry.
 
 ## Additional Information and Agreements
 
-When registering an .it domain you will need to provide some more details about the domain registrant as well as explicitly agreeing to additional agreements of the .it registry.
+When registering an .it domain, you must provide more details about the domain registrant, as well as explicitly agreeing to additional agreements of the .it registry.
 
-### Taxpayer number for .IT domain registrations (reg code)
+### Taxpayer number for .IT domain registrations (registration code)
 
-Italian and foreign natural persons if the Registrant is an Italian natural person, it's their _Codice Fiscale_; for foreigners it must contain a document number.
+Italian and foreign natural persons – if the Registrant is an Italian natural person, it's their _Codice Fiscale_; for foreigners it must contain a document number.
 
-Non-profit organizations without VAT number and numeric tax code use "**n.a.**".
+Non-profit organizations without a VAT number or numeric tax code use "**n.a.**".
 
-Foreign that are not a natural person use the VAT number.
+Foreigners who aren't naturalized citizens should use a VAT number.
 
-In all the other cases, it must be equal to VAT number or the numeric tax code.
+In all other cases, it must be equal to a VAT number or the numeric tax code.
 
 ### Sect. - 3. Declarations and assumptions of liability
 
 The Registrant of the domain name in question, declares under their own responsibility that they are:
-- in possession of the citizenship or resident in a country belonging to the European Union (in the case of registration for natural persons);
-- established in a country belonging to the European Union (in the case of registration for other organizations);
-- aware and accept that the registration and management of a domain name is subject to the "Rules of assignment and management of domain names in ccTLD. it" and "Regulations for the resolution of disputes in the ccTLD.it" and their subsequent amendments;
-- entitled to the use and/or legal availability of the domain name applied for, and that they do not prejudice, with the request for registration, the rights of others;
-- aware that for the inclusion of personal data in the Database of assigned domain names, and their possible dissemination and accessibility via the Internet, consent must be given explicitly by ticking the appropriate boxes in the information below. See "The policy of the .it Registry in the Whois Database" on the website of the Registry (http://www.nic.it);
-- aware and agree that in the case of erroneous or false declarations in this request, the Registry shall immediately revoke the domain name, or proceed with other legal actions. In such case the revocation shall not in any way give rise to claims against the Registry;
-- release the Registry from any liability resulting from the assignment and use of the domain name by the natural person that has made the request;
-- accept Italian jurisdiction and laws of the Italian State.
+- In possession of the citizenship or resident in a country belonging to the European Union (in the case of registration for natural persons);
+- Established in a country belonging to the European Union (in the case of registration for other organizations);
+- Aware and accept that the registration and management of a domain name is subject to the "Rules of assignment and management of domain names in ccTLD. it" and "Regulations for the resolution of disputes in the ccTLD.it" and their subsequent amendments;
+- Entitled to the use and/or legal availability of the domain name applied for, and that they do not prejudice, with the request for registration, the rights of others;
+- Aware that for the inclusion of personal data in the Database of assigned domain names, and their possible dissemination and accessibility via the Internet, consent must be given explicitly by ticking the appropriate boxes in the information below. See "The policy of the .it Registry in the Whois Database" on the website of the Registry (http://www.nic.it);
+- Aware and agree that in the case of erroneous or false declarations in this request, the Registry shall immediately revoke the domain name, or proceed with other legal actions. In such case the revocation shall not in any way give rise to claims against the Registry;
+- Release the Registry from any liability resulting from the assignment and use of the domain name by the natural person that has made the request;
+- Accept Italian jurisdiction and laws of the Italian State.
 
 ### Sec. 5 - Consent to the processing of personal data for registration:
 The interested party, after reading the above disclosure, gives consent to the processing of information required for registration, as defined in the above disclosure. Giving consent is optional, but if no consent is given, it will not be possible to finalize the registration, assignment and management of the domain name.
@@ -57,7 +57,7 @@ The interested party, after reading the above disclosure, gives consent to the d
 
 ### Sec. 7 - Explicit Acceptance of the following points
 For explicit acceptance, the interested party declares that they:
-d) are aware and agree that the registration and management of a domain name is subject to the "Rules of assignment and management of domain names in ccTLD.it" and "Regulations for the resolution of disputes in the ccTLD.it "and their subsequent amendments;
-e) are aware and agree that in the case of erroneous or false declarations in this request, the Registry shall immediately revoke the domain name, or proceed with other legal actions. In such case the revocation shall not in any way give rise to claims against the Registry;
-f) release the Registry from any liability resulting from the assignment and use of the domain name by the natural person that has made the request;
-g) accept the Italian jurisdiction and laws of the Italian State.
+d) Are aware and agree that the registration and management of a domain name is subject to the "Rules of assignment and management of domain names in ccTLD.it" and "Regulations for the resolution of disputes in the ccTLD.it "and their subsequent amendments;
+e) Are aware and agree that in the case of erroneous or false declarations in this request, the Registry shall immediately revoke the domain name, or proceed with other legal actions. In such case the revocation shall not in any way give rise to claims against the Registry;
+f) Release the Registry from any liability resulting from the assignment and use of the domain name by the natural person that has made the request;
+g) Accept the Italian jurisdiction and laws of the Italian State.

--- a/content/articles/domains-it.markdown
+++ b/content/articles/domains-it.markdown
@@ -22,3 +22,42 @@ To register an .IT (Italy) domain you must meet one of the following criteria:
 1. Established in a country belonging to the European Union (in the case of registration for other organizations)
 
 Please make sure the Registrant contact you associate to the domain during the registration meets this requirement, otherwise the registration will be rejected by the registry.
+
+## Additional Information and Agreements
+
+When registering an .it domain you will need to provide some more details about the domain registrant as well as explicitly agreeing to additional agreements of the .it registry.
+
+### Taxpayer number for .IT domain registrations (reg code)
+
+Italian and foreign natural persons if the Registrant is an Italian natural person, it's their _Codice Fiscale_; for foreigners it must contain a document number.
+
+Non-profit organizations without VAT number and numeric tax code use "**n.a.**".
+
+Foreign that are not a natural person use the VAT number.
+
+In all the other cases, it must be equal to VAT number or the numeric tax code.
+
+### Sect. - 3. Declarations and assumptions of liability
+
+The Registrant of the domain name in question, declares under their own responsibility that they are:
+- in possession of the citizenship or resident in a country belonging to the European Union (in the case of registration for natural persons);
+- established in a country belonging to the European Union (in the case of registration for other organizations);
+- aware and accept that the registration and management of a domain name is subject to the "Rules of assignment and management of domain names in ccTLD. it" and "Regulations for the resolution of disputes in the ccTLD.it" and their subsequent amendments;
+- entitled to the use and/or legal availability of the domain name applied for, and that they do not prejudice, with the request for registration, the rights of others;
+- aware that for the inclusion of personal data in the Database of assigned domain names, and their possible dissemination and accessibility via the Internet, consent must be given explicitly by ticking the appropriate boxes in the information below. See "The policy of the .it Registry in the Whois Database" on the website of the Registry (http://www.nic.it);
+- aware and agree that in the case of erroneous or false declarations in this request, the Registry shall immediately revoke the domain name, or proceed with other legal actions. In such case the revocation shall not in any way give rise to claims against the Registry;
+- release the Registry from any liability resulting from the assignment and use of the domain name by the natural person that has made the request;
+- accept Italian jurisdiction and laws of the Italian State.
+
+### Sec. 5 - Consent to the processing of personal data for registration:
+The interested party, after reading the above disclosure, gives consent to the processing of information required for registration, as defined in the above disclosure. Giving consent is optional, but if no consent is given, it will not be possible to finalize the registration, assignment and management of the domain name.
+
+### Sec. 6 - Consent to the processing of personal data for diffusion and accessibility via the Internet
+The interested party, after reading the above disclosure, gives consent to the dissemination and accessibility via the Internet, as defined in the disclosure above. Giving consent is optional, but absence of consent does not allow the dissemination and accessibility of Internet data.
+
+### Sec. 7 - Explicit Acceptance of the following points
+For explicit acceptance, the interested party declares that they:
+d) are aware and agree that the registration and management of a domain name is subject to the "Rules of assignment and management of domain names in ccTLD.it" and "Regulations for the resolution of disputes in the ccTLD.it "and their subsequent amendments;
+e) are aware and agree that in the case of erroneous or false declarations in this request, the Registry shall immediately revoke the domain name, or proceed with other legal actions. In such case the revocation shall not in any way give rise to claims against the Registry;
+f) release the Registry from any liability resulting from the assignment and use of the domain name by the natural person that has made the request;
+g) accept the Italian jurisdiction and laws of the Italian State.


### PR DESCRIPTION
As part of overhauling the extended attributes for Hexonet we place the more complex legal texts in support and link to these from the registration flow.

This site is the link target, as well as explains the attributes and hold the entire legal texts.