### PR TITLE
Creates FAQ structure for Google search results

### DIFF
--- a/Rules
+++ b/Rules
@@ -51,6 +51,7 @@ compile '/**/*.markdown' do
   filter :postprocess
   filter :colorize_syntax, default_colorizer: :rouge
   layout '/default.*'
+  filter :add_structured_data_faq_google
 end
 
 compile '/**/*' do

--- a/Rules
+++ b/Rules
@@ -51,7 +51,7 @@ compile '/**/*.markdown' do
   filter :postprocess
   filter :colorize_syntax, default_colorizer: :rouge
   layout '/default.*'
-  filter :add_structured_data_faq_google
+  filter :add_structured_data
 end
 
 compile '/**/*' do

--- a/content/articles/faq-ssl-certificates.markdown
+++ b/content/articles/faq-ssl-certificates.markdown
@@ -3,6 +3,7 @@ title: SSL Certificates Frequently Asked Questions
 excerpt: A collection of frequently asked questions about the SSL certificates offered by DNSimple.
 categories:
 - SSL Certificates
+structured_data: true
 ---
 
 # SSL Certificate FAQ
@@ -31,7 +32,7 @@ categories:
 
     Yes. SSL certificates are one of our paid products, provided as part of our subscription service.
 
-   To purchase an SSL certificate, you need an active subscription at the time of the purchase. You're not required to have an active subscription to use or install the certificate on your server. If you disable the subscription, you won't receive any additional services for the domain or the certificate.
+    To purchase an SSL certificate, you need an active subscription at the time of the purchase. You're not required to have an active subscription to use or install the certificate on your server. If you disable the subscription, you won't receive any additional services for the domain or the certificate.
 
     You need a valid, active subscription when you renew the certificate or if you want to reissue the certificate.
 

--- a/lib/structured_data.rb
+++ b/lib/structured_data.rb
@@ -9,7 +9,7 @@ require 'erb'
 # See `/articles/faq-ssl-certificates/` for an example.
 class AddStructuredDataFilter < Nanoc::Filter
 
-  identifier :add_structured_data_faq_google
+  identifier :add_structured_data
 
   def run(content, params={})
     if @item[:structured_data]

--- a/lib/structured_data.rb
+++ b/lib/structured_data.rb
@@ -1,0 +1,73 @@
+require 'nokogiri'
+require 'erb'
+
+# This creates a Structured Data FAQ section for google search results
+# https://developers.google.com/search/docs/data-types/faqpage
+#
+# The page needs to be annotated with the attribute `structured_data`
+# and questions and answers formatted with a `.section-faq`.
+# See `/articles/faq-ssl-certificates/` for an example.
+class AddStructuredDataFilter < Nanoc::Filter
+
+  identifier :add_structured_data_faq_google
+
+  def run(content, params={})
+    if @item[:structured_data]
+      doc = Nokogiri::HTML(content)
+      write_faqs(doc, collect_faqs(doc))
+      return doc.to_html
+    end
+    content
+  end
+
+  def write_faqs(doc, faqs)
+    head = doc.at('head')
+    template = ERB.new <<-eos
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        <% faqs.each_with_index do |faq, index| %>
+          {
+            "@type": "Question",
+            "name": "<%= faq[:question] %>",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "<%= faq[:answer] %>"
+            }
+          }
+          <%= index != faqs.size - 1 ? "," : "" %>
+        <% end %>
+      ]
+    }
+    </script>
+    eos
+    head << template.result(binding)
+  end
+
+  def collect_faqs(doc)
+    faqs = []
+    section = doc.css('.section-faq li')
+    section.each do |faq|
+      transform_links(faq)
+      question = faq.css('h4').text
+      answer = faq.css('p').to_html
+      faqs << { question: question, answer: enforce_single_quotes(answer) }
+    end
+    faqs
+  end
+
+  def transform_links(faq)
+    faq.css('a').each do |a|
+      if a['href'].start_with? ("/")
+        a['href'] = "https://support.dnsimple.com#{a['href']}"
+      end
+    end
+  end
+
+  def enforce_single_quotes(string)
+    string.gsub("\"", "'")
+  end
+
+end

--- a/lib/structured_data.rb
+++ b/lib/structured_data.rb
@@ -21,7 +21,6 @@ class AddStructuredDataFilter < Nanoc::Filter
   end
 
   def write_faqs(doc, faqs)
-    head = doc.at('head')
     template = ERB.new <<-eos
     <script type="application/ld+json">
     {
@@ -37,12 +36,13 @@ class AddStructuredDataFilter < Nanoc::Filter
               "text": "<%= faq[:answer] %>"
             }
           }
-          <%= index != faqs.size - 1 ? "," : "" %>
+          <%= add_comma_if_necessary(faqs, index) %>
         <% end %>
       ]
     }
     </script>
     eos
+    head = doc.at('head')
     head << template.result(binding)
   end
 
@@ -68,6 +68,12 @@ class AddStructuredDataFilter < Nanoc::Filter
 
   def enforce_single_quotes(string)
     string.gsub("\"", "'")
+  end
+
+  def add_comma_if_necessary(faqs, index)
+    unless index == faqs.size - 1
+      ","
+    end
   end
 
 end


### PR DESCRIPTION
Related to https://github.com/dnsimple/dnsimple-business/issues/847. This was recommended by our SEO partner.

A structured FAQ page let's google format question and answers in a rich preview:
![](https://developers.google.com/search/docs/data-types/images/faqpage-searchresult.png)

I've created a Nanoc filter for the following reasons:
1. The content for the structured FAQ stays always up to date. We update the article, and it updates the rich preview. No copy paste.
2. We can support more FAQ pages in the future.

# Verification:

1. Open `/articles/faq-ssl-certificates/` and view source code. You should see a `application/ld+json` script block before the closing `</head>` tag.
2. Browse to https://search.google.com/test/rich-results.
3. Select Code and paste the source code for the FAQ SSL certificates page
4. Run the test and verify the test results. You can preview the results as well.