### PR TITLE
Moving DNSSEC support out of beta

### DIFF
--- a/content/articles/dnssec.markdown
+++ b/content/articles/dnssec.markdown
@@ -8,10 +8,6 @@ categories:
 # DNSSEC
 
 <info>
-This article describes a feature in Public Beta.
-</info>
-
-<info>
 This article describes a feature only available on [newer plans](/articles/new-plans#newer-plans-only).
 </info>
 


### PR DESCRIPTION
Remove the beta designation from the DNSSEC support article.