### PR TITLE
Update auto-renewal domain information

### DIFF
--- a/content/articles/auto-renew-only-domains.markdown
+++ b/content/articles/auto-renew-only-domains.markdown
@@ -15,19 +15,4 @@ Auto-renewals are automatically processed by the registrar at any time within th
 
 The best solution is to always have auto-renewal enabled. We notify you 2 months before a domain is auto-renewed, so you have the opportunity to disable auto-renewal if you don't want to keep the domain.
 
-The following TLDs are auto-renewal only:
-
-- [`AC`](https://dnsimple.com/tlds/ac-domains)
-- [`AT`](https://dnsimple.com/tlds/at-domains)
-- [`BE`](https://dnsimple.com/tlds/be-domains)
-- [`CH`](https://dnsimple.com/tlds/ch-domains)
-- [`DE`](https://dnsimple.com/tlds/de-domains)
-- [`FR`](https://dnsimple.com/tlds/fr-domains)
-- [`IO`](https://dnsimple.com/tlds/io-domains)
-- [`IT`](https://dnsimple.com/tlds/it-domains)
-- [`JOBS`](https://dnsimple.com/tlds/jobs-domains)
-- [`JP`](https://dnsimple.com/tlds/jp-domains)
-- [`LI`](https://dnsimple.com/tlds/li-domains)
-- [`NL`](https://dnsimple.com/tlds/nl-domains)
-- [`SH`](https://dnsimple.com/tlds/sh-domains)
-- [`TM`](https://dnsimple.com/tlds/tm-domains)
+For further information, visit the [TLD-specific articles](/categories/domains/). If a domain requires auto-renewal, we will indicate it with a message in the renewal section of the domain, in your DNSimple account page.

--- a/content/articles/auto-renew-only-domains.markdown
+++ b/content/articles/auto-renew-only-domains.markdown
@@ -10,9 +10,9 @@ categories:
 Certain domain names are **auto-renew only** and cannot be renewed manually. For these domains, it's important to have the [auto-renewal feature turned on](/articles/domain-auto-renewal) at least 1 month prior to the expiration date.
 
 <warning>
-Auto-renewals are automatically processed by the registrar at any time within the last 30 days before expiration. Enabling the auto-renew feature a few days or immediately before the expiration date is not enough to ensure the domain will be automatically renewed and **you risk losing your domain**. In most cases, the registrar will also require you to pay an extra fee to recover the domain from deletion.
+Auto-renewals are automatically processed by the registrar within the last 30 days before expiration. Enabling the auto-renew feature on a domain a few days or immediately before the expiration date will not ensure automatic renewal, and **you risk losing your domain**. In most cases, the registrar will also charge an extra fee to recover the domain from deletion.
 </warning>
 
-The best solution is to always have auto-renewal enabled. We notify you 2 months before a domain is auto-renewed, so you have the opportunity to disable auto-renewal if you don't want to keep the domain.
+The best solution is to always have auto-renewal enabled. We notify you 2 months before a domain is auto-renewed, so you can disable auto-renewal if you don't want to keep the domain.
 
-For further information, visit the [TLD-specific articles](/categories/domains/). If a domain requires auto-renewal, we will indicate it with a message in the renewal section of the domain, in your DNSimple account page.
+For more information, visit the [TLD-specific articles](/categories/domains/). If a domain requires auto-renewal, we will alert you with a message on your DNSimple account page in the renewal section of the domain.

--- a/content/articles/domains-ch.markdown
+++ b/content/articles/domains-ch.markdown
@@ -19,6 +19,6 @@ This article explains the requirements and special procedures for .CH domain nam
 
 ### Auto-renewal only {#auto-renewal-required}
 
-This TLD doesn't support manual renewals. In order to successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
+This TLD doesn't support manual renewals. To successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
 
-If auto-renewal is not enabled, the domain will be scheduled for removal immediately after the expiration, and the deactivation will take place by the registrar at any point during this period. It may be possible to recover the domain until the final deletion, but the registry will require the payment of a redemption fee.
+If auto-renewal is not enabled, the domain will be scheduled for removal immediately after the expiration. The registrar can decativate it at any point during this period. It might be possible to recover the domain before final deletion, but the registry will charge a redemption fee.

--- a/content/articles/domains-ch.markdown
+++ b/content/articles/domains-ch.markdown
@@ -1,0 +1,24 @@
+---
+title: .CH Domains
+excerpt: This article explains the requirements and special procedures for .CH domain names.
+categories:
+- Domains
+---
+
+# .CH Domain Names
+
+* TOC
+{:toc}
+
+---
+
+This article explains the requirements and special procedures for .CH domain names.
+
+
+## Renewing
+
+### Auto-renewal only {#auto-renewal-required}
+
+This TLD doesn't support manual renewals. In order to successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
+
+If auto-renewal is not enabled, the domain will be scheduled for removal immediately after the expiration, and the deactivation will take place by the registrar at any point during this period. It may be possible to recover the domain until the final deletion, but the registry will require the payment of a redemption fee.

--- a/content/articles/domains-es.markdown
+++ b/content/articles/domains-es.markdown
@@ -28,6 +28,8 @@ Anyone may register a .ES domain, however you will need to provide additional in
 
 ## Renewing
 
-ES domains do not follow the same renewal procedures as TLDs like .com, .net, and .org. ES domains must have auto-renewal enabled at least 30 days prior to expiration. This is because ES domains do not have a typical redemption period as other popular TLDs mentioned before, they begin the deletion process a few days before expiration.
+### Auto-renewal only {#auto-renewal-required}
 
-If your domain is in this redemption period, it will need to be manually renewed by support for a substantial fee imposed by the registry. As soon as the expiration date happens and it is not renewed, the domain is immediately deleted and made available for registration again.
+This TLD doesn't support manual renewals. In order to successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
+
+If auto-renewal is not enabled, the domain will be scheduled for removal **12 days before the expiration**, and the deactivation will take place by the registrar at any point during this period (even before the expiration date). It may be possible to recover the domain until the final deletion, but the registry will require the payment of a redemption fee.

--- a/content/articles/domains-es.markdown
+++ b/content/articles/domains-es.markdown
@@ -30,6 +30,6 @@ Anyone may register a .ES domain, however you will need to provide additional in
 
 ### Auto-renewal only {#auto-renewal-required}
 
-This TLD doesn't support manual renewals. In order to successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
+This TLD doesn't support manual renewals. To successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
 
-If auto-renewal is not enabled, the domain will be scheduled for removal **12 days before the expiration**, and the deactivation will take place by the registrar at any point during this period (even before the expiration date). It may be possible to recover the domain until the final deletion, but the registry will require the payment of a redemption fee.
+If auto-renewal is not enabled, the domain will be scheduled for removal **12 days before the expiration**. The registrar can decativate it at any point during this period (even before the expiration date). It might be possible to recover the domain before the final deletion, but the registry will charge a redemption fee.

--- a/content/articles/domains-es.markdown
+++ b/content/articles/domains-es.markdown
@@ -32,4 +32,4 @@ Anyone may register a .ES domain, however you will need to provide additional in
 
 This TLD doesn't support manual renewals. To successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
 
-If auto-renewal is not enabled, the domain will be scheduled for removal **12 days before the expiration**. The registrar can decativate it at any point during this period (even before the expiration date). It might be possible to recover the domain before the final deletion, but the registry will charge a redemption fee.
+If auto-renewal is not enabled, the domain will be scheduled for removal **12 days before the expiration**. The registrar can decativate it at any point during this period (even before the expiration date). It might be possible to recover the domain before final deletion, but the registry will charge a redemption fee.

--- a/content/articles/domains-li.markdown
+++ b/content/articles/domains-li.markdown
@@ -5,7 +5,7 @@ categories:
 - Domains
 ---
 
-# .CH Domain Names
+# .LI Domain Names
 
 * TOC
 {:toc}

--- a/content/articles/domains-li.markdown
+++ b/content/articles/domains-li.markdown
@@ -19,6 +19,6 @@ This article explains the requirements and special procedures for .LI domain nam
 
 ### Auto-renewal only {#auto-renewal-required}
 
-This TLD doesn't support manual renewals. In order to successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
+This TLD doesn't support manual renewals. To successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
 
-If auto-renewal is not enabled, the domain will be scheduled for removal immediately after the expiration, and the deactivation will take place by the registrar at any point during this period. It may be possible to recover the domain until the final deletion, but the registry will require the payment of a redemption fee.
+If auto-renewal is not enabled, the domain will be scheduled for removal immediately after the expiration. The registrar can decativate it at any point during this period. It might be possible to recover the domain before final deletion, but the registry will charge a redemption fee.

--- a/content/articles/domains-li.markdown
+++ b/content/articles/domains-li.markdown
@@ -1,0 +1,24 @@
+---
+title: .LI Domains
+excerpt: This article explains the requirements and special procedures for .LI domain names.
+categories:
+- Domains
+---
+
+# .CH Domain Names
+
+* TOC
+{:toc}
+
+---
+
+This article explains the requirements and special procedures for .LI domain names.
+
+
+## Renewing
+
+### Auto-renewal only {#auto-renewal-required}
+
+This TLD doesn't support manual renewals. In order to successfully renew the domain, the [auto-renewal feature](/articles/domain-auto-renewal) must be enabled at least 1 month before the domain will expire, as explained in the ["auto-renew only" article](/articles/auto-renew-only-domains).
+
+If auto-renewal is not enabled, the domain will be scheduled for removal immediately after the expiration, and the deactivation will take place by the registrar at any point during this period. It may be possible to recover the domain until the final deletion, but the registry will require the payment of a redemption fee.


### PR DESCRIPTION
I removed the static list because it tends to get outdated over time. Cutomers should rely on the live info in their account.

For most common TLDs, having a specific page may help. Although as we've seen, this gets stale as well.