### PR TITLE
Updates with a warning that wildcard certificates do not cover root

### DIFF
--- a/content/articles/ordering-wildcard-certificate.markdown
+++ b/content/articles/ordering-wildcard-certificate.markdown
@@ -28,7 +28,7 @@ wildcard
 ```
 
 <warning>
-When ordering a wildcard SSL certificate, the wildcard (*) will _only_ secure subdomains. A wildcard certificate cannot secure the root (such as example.com). If you want to secure both the root domain and subdomains, you will also need to [order an additional certificate](articles/getting-started-ssl-certificates/).
+When ordering a wildcard SSL certificate, the wildcard (*) will _only_ secure subdomains. A wildcard certificate cannot secure the root (such as example.com). If you want to secure both the root domain and subdomains, you will need to [order an additional certificate](articles/getting-started-ssl-certificates/).
 </warning>
 
 ## Let's Encrypt or Standard

--- a/content/articles/ordering-wildcard-certificate.markdown
+++ b/content/articles/ordering-wildcard-certificate.markdown
@@ -28,7 +28,7 @@ wildcard
 ```
 
 <warning>
-When ordering a wildcard SSL certificate, the wildcard (*) will _only_ secure subdomains. A wildcard certificate cannot secure the root (such as example.com). If you want to secure both the root domain and subdomains, you will also need to [order an additional certificate](articles/getting-started-ssl-certificates/) to do so.
+When ordering a wildcard SSL certificate, the wildcard (*) will _only_ secure subdomains. A wildcard certificate cannot secure the root (such as example.com). If you want to secure both the root domain and subdomains, you will also need to [order an additional certificate](articles/getting-started-ssl-certificates/).
 </warning>
 
 ## Let's Encrypt or Standard

--- a/content/articles/ordering-wildcard-certificate.markdown
+++ b/content/articles/ordering-wildcard-certificate.markdown
@@ -28,7 +28,7 @@ wildcard
 ```
 
 <warning>
-When ordering a wildcard SSL certificate, the wildcard (*) will _only_ secure subdomains. A wildcard certificate cannot secure the root (such as example.com). If you want to secure both the root domain and subdomains, you will need to [order an additional certificate](articles/getting-started-ssl-certificates/).
+When ordering a Let's Encrypt wildcard SSL certificate, the wildcard (*) will _only_ secure subdomains. A wildcard certificate cannot secure the root (such as example.com). If you want to secure both the root domain and subdomains with Let's Encrypt, you will need to [order an additional certificate](articles/getting-started-ssl-certificates/).
 </warning>
 
 ## Let's Encrypt or Standard

--- a/content/articles/ordering-wildcard-certificate.markdown
+++ b/content/articles/ordering-wildcard-certificate.markdown
@@ -27,6 +27,10 @@ Wildcard certificates are no different from single name certificates. They conta
 wildcard
 ```
 
+<warning>
+When ordering a wildcard SSL certificate, the wildcard (*) will _only_ secure subdomains. A wildcard certificate cannot secure the root (such as example.com). If you want to secure both the root domain and subdomains, you will also need to [order an additional certificate](articles/getting-started-ssl-certificates/) to do so.
+</warning>
+
 ## Let's Encrypt or Standard
 
 Both providers support wildcard certificates. Let's Encrypt certificates are free, but are only valid for a short period. Comodo certificates are valid for much longer, but also come with a cost per wildcard certificate.


### PR DESCRIPTION
Closes #620 

Updates the article with a clear warning that a wildcard certificate will not cover the domain apex, and if a user wishes to secure both the apex and subdomains, they will need an additional certificate. 