### PR TITLE
Add links to headlines

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -81,7 +81,7 @@
   <script type="text/javascript">
     document
       .getElementById('main')
-      .querySelectorAll('h2, h3, h4, h5, h6')
+      .querySelectorAll('h2, h3')
       .forEach(function (heading) {
         if (heading.id === 'toc') return;
         const link = document.createElement('a');

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -87,7 +87,7 @@
         const link = document.createElement('a');
         link.setAttribute('href', '#' + heading.id);
         link.className = 'f7 o-80 no-underline dib w2 ml1 ml0-ns nl4-ns fr fn-ns v-mid';
-        link.innerHTML = '🔗';
+        link.innerHTML = '📎';
         heading.prepend(link);
       });
   </script>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -78,5 +78,19 @@
     </div>
   </footer>
 
+  <script type="text/javascript">
+    document
+      .getElementById('main')
+      .querySelectorAll('h2, h3, h4, h5, h6')
+      .forEach(function (heading) {
+        if (heading.id === 'toc') return;
+        const link = document.createElement('a');
+        link.setAttribute('href', '#' + heading.id);
+        link.className = 'f7 o-80 no-underline dib w2 ml1 ml0-ns nl4-ns fr fn-ns v-mid';
+        link.innerHTML = '🔗';
+        heading.prepend(link);
+      });
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
This PR adds a link button to headlines. This makes it easier to share links to specific sections of a support article!

![anchor](https://user-images.githubusercontent.com/900449/90065534-cf6cc680-dcc2-11ea-8301-9a921d26826d.png)

## QA

- Check mobile styling
- Check desktop styling