### PR TITLE
Adds verification requirement information to changing contact details

### DIFF
--- a/content/articles/changing-whois-contact.markdown
+++ b/content/articles/changing-whois-contact.markdown
@@ -27,6 +27,10 @@ You cannot currently change the Registrant, Administrative, and Technical record
 
 To update the WHOIS information associated with a domain name in DNSimple, simply follow the procedure to [update an existing contact information](/articles/changing-domain-contact/#changing-an-existing-contact-information), or [replace the contact](/articles/changing-domain-contact/#replacing-a-domain-contact) if you want to completely replace the contact details.
 
+<info>
+ICANN, the organization that oversees domain name registrations for most top-level domains, requires validation of your registrant email address whenever your registrant email address or name is changed. Failure to validate your updated registrant email address results in suspension of the domain name after 15 days of non-compliance. You can read more information about this [here](https://support.dnsimple.com/articles/icann-domain-validation/).
+</info>
+
 Upon the successful update of the domain contact, we will automatically update the registry data and the WHOIS record with the new contact information.
 
 

--- a/content/articles/changing-whois-contact.markdown
+++ b/content/articles/changing-whois-contact.markdown
@@ -19,7 +19,7 @@ This article explains how to update the public WHOIS information associated with
 To check the existing public WHOIS record for a domain you can use our [WHOIS tool](https://dnsimple.com/whois).
 
 <info>
-You cannot currently change the Registrant, Administrative, and Technical record separately in our system. When you change the contact of a domain, our system will automatically attempt to update Registrant, Technical and Admin contacts together.
+You cannot change the Registrant, Administrative, and Technical record separately in our system. When you change the contact of a domain, our system will automatically attempt to update Registrant, Technical, and Admin contacts together.
 </info>
 
 
@@ -28,7 +28,7 @@ You cannot currently change the Registrant, Administrative, and Technical record
 To update the WHOIS information associated with a domain name in DNSimple, simply follow the procedure to [update an existing contact information](/articles/changing-domain-contact/#changing-an-existing-contact-information), or [replace the contact](/articles/changing-domain-contact/#replacing-a-domain-contact) if you want to completely replace the contact details.
 
 <info>
-ICANN, the organization that oversees domain name registrations for most top-level domains, requires validation of your registrant email address whenever your registrant email address or name is changed. Failure to validate your updated registrant email address results in suspension of the domain name after 15 days of non-compliance. You can read more information about this [here](https://support.dnsimple.com/articles/icann-domain-validation/).
+ICANN, the organization that oversees domain name registrations for most top-level domains, requires validation of your registrant email address whenever your registrant email address or name is changed. Failure to validate your updated registrant email address results in suspension of the domain name after 15 days of non-compliance. You can read more about this [here](https://support.dnsimple.com/articles/icann-domain-validation/).
 </info>
 
 Upon the successful update of the domain contact, we will automatically update the registry data and the WHOIS record with the new contact information.


### PR DESCRIPTION
Closes #281 

Adds information to the Changing WHOIS contact page that informs users that they must validate their email address upon changing contact information, or risk domain suspension.

### Validation

- [ ] Visit https://support.dnsimple.com/articles/changing-whois-contact/ and ensure the information is displayed.