### PR TITLE
Fixes duplicate warning about secondary DNS

### DIFF
--- a/content/articles/secondary-dns.markdown
+++ b/content/articles/secondary-dns.markdown
@@ -7,10 +7,6 @@ categories:
 
 # Secondary DNS
 
-<warning>
-  You cannot set up Secondary DNS if you have [DNSSEC](/articles/dnssec) enabled, as they will not work in conjunction. Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS.
-</warning>
-
 ### Table of Contents {#toc}
 
 * TOC


### PR DESCRIPTION
Closes #641 

Removes an accidentally duplicated warning in this article.