### PR TITLE
Add reseller plans to https redirector requisites

### DIFF
--- a/content/articles/redirector.markdown
+++ b/content/articles/redirector.markdown
@@ -18,10 +18,10 @@ The redirector is a special feature provided by DNSimple that you can use to red
 
 This feature can be used, for example, to redirect the www version of a domain to the non-www hostname. Another use case is to redirect a secondary domain you purchased to the main domain without pointing it to any web hosting service.
 
-This feature can't be used to redirect from one protocol to another protocol on the same host name. For example, you can't use it to redirect from `http://example.com` to `https://example.com`. To perform a redirect from HTTP to HTTPS on the same host, you'll need to implement the redirection inside your application. If you host on Heroku, [this guide](https://support.dnsimple.com/articles/redirect-heroku/#redirect-http2https) explains how to perform the redirection. 
+This feature can't be used to redirect from one protocol to another protocol on the same host name. For example, you can't use it to redirect from `http://example.com` to `https://example.com`. To perform a redirect from HTTP to HTTPS on the same host, you'll need to implement the redirection inside your application. If you host on Heroku, [this guide](https://support.dnsimple.com/articles/redirect-heroku/#redirect-http2https) explains how to perform the redirection.
 
 <info>
-HTTP redirects are available to all plans. HTTPS redirects are available only on the following [plans](https://dnsimple.com/pricing): Professional or Business.
+HTTP redirects are available to all plans. HTTPS redirects are available only on the following [plans](https://dnsimple.com/pricing): Professional, Business, Expert Reseller and Master Reseller.
 </info>
 
 

--- a/content/articles/redirector.markdown
+++ b/content/articles/redirector.markdown
@@ -21,7 +21,7 @@ This feature can be used, for example, to redirect the www version of a domain t
 This feature can't be used to redirect from one protocol to another protocol on the same host name. For example, you can't use it to redirect from `http://example.com` to `https://example.com`. To perform a redirect from HTTP to HTTPS on the same host, you'll need to implement the redirection inside your application. If you host on Heroku, [this guide](https://support.dnsimple.com/articles/redirect-heroku/#redirect-http2https) explains how to perform the redirection.
 
 <info>
-HTTP redirects are available to all plans. HTTPS redirects are available only on the following [plans](https://dnsimple.com/pricing): Professional, Business, Expert Reseller and Master Reseller.
+HTTP redirects are available to all plans. HTTPS redirects are available only on the following [plans](https://dnsimple.com/pricing): Professional, Business, Expert Reseller or Master Reseller.
 </info>
 
 


### PR DESCRIPTION
Motivated by https://dnsimple.groovehq.com/tickets/78950 since we were not listing reseller plans in the HTTPS redirector requisites 