### PR TITLE
Bring back "contact change 60 day lock"

### DIFF
--- a/content/articles/icann-60-day-lock-registrant-change.markdown
+++ b/content/articles/icann-60-day-lock-registrant-change.markdown
@@ -7,7 +7,7 @@ categories:
 
 # 60-Day Lock After Change of Registrant
 
-Due to [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making certain changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
+For all domains under ICANN management, all [gTLDs](/articles/what-is-tld/) and potentially some [ccTLDs](/articles/what-is-tld/), a new [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making certain changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
 
 > After 1 December 2016, registrars must impose a lock that will prevent any transfer to another registrar for sixty (60) days following a change to a registrant's information. Registrars may (but are not required to) allow registrants to opt out of the 60-day lock prior to the change of registrant request.
 >

--- a/content/articles/icann-60-day-lock-registrant-change.markdown
+++ b/content/articles/icann-60-day-lock-registrant-change.markdown
@@ -7,7 +7,7 @@ categories:
 
 # 60-Day Lock After Change of Registrant
 
-For all domains under ICANN management, all [gTLDs](/articles/what-is-tld/) and potentially some [ccTLDs](/articles/what-is-tld/), a new [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making certain changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
+For all domains under registries under contract with ICANN, including all [gTLDs](/articles/what-is-tld/), [newGTLDs](/articles/what-is-tld/), and potentially some [ccTLDs](/articles/what-is-tld/), a new [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making certain changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
 
 > After 1 December 2016, registrars must impose a lock that will prevent any transfer to another registrar for sixty (60) days following a change to a registrant's information. Registrars may (but are not required to) allow registrants to opt out of the 60-day lock prior to the change of registrant request.
 >

--- a/content/articles/icann-60-day-lock-registrant-change.markdown
+++ b/content/articles/icann-60-day-lock-registrant-change.markdown
@@ -10,12 +10,12 @@ categories:
 Due to [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
 
 > After 1 December 2016, registrars must impose a lock that will prevent any transfer to another registrar for sixty (60) days following a change to a registrant's information. Registrars may (but are not required to) allow registrants to opt out of the 60-day lock prior to the change of registrant request.
-> 
+>
 > To transfer a domain name to another registrar and change the registrant's information, registrants may:
-> 
+>
 > - Request the transfer to another registrar before changing the registrant's information (to avoid the 60-day lock); or
 > - Have the prior registrant opt-out the 60-day lock (if this option is offered by the registrar) before making any change to registrant information.
-> 
+>
 > Because policies may vary by registrar, please review a registrar's policy before making a change to registrant information or transferring to another registrar.
 
-At the time being, we don't support the ability to opt-out the 60-day lock, therefore we highly recommend that if you plan on transfering your domain you should make sure to wait until it is transferred to update the contact information.
+At the time being, we don't support the ability to opt-out the 60-day lock, therefore we highly recommend that if you plan on transferring your domain you should make sure to wait until it is transferred to update the contact information.

--- a/content/articles/icann-60-day-lock-registrant-change.markdown
+++ b/content/articles/icann-60-day-lock-registrant-change.markdown
@@ -1,13 +1,13 @@
 ---
 title: ICANN 60-Day Lock After Change of Registrant
-excerpt: After changing your registration info you cannot transfer your domain for sixty days.
+excerpt: After changing your registration info, you cannot transfer your domain for 60 days.
 categories:
 - Contacts
 ---
 
 # 60-Day Lock After Change of Registrant
 
-For all domains under registries under contract with ICANN, including all [gTLDs](/articles/what-is-tld/), [newGTLDs](/articles/what-is-tld/), and potentially some [ccTLDs](/articles/what-is-tld/), a new [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making certain changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
+For all domains under registries contracted with ICANN, including all [gTLDs](/articles/what-is-tld/), [newGTLDs](/articles/what-is-tld/), and potentially some [ccTLDs](/articles/what-is-tld/), a new [ICANN policies went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en):
 
 > After 1 December 2016, registrars must impose a lock that will prevent any transfer to another registrar for sixty (60) days following a change to a registrant's information. Registrars may (but are not required to) allow registrants to opt out of the 60-day lock prior to the change of registrant request.
 >
@@ -18,4 +18,4 @@ For all domains under registries under contract with ICANN, including all [gTLDs
 >
 > Because policies may vary by registrar, please review a registrar's policy before making a change to registrant information or transferring to another registrar.
 
-At the time being, we don't support the ability to opt-out the 60-day lock, therefore we highly recommend that if you plan on transferring your domain you should make sure to wait until it is transferred to update the contact information.
+We don't support the ability to opt-out of the 60-day lock. We highly recommend that if you plan to transfer your domain, you wait to update the contact information until after it's transferred.

--- a/content/articles/icann-60-day-lock-registrant-change.markdown
+++ b/content/articles/icann-60-day-lock-registrant-change.markdown
@@ -7,7 +7,7 @@ categories:
 
 # 60-Day Lock After Change of Registrant
 
-Due to [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
+Due to [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making certain changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
 
 > After 1 December 2016, registrars must impose a lock that will prevent any transfer to another registrar for sixty (60) days following a change to a registrant's information. Registrars may (but are not required to) allow registrants to opt out of the 60-day lock prior to the change of registrant request.
 >

--- a/content/articles/icann-60-day-lock-registrant-change.markdown
+++ b/content/articles/icann-60-day-lock-registrant-change.markdown
@@ -1,0 +1,21 @@
+---
+title: ICANN 60-Day Lock After Change of Registrant
+excerpt: After changing your registration info you cannot transfer your domain for sixty days.
+categories:
+- Contacts
+---
+
+# 60-Day Lock After Change of Registrant
+
+Due to [ICANN policies that went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en), making changes the registrant contact will lock the domain for 60 days. During that period, it will not be possible to transfer the domain to another registrar.
+
+> After 1 December 2016, registrars must impose a lock that will prevent any transfer to another registrar for sixty (60) days following a change to a registrant's information. Registrars may (but are not required to) allow registrants to opt out of the 60-day lock prior to the change of registrant request.
+> 
+> To transfer a domain name to another registrar and change the registrant's information, registrants may:
+> 
+> - Request the transfer to another registrar before changing the registrant's information (to avoid the 60-day lock); or
+> - Have the prior registrant opt-out the 60-day lock (if this option is offered by the registrar) before making any change to registrant information.
+> 
+> Because policies may vary by registrar, please review a registrar's policy before making a change to registrant information or transferring to another registrar.
+
+At the time being, we don't support the ability to opt-out the 60-day lock, therefore we highly recommend that if you plan on transfering your domain you should make sure to wait until it is transferred to update the contact information.


### PR DESCRIPTION
Reverts dnsimple/dnsimple-support#357

This will need some more adjustments, regarding when we lock. This depends on the registrar we are using for a registration.