### PR TITLE
Add Q/A about Certificates validness after account unsubscribal

### DIFF
--- a/content/articles/faq-ssl-certificates.markdown
+++ b/content/articles/faq-ssl-certificates.markdown
@@ -42,6 +42,13 @@ categories:
     An SSL certificate is not a single-time purchase. You need to renew the certificate periodically, sometimes you need to rekey it or you find yourself having issues installing it, and you want to ask for some help. All these tasks are covered by our subscription service.
 
     Additionally, if you are requesting a [Let's Encrypt certificate](/articles/letsencrypt/), we will use our DNS hosting service to automatically provision the DNS records required to validate your certificate, and we will [automatically renew](/articles/letsencrypt/#auto-renewal) the certificate for you before it expires. All these services require a subscription.
+
+1.  #### I'm unsubscribed/ing my account, will my current certificate keep valid?
+
+    Yes. As explained in the previous questions, you are not required to have an active subscription to use or install the certificate on your domain/server.
+
+    However please note that if you disable the subscription you will not receive any additional service for the domain or the certificate, like expiration warnings or the ability to renew or reissue it.
+
 </div>
 
 ## Domains and SSL certificates

--- a/content/articles/faq-ssl-certificates.markdown
+++ b/content/articles/faq-ssl-certificates.markdown
@@ -1,6 +1,6 @@
 ---
 title: SSL Certificates Frequently Asked Questions
-excerpt: This is a collection of frequently asked questions about the SSL certificates offered by DNSimple.
+excerpt: A collection of frequently asked questions about the SSL certificates offered by DNSimple.
 categories:
 - SSL Certificates
 ---
@@ -19,7 +19,7 @@ categories:
 <div class="section-faq" markdown="1">
 1.  #### What is the price of an SSL certificate?
 
-    The price depends on the certificate type. To learn more visit the [SSL Certificates](/articles/ssl-certificates) article.
+    The price depends on the certificate type. To learn more, visit [SSL Certificates](/articles/ssl-certificates).
 
 1.  #### I want to purchase an SSL certificate. What is the DNSimple subscription?
 
@@ -29,25 +29,25 @@ categories:
 
 1.  #### I want to purchase an SSL certificate. Do I need a subscription?
 
-    Yes. As explained in the previous question, SSL certificates are one of our paid products, provided as part of our subscription service.
+    Yes. SSL certificates are one of our paid products, provided as part of our subscription service.
 
-    In order to purchase an SSL certificate you need an active subscription at the time of the purchase. You are not required to have an active subscription to use or install the certificate on your server, however please note that if you disable the subscription you will not receive any additional service for the domain or the certificate.
+   To purchase an SSL certificate, you need an active subscription at the time of the purchase. You're not required to have an active subscription to use or install the certificate on your server. If you disable the subscription, you won't receive any additional services for the domain or the certificate.
 
-    You will also need a valid, active subscription when you renew the certificate, or if you want to reissue the certificate.
+    You need a valid, active subscription when you renew the certificate or if you want to reissue the certificate.
 
 1.  #### I just want to purchase an SSL certificate, why do I need a subscription?
 
-    As explained in the previous questions, we offer SSL certificate purchases as part of our subscription service.
+    We offer SSL certificate purchases as part of our subscription service.
 
-    An SSL certificate is not a single-time purchase. You need to renew the certificate periodically, sometimes you need to rekey it or you find yourself having issues installing it, and you want to ask for some help. All these tasks are covered by our subscription service.
+    An SSL certificate is not a one-off purchase. You need to renew the certificate periodically. Sometimes you need to rekey it, or may have issues installing it, and need support. All these tasks are covered by our subscription service.
 
-    Additionally, if you are requesting a [Let's Encrypt certificate](/articles/letsencrypt/), we will use our DNS hosting service to automatically provision the DNS records required to validate your certificate, and we will [automatically renew](/articles/letsencrypt/#auto-renewal) the certificate for you before it expires. All these services require a subscription.
+    If you're requesting a [Let's Encrypt certificate](/articles/letsencrypt/), we'll use our DNS hosting service to automatically provision the DNS records required to validate your certificate, and we'll [automatically renew](/articles/letsencrypt/#auto-renewal) the certificate for you before it expires. All these services require a subscription.
 
 1.  #### Will my certificate remain valid after unsubscribing?
 
-    Yes. As explained in the previous questions, you are not required to have an active subscription to use or install the certificate on your server.
+    Yes. You're not required to have an active subscription to use or install the certificate on your server.
 
-    However please note that if you disable the subscription you will not receive any additional service for the domain or the certificate, like expiration warnings or the ability to renew or reissue it.
+    If you disable the subscription, you won't receive any additional service for the domain or the certificate, like expiration warnings or the ability to renew or reissue it.
 
 </div>
 
@@ -56,21 +56,21 @@ categories:
 <div class="section-faq" markdown="1">
 1.  #### Do I need to transfer the domain to DNSimple to purchase an SSL certificate?
 
-    No. You can purchase an SSL certificate for a domain that is not registered with us, without transferring it to us. However you will need to add the domain to your account in order to be able to request the certificate. You also need a valid, active subscription.
+    No. You can purchase an SSL certificate for a domain that is not registered with us without transferring it to us. However, you need to add the domain to your account to request the certificate. You also need a valid, active subscription.
 
-    Just follow the general instruction explained in the [Getting Started](/articles/getting-started-ssl-certificates) guide. When you are asked to add the domain to purchase the certificate, select the option to add a domain without transferring or registering it.
+    Follow the instructions in [Getting Started](/articles/getting-started-ssl-certificates). When you're asked to add the domain to purchase the certificate, select the option to add a domain without transferring or registering it.
 
 1.  #### Do I need to host the domain with DNSimple to purchase an SSL certificate?
 
-    Not for Standard certificates. You can purchase an SSL certificate for a domain that is not hosted with us. However you will need to add the domain to your account in order to be able to request the certificate. You also need a valid, active subscription.
+    Not for Standard certificates. You can purchase an SSL certificate for a domain that is not hosted with us. However, you need to add the domain to your account in order to be able to request the certificate. You also need a valid, active subscription.
 
-    Just follow the general instruction explained in the [Getting Started](/articles/getting-started-ssl-certificates) guide. When you are asked to add the domain to purchase the certificate, select the option to add a domain without transferring or registering it.
+    Follow the instructions in [Getting Started](/articles/getting-started-ssl-certificates). When you are asked to add the domain to purchase the certificate, select the option to add a domain without transferring or registering it.
 
-    If you are getting a free [Let's Encrypt certificate](/articles/letsencrypt) you will need to have the domain hosted with us in order for us to set up the required records for domain-based validation.
+    If you're getting a free [Let's Encrypt certificate](/articles/letsencrypt), you must have the domain hosted with us so we can set up the required records for domain-based validation.
 
 1. #### How do CAA records affect purchasing SSL certificates?
 
-    If you have [CAA Records](/articles/caa-record) already set up, or you wish to use them, you will need to make sure to add the appropriate record for Comodo or Let's Encrypt before you purchase the SSL certificate. Please see [this support document](/articles/caa-record#caa-record-usage) for more details.
+    If you have [CAA Records](/articles/caa-record) already set up, or you want to use them, you need to add the appropriate record for Comodo or Let's Encrypt before you purchase the SSL certificate. Please see [this support document](/articles/caa-record#caa-record-usage) for more details.
 </div>
 
 
@@ -81,13 +81,13 @@ categories:
 
     We provide different types of _domain-validated_ [SSL certificates](/articles/ssl-certificates), signed by globally recognized [certificate authorities](/articles/what-is-certificate-authority). We don't provide _organization-validated_ (OV) or _extended-validation_ (EV) SSL certificates.
 
-    To learn more visit the [SSL Certificates](/articles/ssl-certificates) article.
+    To learn more, visit [SSL Certificates](/articles/ssl-certificates).
 
 1.  #### What certificates show the company name in the green bar near the padlock?
 
-    The green bar in the browser is displayed only if you purchase an _extended-validation_ (EV) certificate. We currently do not sell EV certificates.
+    The green bar in the browser is displayed only if you purchase an _extended-validation_ (EV) certificate. We don't sell EV certificates.
 
-    We currently only sell DV certificates. These are less expensive than EV certificates and offer the same cryptographic level of security. If you still need/want to purchase an EV certificate, we provide some recommendation at [this page](/articles/can-ev-ssl-certificates).
+    We only sell DV certificates. These are less expensive than EV certificates and offer the same cryptographic level of security. If you still need/want to purchase an EV certificate, we provide some recommendations on [this page](/articles/can-ev-ssl-certificates).
 </div>
 
 
@@ -96,9 +96,9 @@ categories:
 <div class="section-faq" markdown="1">
 1.  #### How long does it take to issue an SSL certificate?
 
-    In general, issuing a new SSL certificate can take from a few minutes to a few hours. However, [the time frame depends on many factors](/articles/how-long-to-issue-ssl-certificate).
+    Issuing a new SSL certificate can take anywhere from a few minutes to a few hours. However, [the time frame depends on many factors](/articles/how-long-to-issue-ssl-certificate).
 
 1.  #### Does renewing a certificate update the one I have installed?
 
-    No. After renewing or purchasing a new certificate you will need to install the updated files on your server(s). It is possible to automate this using [webhooks and our api](https://developer.dnsimple.com) but we do not have access to your systems to update your certificates for you.
+    No. After renewing or purchasing a new certificate you need to install the updated files on your server(s). You can automate this using [webhooks and our api](https://developer.dnsimple.com), but we don't have access to your systems to update your certificates for you.
 </div>

--- a/content/articles/faq-ssl-certificates.markdown
+++ b/content/articles/faq-ssl-certificates.markdown
@@ -47,7 +47,7 @@ categories:
 
     Yes. You're not required to have an active subscription to use or install the certificate on your server.
 
-    If you disable the subscription, you won't receive any additional service for the domain or the certificate, like expiration warnings or the ability to renew or reissue it.
+    If you disable the subscription, you won't receive any additional services for the domain or the certificate, like expiration warnings or the ability to renew or reissue it.
 
 </div>
 

--- a/content/articles/faq-ssl-certificates.markdown
+++ b/content/articles/faq-ssl-certificates.markdown
@@ -31,7 +31,7 @@ categories:
 
     Yes. As explained in the previous question, SSL certificates are one of our paid products, provided as part of our subscription service.
 
-    In order to purchase an SSL certificate you need an active subscription at the time of the purchase. You are not required to have an active subscription to use or install the certificate on your domain/server, however please note that if you disable the subscription you will not receive any additional service for the domain or the certificate.
+    In order to purchase an SSL certificate you need an active subscription at the time of the purchase. You are not required to have an active subscription to use or install the certificate on your server, however please note that if you disable the subscription you will not receive any additional service for the domain or the certificate.
 
     You will also need a valid, active subscription when you renew the certificate, or if you want to reissue the certificate.
 
@@ -43,9 +43,9 @@ categories:
 
     Additionally, if you are requesting a [Let's Encrypt certificate](/articles/letsencrypt/), we will use our DNS hosting service to automatically provision the DNS records required to validate your certificate, and we will [automatically renew](/articles/letsencrypt/#auto-renewal) the certificate for you before it expires. All these services require a subscription.
 
-1.  #### I'm unsubscribed/ing my account, will my current certificate keep valid?
+1.  #### Will my certificate remain valid after unsubscribing?
 
-    Yes. As explained in the previous questions, you are not required to have an active subscription to use or install the certificate on your domain/server.
+    Yes. As explained in the previous questions, you are not required to have an active subscription to use or install the certificate on your server.
 
     However please note that if you disable the subscription you will not receive any additional service for the domain or the certificate, like expiration warnings or the ability to renew or reissue it.
 


### PR DESCRIPTION
A customer asked about what happens with his valid certificate when he unsubscribes and I think that can be added to the SSL certificate FAQ

If this make sense, I'll ask @itsalyse for checking the phrasing/wording.

## :mag: QA

- Go to http://127.0.0.1:3000/articles/faq-ssl-certificates/
- Check that the new Question "I’m unsubscribing my account, will my current certificate keep valid?" is there.

## :shipit: Verification

- [ ] Check the update section is deployed https://support.dnsimple.com/articles/faq-ssl-certificates/