### PR TITLE
Adds information about GPDR to WHOIS privacy and clarifies ccTLD caveats

### DIFF
--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -141,6 +141,7 @@ While we will send an email reminder when the WHOIS Privacy on a domain is due t
 </div>
 
 ## WHOIS Privacy and GDPR #{gdpr}
+
 For generic TLDs (gTLDs) like .com, .net, and .org, WHOIS privacy is not necessary at this time as it will be redacted through GDPR. This also applies to new TLDs (nTLDs) like .app, .dev, and others.
 
 For country code TLDs (ccTLDs) you will need to look at the policies for the TLD to determine their stance on WHOIS data. With ccTLDs, please research any TLD you plan on using to determine their stance on WHOIS data, and apply WHOIS privacy when it is available as you see fit.

--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -140,7 +140,7 @@ While we will send an email reminder when the WHOIS Privacy on a domain is due t
 
 </div>
 
-## WHOIS Privacy and GDPR #{gdpr}
+## WHOIS Privacy and GDPR {#gdpr}
 
 For generic TLDs (gTLDs) like .com, .net, and .org, WHOIS privacy is not necessary at this time as it will be redacted through GDPR. This also applies to new TLDs (nTLDs) like .app, .dev, and others.
 

--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -139,3 +139,10 @@ While we will send an email reminder when the WHOIS Privacy on a domain is due t
     ![Renew WHOIS Privacy](/files/whoisprivacy-renew-page.png)
 
 </div>
+
+## WHOIS Privacy and GDPR
+For generic TLDs (gTLDs) like .com, .net, and .org, WHOIS privacy is not necessary at this time as it will be redacted through GDPR. This also applies to new TLDs (nTLDs) like .app, .dev, and others.
+
+For country code TLDs (ccTLDs) you will need to look at the policies for the TLD to determine their stance on WHOIS data. With ccTLDs, please research any TLD you plan on using to determine their stance on WHOIS data, and apply WHOIS privacy when it is available as you see fit. 
+
+</div>

--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -140,9 +140,9 @@ While we will send an email reminder when the WHOIS Privacy on a domain is due t
 
 </div>
 
-## WHOIS Privacy and GDPR
+## WHOIS Privacy and GDPR #{gdpr}
 For generic TLDs (gTLDs) like .com, .net, and .org, WHOIS privacy is not necessary at this time as it will be redacted through GDPR. This also applies to new TLDs (nTLDs) like .app, .dev, and others.
 
-For country code TLDs (ccTLDs) you will need to look at the policies for the TLD to determine their stance on WHOIS data. With ccTLDs, please research any TLD you plan on using to determine their stance on WHOIS data, and apply WHOIS privacy when it is available as you see fit. 
+For country code TLDs (ccTLDs) you will need to look at the policies for the TLD to determine their stance on WHOIS data. With ccTLDs, please research any TLD you plan on using to determine their stance on WHOIS data, and apply WHOIS privacy when it is available as you see fit.
 
 </div>


### PR DESCRIPTION
Closes #302 

Adds a heading section on WHOIS and GDPR, clarifying that any gTLDs or nTLDs are covered by GDPR redaction automatically, but ccTLDs are not. It also encourages users to research ccTLD GDPR and WHOIS policies before purchase.

