### PR TITLE
Add default styling to tables

### DIFF
--- a/content/articles/a-record.markdown
+++ b/content/articles/a-record.markdown
@@ -33,6 +33,7 @@ The DNS A record is specified by [RFC 1035](https://tools.ietf.org/html/rfc1035)
 
 The structure of an A record follows the standard top-level format definition defined [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.2.1). The RDATA section is composed of one single element:
 
+| Element | Description |
 |:--------|:-------------------------------------------------------|
 | address | A 32 bit Internet address representing an IPv4 address |
 
@@ -48,6 +49,7 @@ where `<address>` is an IPv4 address and looks like `162.159.24.4`.
 
 In DNSimple, the A record is represented by the following customizable elements:
 
+| Element | Description |
 |:--------|:-------------------------------------------------------------------------------------------------------------------------------------------|
 | Name    | The host name for the record, without the domain name. This is generally referred to as "subdomain". We automatically append the domain name. |
 | TTL     | The time-to-live in seconds. This is the amount of time the record is allowed to be cached by a resolver.                                  |

--- a/content/articles/aaaa-record.markdown
+++ b/content/articles/aaaa-record.markdown
@@ -31,6 +31,7 @@ The DNS A record is specified by [RFC 3596](https://tools.ietf.org/html/rfc3596)
 
 The structure of an AAAA record follows the standard top-level format definition defined [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.2.1). The RDATA section is composed of one single element:
 
+| Element | Description |
 |:--------|:--------------------------------------------------------|
 | address | A 128 bit Internet address representing an IPv6 address |
 
@@ -46,6 +47,7 @@ where `<address>` is an IPv6 address and looks like `2400:cb00:2049:1::a29f:1804
 
 In DNSimple, the AAAA record is represented by the following customizable elements:
 
+| Element | Description |
 |:--------|:-------------------------------------------------------------------------------------------------------------------------------------------|
 | Name    | The host name for the record without the domain name. This is generally referred to as "subdomain". We automatically append the domain name. |
 | TTL     | The time-to-live in seconds. This is the amount of time the record is allowed to be cached by a resolver.                                  |

--- a/content/articles/caa-record.markdown
+++ b/content/articles/caa-record.markdown
@@ -29,6 +29,7 @@ The DNS CAA record is specified by [RFC 6844](https://tools.ietf.org/html/rfc684
 
 The structure of a CAA record follows the standard top-level format definition defined [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.2.1). The RDATA section is composed of the following elements:
 
+| Element | Description |
 |:------|:---------------------------------------------------------------------------------------------------------------------------------------------|
 | flag  | An unsigned integer between 0-255.                                                                                                           |
 |       | It is currently used to represent the _critical_ flag, that has a specific meaning per [RFC](https://tools.ietf.org/html/rfc6844#section-3). |
@@ -51,6 +52,7 @@ The RFC currently defines 3 available tags:
 
 In DNSimple, the CAA record is represented by the following customizable elements:
 
+| Element | Description |
 |:------|:-------------------------------------------------------------------------------------------------------------------------------------------|
 | Name  | The host name for the record, without the domain name. This is generally referred to as "subdomain". We automatically append the domain name. |
 | TTL   | The time-to-live in seconds. This is the amount of time the record is allowed to be cached by a resolver.                                  |

--- a/content/articles/cname-record.markdown
+++ b/content/articles/cname-record.markdown
@@ -43,6 +43,7 @@ The DNS A record is specified by [RFC 1035](https://tools.ietf.org/html/rfc1035)
 
 The structure of an A record follows the standard top-level format definition defined [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.2.1). The RDATA section is composed of one single element:
 
+| Element | Description |
 |:------------|:----------------------------------------------------------------------------|
 | domain-name | A domain name which specifies the canonical or primary name for the record. |
 
@@ -56,6 +57,7 @@ where `<domain-name>` is a fully-qualified domain name such as `example.com`.
 
 In DNSimple, the CNAME record is represented by the following customizable elements:
 
+| Element | Description |
 |:--------|:-------------------------------------------------------------------------------------------------------------------------------------------|
 | Name    | The host name for the record, without the domain name. This is generally referred to as "subdomain". We automatically append the domain name. |
 | TTL     | The time-to-live in seconds. This is the amount of time the record is allowed to be cached by a resolver.                                  |

--- a/content/articles/url-record.markdown
+++ b/content/articles/url-record.markdown
@@ -29,6 +29,7 @@ The URL record is a special record, and it's not defined by any RFC.
 
 In DNSimple, the URL record is represented by the following customizable elements:
 
+| Element | Description |
 |:--------|:-------------------------------------------------------------------------------------------------------------------------------------------|
 | name    | The host name for the record without the domain name. This is generally referred to as "subdomain". We automatically append the domain name. |
 | TTL     | The time-to-live in seconds. This is the amount of time the record is allowed to be cached by a resolver.                                  |

--- a/content/assets/css/_tables.scss
+++ b/content/assets/css/_tables.scss
@@ -1,4 +1,4 @@
-table {
+main table {
     background: $white;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.15);
     border-radius: 3px;

--- a/content/assets/css/_tables.scss
+++ b/content/assets/css/_tables.scss
@@ -1,0 +1,21 @@
+table {
+    background: $white;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.15);
+    border-radius: 3px;
+    width: 100%;
+    border-collapse: collapse;
+
+    th, td {
+        padding: 0.6rem 1.2rem;
+    }
+
+    th {
+        border-bottom: 2px solid $yellow;
+        font-weight: bold;
+        background: $white;
+    }
+
+    tr:nth-child(2n + 1) {
+        background-color: #f1f1f1;
+    }
+}

--- a/content/assets/css/_typography.scss
+++ b/content/assets/css/_typography.scss
@@ -48,7 +48,7 @@ h5 {
 }
 
 
-p, pre {
+p, pre, table {
   margin: 0 0 $base-unit/1.5 0;
 }
 

--- a/content/assets/css/style.scss
+++ b/content/assets/css/style.scss
@@ -11,3 +11,4 @@
 @import "template";
 @import "application";
 @import "resolving";
+@import "tables";


### PR DESCRIPTION
This PR adds default table styling to match our dashboard:

![image](https://user-images.githubusercontent.com/900449/89535760-3d9a2080-d7cd-11ea-9264-169c5119e02b.png)

I also added headers to the tables on the following pages:

- http://localhost:3000/articles/a-record/
- http://localhost:3000/articles/aaaa-record/
- http://localhost:3000/articles/caa-record/
- http://localhost:3000/articles/cname-record/
- http://localhost:3000/articles/common-dns-records/
- http://localhost:3000/articles/letsencrypt/
- http://localhost:3000/articles/standard-vs-letsencrypt/
- http://localhost:3000/articles/txt-record/
- http://localhost:3000/articles/url-record/

Fixes https://github.com/dnsimple/dnsimple-support/issues/603