### PR TITLE
Removes jquery

### DIFF
--- a/content/assets/js/search.js
+++ b/content/assets/js/search.js
@@ -1,11 +1,11 @@
-(function($){
+(function(){
 
   var parseQueryParams = function() {
     return decodeURIComponent(window.location.search.substring(3).replace(/\+/g, " "));
   };
 
-  $resultList = $("#js-result-list");
-  $("#js-query").text(parseQueryParams());
+  // Show query on page
+  document.getElementById("js-query").innerText = parseQueryParams();
 
   var titles = [];
   var searchIndex = null;
@@ -29,10 +29,11 @@
   }
 
   var render = function(results) {
-    $resultList.html("");
+    var el = document.getElementById("js-result-list");
+    el.innerHTML = "";
 
     if (results.length == 0) {
-      $resultList.html("No results found");
+      el.innerHTML = "No results found";
     }
 
     for (item of results) {
@@ -42,18 +43,25 @@
       a.href = ref;
       a.innerHTML = titles[ref];
       li.appendChild(a);
-      $resultList.append(li);
+      el.append(li);
     }
 
   }
 
-  $.getJSON('/search.json')
-    .done(function(data) {
+  var request = new XMLHttpRequest();
+  request.open('GET', '/search.json', true);
+  request.onload = function() {
+    if (request.status >= 200 && request.status < 400) {
+      var data = JSON.parse(request.responseText);
       initIndex(data);
       render(search());
-    })
-    .fail(function() {
-      $resultList.html("Sorry, the search is broken at this time. Please contact support.");
-    });
+    } else {
+      document.getElementById("js-result-list").innerHTML = "Sorry, the search is broken at this time. Please contact support.";
+    }
+  };
+  request.onerror = function() {
+    document.getElementById("js-result-list").innerHTML = "Sorry, the search is broken at this time. Please contact support.";
+  };
+  request.send();
 
-})(jQuery);
+})();

--- a/content/assets/js/search.js
+++ b/content/assets/js/search.js
@@ -1,5 +1,6 @@
 (function(){
 
+  // Decodes query parameter for search
   var parseQueryParams = function() {
     return decodeURIComponent(window.location.search.substring(3).replace(/\+/g, " "));
   };
@@ -7,9 +8,11 @@
   // Show query on page
   document.getElementById("js-query").innerText = parseQueryParams();
 
+  // Vars for Lunr article titles and search index
   var titles = [];
   var searchIndex = null;
 
+  // Initialize Lunr's Index
   var initIndex = function(data) {
     searchIndex = lunr(function(){
       this.ref('id');
@@ -24,10 +27,12 @@
     });
   }
 
+  // Search Lunr's index based on the query parameter
   var search = function() {
     return searchIndex.search(parseQueryParams());
   }
 
+  // Display results on page
   var render = function(results) {
     var el = document.getElementById("js-result-list");
     el.innerHTML = "";
@@ -45,23 +50,28 @@
       li.appendChild(a);
       el.append(li);
     }
-
   }
 
-  var request = new XMLHttpRequest();
-  request.open('GET', '/search.json', true);
-  request.onload = function() {
-    if (request.status >= 200 && request.status < 400) {
-      var data = JSON.parse(request.responseText);
-      initIndex(data);
-      render(search());
-    } else {
+  // Get the data to index from server
+  var retrieveData = function() {
+    var request = new XMLHttpRequest();
+    request.open('GET', '/search.json', true);
+    request.onload = function() {
+      if (request.status >= 200 && request.status < 400) {
+        var data = JSON.parse(request.responseText);
+        initIndex(data);
+        render(search());
+      } else {
+        document.getElementById("js-result-list").innerHTML = "Sorry, the search is broken at this time. Please contact support.";
+      }
+    };
+    request.onerror = function() {
       document.getElementById("js-result-list").innerHTML = "Sorry, the search is broken at this time. Please contact support.";
-    }
-  };
-  request.onerror = function() {
-    document.getElementById("js-result-list").innerHTML = "Sorry, the search is broken at this time. Please contact support.";
-  };
-  request.send();
+    };
+    request.send();
+  }
+
+  // Search!
+  retrieveData();
 
 })();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "jquery": "^3.4.1",
     "lunr": "^2.3.6"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,2 @@
-var $ = require('jquery');
-window.jQuery = $;
-window.$ = $;
-
 var lunr = require('lunr');
 window.lunr = lunr;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,11 +1583,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-jquery@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"


### PR DESCRIPTION
Closes #448

This PR removes the jQuery dependency.

## 🔍 Test cases

- Run `yarn` to get the latest dependencies.
- Run `rm -rf output` to remove the `output` folder. This is what gets deliver when we deploy this static site.
- Run `yarn live`. This regenerates the `output` folder.
- Perform a search and compare with the production site: support.dnsimple.com. Search for a wide range of results: `let's encrypt`, `best`, `oranges`


## :shipit: Deployment Pre/Post tasks

None. Travis uses `rake` to build and deploy the site.

## 🚀 Verification

See :mag: test cases above


