### PR TITLE
Add categories to search.json

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -11,6 +11,7 @@ module Search
           id: item.path,
           title: item.attributes[:title],
           excerpt: item[:excerpt],
+          categories: item[:categories],
           body: item.compiled_content,
         }
       end


### PR DESCRIPTION
The intent of this PR is to add categories to search.json, originally intended to use on the support widget. 

Belongs to https://github.com/dnsimple/dnsimple-app/issues/13088