### PR TITLE
Allow search.json to be used in the Support Widget

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ task :compile => [:clean] do
 
   FileUtils.cp_r 'dist', 'output'
   FileUtils.cp_r '_redirects', 'output'
+  FileUtils.cp_r '_headers', 'output'
 
   if $?.to_i == 0
     puts  "Compilation succeeded"

--- a/_headers
+++ b/_headers
@@ -1,2 +1,3 @@
 /search.json
   Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: OPTIONS, GET

--- a/_headers
+++ b/_headers
@@ -1,3 +1,2 @@
 /search.json
   Access-Control-Allow-Origin: *
-  Access-Control-Allow-Methods: OPTIONS, GET

--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/search.json
+  Access-Control-Allow-Origin: *

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -11,6 +11,7 @@ module Search
           id: item.path,
           title: item.attributes[:title],
           body: strip_html(item.compiled_content),
+          excerpt: item[:excerpt],
         }
       end
     end

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -10,8 +10,8 @@ module Search
         index << {
           id: item.path,
           title: item.attributes[:title],
-          body: strip_html(item.compiled_content),
           excerpt: item[:excerpt],
+          body: item.compiled_content,
         }
       end
     end


### PR DESCRIPTION
There are a couple blockers for the support widget to use AJAX to pull in content from support.dnsimple.com:

- No CORS headers
- HTML is stripped from the content
- No Excerpt

I have resolved each of these items.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1078

## :mag: QA

- Ensure the site builds, specifically `search.json`
- I'm not certain this CORS implementation will work – my research leads me to suggest it will though.

## :shipit: Pre/Post tasks

None

## :shipit: Verification

- [ ] Verify cross origin request works