### PR TITLE
Add note about how issuewild takes precedence over issue

### DIFF
--- a/content/articles/caa-record.markdown
+++ b/content/articles/caa-record.markdown
@@ -50,7 +50,7 @@ The RFC currently defines three available tags:
 - `issuewild`: explicitly authorizes a single certificate authority to issue a wildcard certificate (and only wildcard) for the hostname.
 - `iodef`: specifies a URL to which a certificate authority may report policy violations.
 
-Please, note that `issuewild` tags take precedence over `issue` tags when specified. This means that, once there is one CAA record with the `issuewild` tag in place, regardless of its value, wildcard certificate requests will be rejected unless there's a specific CAA record with the `issuewild` tag for that CA and the requested hostname.
+Please note that `issuewild` tags take precedence over `issue` tags when specified. This means that once there is one CAA record with the `issuewild` tag in place regardless of its value, wildcard certificate requests will be rejected unless there's a specific CAA record with the `issuewild` tag for that CA and the requested hostname.
 
 In DNSimple, the CAA record is represented by the following customizable elements:
 

--- a/content/articles/caa-record.markdown
+++ b/content/articles/caa-record.markdown
@@ -50,7 +50,7 @@ The RFC currently defines three available tags:
 - `issuewild`: explicitly authorizes a single certificate authority to issue a wildcard certificate (and only wildcard) for the hostname.
 - `iodef`: specifies a URL to which a certificate authority may report policy violations.
 
-Please note that `issuewild` tags take precedence over `issue` tags when specified. This means that once there is one CAA record with the `issuewild` tag in place regardless of its value, wildcard certificate requests will be rejected unless there's a specific CAA record with the `issuewild` tag for that CA and the requested hostname.
+`issuewild` tags take precedence over `issue` tags when specified. Once there's one CAA record with the `issuewild` tag in place, regardless of its value, wildcard certificate requests will be rejected unless there's a specific CAA record with the `issuewild` tag for that CA and the requested hostname.
 
 In DNSimple, the CAA record is represented by the following customizable elements:
 

--- a/content/articles/caa-record.markdown
+++ b/content/articles/caa-record.markdown
@@ -50,6 +50,8 @@ The RFC currently defines three available tags:
 - `issuewild`: explicitly authorizes a single certificate authority to issue a wildcard certificate (and only wildcard) for the hostname.
 - `iodef`: specifies a URL to which a certificate authority may report policy violations.
 
+Please, note that `issuewild` tags take precedence over `issue` tags when specified. This means that, once there is one CAA record with the `issuewild` tag in place, regardless of its value, wildcard certificate requests will be rejected unless there's a specific CAA record with the `issuewild` tag for that CA and the requested hostname.
+
 In DNSimple, the CAA record is represented by the following customizable elements:
 
 | Element | Description |


### PR DESCRIPTION
Hopefully, this will prevent customer support requests due to the way that having one issuewild CAA record forces users to create issuewild records for every other cert provider that they would want to get wildcard certs from.