### PR TITLE
No more multi-year certificates

### DIFF
--- a/content/articles/can-multi-year-ssl-certificates.markdown
+++ b/content/articles/can-multi-year-ssl-certificates.markdown
@@ -7,6 +7,6 @@ categories:
 
 # Can I purchase an SSL certificate for more than one year?
 
-Since August 14, 2020, it's no longer possible to purchase certificates for a period longer than one year. [As explained in this article](https://blog.dnsimple.com/2020/08/ssl-certificates-1-year/), with the ballot SC31 the CA/B forum has effectively prohibited Certificate Authorities to issues certificates valid for more than 397 days, with effective date September 1, 2020.
+As of August 14, 2020, it's no longer possible to purchase certificates for a period of longer than one year. [As explained in this article](https://blog.dnsimple.com/2020/08/ssl-certificates-1-year/), with ballot SC31, the CA/B forum has effectively prohibited Certificate Authorities from issuing certificates that are valid for longer than 397 days, effective September 1, 2020.
 
-Please note that this is an industry-standard requirement, and applies to any certificate authority or reseller, and not just to DNSimple.
+This is an industry-standard requirement. It applies to any Certificate Authority or reseller, and not just to DNSimple.

--- a/content/articles/can-multi-year-ssl-certificates.markdown
+++ b/content/articles/can-multi-year-ssl-certificates.markdown
@@ -7,16 +7,6 @@ categories:
 
 # Can I purchase an SSL certificate for more than one year?
 
-<info>
-This article describes a feature that is only available to the [new plans](/articles/new-plans#newer-plans-only).
-</info>
+Since August 14, 2020, it's no longer possible to purchase certificates for a period longer than one year. [As explained in this article](https://blog.dnsimple.com/2020/08/ssl-certificates-1-year/), with the ballot SC31 the CA/B forum has effectively prohibited Certificate Authorities to issues certificates valid for more than 397 days, with effective date September 1, 2020.
 
-Yes – you can purchase a multi-year SSL certificate from now **until August 13, 2020 23:59 UTC** (see below for upcoming changes). You can select the number of years when [purchasing](/articles/ordering-standard-certificate) or [renewing](/articles/renewing-ssl-certificate) the SSL certificate.
-
-If you order a certificate for more than one year, the final price will be the certificate price multiplied by the number of years.
-
-## Important information about certificate lifetime
-
-- We don't allow the purchase of a certificate for more than two years (as [enforced by the CA/B forum](https://cabforum.org/2017/03/17/ballot-193-825-day-certificate-lifetimes/)).
-- We will allow you to purchase two-year certificates **until August 13, 2020 23:59 UTC**.
-- From August 14, 2020, to comply with the new industry standard requirements, we will no longer support the purchase or renewal of SSL certificates for a period longer than one year. You can [read more on our blog](https://blog.dnsimple.com/2020/08/ssl-certificates-1-year/).
+Please note that this is an industry-standard requirement, and applies to any certificate authority or reseller, and not just to DNSimple.

--- a/content/articles/letsencrypt.markdown
+++ b/content/articles/letsencrypt.markdown
@@ -55,7 +55,7 @@ Let's Encrypt is different from most traditional certificate authorities. Here a
 - Let's Encrypt only issues [domain-validated](/articles/ssl-certificates-types/) SSL certificates. There's no plan to support <acronym title="Organization Validated">OV</acronym> or <acronym title="Extended Validation">EV</acronym> certificates.
 - Let's Encrypt supports both single-name and wildcard names.
 - A single Let's Encrypt certificate can include up to 100 SAN names. Names can be single-name, wildcard names, or both.
-- Let's Encrypt certificates have a fixed expiration period of 90 days. It's not possible to request a certificate with a longer expiration, so it's not possible to obtain 1-year or [multi-year](/articles/can-multi-year-ssl-certificates) SSL certificates.
+- Let's Encrypt certificates have a fixed expiration period of 90 days. It's not possible to request a certificate with a longer expiration, whereas most CAs will issue certificates valid for up to 1 year.
 - Although Let's Encrypt is a new authority, their SSL certificates are [compatible with major browsers](https://letsencrypt.org/docs/certificate-compatibility/) and [trusted by all major root programs](https://letsencrypt.org/2018/08/06/trusted-by-all-major-root-programs.html).
 - Let's Encrypt certificates are domain-validated. The most common validation mechanisms are DNS-based and HTTP-based. They don't support traditional [email-based validation](/articles/ssl-certificates-email-validation).
 - Let's Encrypt [rate-limits](https://letsencrypt.org/docs/rate-limits/) requests. Make sure you understand their limits before requesting a large number of certificates.

--- a/content/articles/letsencrypt.markdown
+++ b/content/articles/letsencrypt.markdown
@@ -55,7 +55,7 @@ Let's Encrypt is different from most traditional certificate authorities. Here a
 - Let's Encrypt only issues [domain-validated](/articles/ssl-certificates-types/) SSL certificates. There's no plan to support <acronym title="Organization Validated">OV</acronym> or <acronym title="Extended Validation">EV</acronym> certificates.
 - Let's Encrypt supports both single-name and wildcard names.
 - A single Let's Encrypt certificate can include up to 100 SAN names. Names can be single-name, wildcard names, or both.
-- Let's Encrypt certificates have a fixed expiration period of 90 days. It's not possible to request a certificate with a longer expiration, whereas most CAs will issue certificates valid for up to 1 year.
+- Let's Encrypt certificates have a fixed expiration period of 90 days. It's not possible to request a certificate with a longer expiration, though most other CAs will issue certificates valid for up to 1 year.
 - Although Let's Encrypt is a new authority, their SSL certificates are [compatible with major browsers](https://letsencrypt.org/docs/certificate-compatibility/) and [trusted by all major root programs](https://letsencrypt.org/2018/08/06/trusted-by-all-major-root-programs.html).
 - Let's Encrypt certificates are domain-validated. The most common validation mechanisms are DNS-based and HTTP-based. They don't support traditional [email-based validation](/articles/ssl-certificates-email-validation).
 - Let's Encrypt [rate-limits](https://letsencrypt.org/docs/rate-limits/) requests. Make sure you understand their limits before requesting a large number of certificates.

--- a/content/articles/ordering-standard-certificate.markdown
+++ b/content/articles/ordering-standard-certificate.markdown
@@ -56,9 +56,8 @@ The order is the first step into getting an SSL certificate. It will create an S
     1.  [Read this article](/articles/ssl-certificate-names) to determine the appropriate host name of your SSL certificate.
     1.  Enter the certificate common name. Use an `*` to order a wildcard certificate.
     1.  Select a Contact from your contact list. The contact information will be used to generate the certificate request (CSR).
-    1.  Change the number of years if you want to purchase a certificate for more than 1 year. The [multi-year SSL certificate](/articles/can-multi-year-ssl-certificates) feature is only available to new plans.
-    1.  Leave the CSR option unchecked, unless you really need to provide a [custom CSR](/articles/what-is-csr). The easiest thing to do is to have us automatically generate the CSR (and a new private key to go with it). Make sure to read our [private key policy](https://dnsimple.com/private-key-policy).
-    1.  Submit the order.
+    2.  Leave the CSR option unchecked, unless you really need to provide a [custom CSR](/articles/what-is-csr). The easiest thing to do is to have us automatically generate the CSR (and a new private key to go with it). Make sure to read our [private key policy](https://dnsimple.com/private-key-policy).
+    3.  Submit the order.
 
     ![Purchase a Certificate](/files/dnsimple-certificate-purchase.png)
 

--- a/content/articles/renewing-standard-ssl-certificate.markdown
+++ b/content/articles/renewing-standard-ssl-certificate.markdown
@@ -34,7 +34,6 @@ These are the steps to renew your standard certificate:
 1.  Follow the instructions to purchase the certificate renewal.
 
     1.  Check the certificate [common name](/articles/what-is-common-name) matches the one you want to renew.
-    1.  Change the number of years if you want to purchase a certificate for more than 1 year. **The [multi-year SSL certificate](/articles/can-multi-year-ssl-certificates) feature is only available to new plans.**
     1.  Leave the CSR option unchecked, unless you really need to provide a [custom CSR](/articles/what-is-csr). The easiest thing to do is to have us automatically generate the CSR (and a new private key to go with it).
     1.  Submit the order.
 

--- a/content/articles/standard-vs-letsencrypt.markdown
+++ b/content/articles/standard-vs-letsencrypt.markdown
@@ -28,7 +28,7 @@ The table only reflects the status of the current DNSimple offering. Some featur
 
 |               | Let's Encrypt | Standard      |
 |---------------+---------------+---------------|
-Certificate Expiration | 90 days | Multi-year
+Certificate Expiration | 90 days | 1 year
 Single names | Supported | Supported
 Custom names | Supported (on certain plans) | Supported
 Wildcard names | Supported (on certain plans) | Supported
@@ -48,7 +48,7 @@ You want to secure a domain name. | **Let's Encrypt** or **Standard**
 You want to provide a custom CSR | **Standard**
 You want to use a custom private key. | **Standard**
 You want to use a wildcard name. | **Let's Encrypt** or **Standard**
-You want a longer multi-year expiration. | **Standard**
+You want a longer expiration. | **Standard**
 You want to fully automate SSL certificate orders without manual intervention. | **Let's Encrypt**
 Your domain is resolving with DNSimple. | **Let's Encrypt** or **Standard**
 Your domain is NOT resolving with DNSimple. | **Standard**


### PR DESCRIPTION
Remove or update references to multi-year SSL certificates. The maximum allowed validity is now 1 year.

I've search through the docs and I believe I updated all the references. A second eye would definitely be useful to make sure I did not miss anything.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1139