### PR TITLE
Moves deprecation warning to be more prominent, fixes example URL

### DIFF
--- a/content/articles/spf-record.markdown
+++ b/content/articles/spf-record.markdown
@@ -15,7 +15,7 @@ categories:
 ---
 
 <note>
-Although the SPF record type is deprecated, it's still supported by DNSimple name servers. In the future we may discontinue serving SPF records, so you should **always** have a TXT record whose content is the same as the record using the SPF type.
+Although the SPF record type is deprecated, it's still supported by DNSimple name servers. We may discontinue serving SPF records in the future, so you should **always** have a TXT record whose content is the same as the record using the SPF type.
 </note>
 
 ## What's an SPF record?
@@ -33,7 +33,7 @@ SPF records are defined as a single string of text. Here's an example record:
 v=spf1 a mx ip4:69.64.153.131 include:_spf.google.com ~all
 ```
 
-The SPF record always starts with the `v=` element. This indicates the SPF version that is used. Right now the version should always be `spf1` as this is the most common version of SPF that is understood by mail exchanges.
+The SPF record always starts with the `v=` element. This indicates the SPF version that is used. Right now, the version should always be `spf1` as this is the most common version of SPF that is understood by mail exchanges.
 
 One or more terms follow the version indicator. These define the rules for which hosts are allowed to send mail from the domain, or provide additional information for processing the SPF record. Terms are made up of mechanisms and modifiers. The following mechanisms are defined:
 
@@ -57,7 +57,7 @@ There are two modifiers defined:
 
 ## SPF mechanisms
 
-The following mechanisms define what IP addresses are allowed to send mail from the domain:
+The following mechanisms define which IP addresses are allowed to send mail from the domain:
 
 - `a`
 - `mx`

--- a/content/articles/spf-record.markdown
+++ b/content/articles/spf-record.markdown
@@ -14,6 +14,10 @@ categories:
 
 ---
 
+<note>
+Although the SPF record type is deprecated, it's still supported by DNSimple name servers. In the future we may discontinue serving SPF records, so you should **always** have a TXT record whose content is the same as the record using the SPF type.
+</note>
+
 ## What's an SPF record?
 
 An SPF record is a Sender Policy Framework record. It's used to indicate to mail exchanges which hosts are authorized to send mail for a domain. It's defined in [RFC 4408](https://www.ietf.org/rfc/rfc4408.txt), and clarified by [RFC 7208](https://www.ietf.org/rfc/rfc7208.txt).
@@ -92,10 +96,6 @@ Note that we currently do not support modifiers in our SPF editing UI, but you m
 
 **Each fully-qualified name may have at maximum one SPF record**, defined as a TXT record or as an SPF record type.
 
-<note>
-Although the SPF record type is deprecated, it's still supported by DNSimple name servers. In the future we may discontinue serving SPF records, so you should always have a TXT record whose content is the same as the record using the SPF type.
-</note>
-
 There are various limitations on the number of items and lookups permitted in an SPF record:
 
 - SPF records may not have more than 10 mechanisms that require DNS lookups. These are the `include`, `a`, `mx`, `ptr`, and `exists` mechanisms.
@@ -107,6 +107,6 @@ There are various limitations on the number of items and lookups permitted in an
 
 Since you may only have one SPF record per fully-qualified name, if you need to add additional modifiers you should add them to your existing SPF record if it's present.
 
-SPF records are most often specified on your naked domain name. If you need to exceed the number of modifiers allowed in a single SPF record, you may need to send some of your messages from subdomains below your naked domain. For example, if a third-party SaaS sends mail on your behalf, you may need to send email from `something.yourdomain.com` for that provider. This is especially true if you have multiple SaaS providers that send email on your behalf.
+SPF records are most often specified on your naked domain name. If you need to exceed the number of modifiers allowed in a single SPF record, you may need to send some of your messages from subdomains below your naked domain. For example, if a third-party SaaS sends mail on your behalf, you may need to send email from `something.example.com` for that provider. This is especially true if you have multiple SaaS providers that send email on your behalf.
 
 If you want to test your SPF records for compliance with the RFCs, you may want to use [an online SPF testing tool](https://www.kitterman.com/spf/validate.html).


### PR DESCRIPTION
This fixes two aspects of the article:

1. Makes the information box about the SPF record deprecation more prominent, and more strongly suggests always having a TXT record.
2. Fixes `yourdomain.com` to `example.com` for consistency. 