### PR TITLE
Put title for DNSSEC/Secondary in correct place

### DIFF
--- a/content/articles/dnssec-and-secondary-dns.markdown
+++ b/content/articles/dnssec-and-secondary-dns.markdown
@@ -5,16 +5,7 @@ categories:
 - DNS
 ---
 
-### Table of Contents {#toc}
-
-* TOC
-{:toc}
-
----
-
-## Why won't DNSSEC and Secondary DNS work together?
-
-Here is why DNSSEC and secondary DNS may not work together:
+# Why DNSSEC and Secondary DNS may not work together
 
 All authoritative name servers MUST sign all record sets with all private keys that are Zone Signing Key (ZSK) type. This is necessary because a resolver could get the ZSK from one authoritative name server and the RRSIG from another authoritative name server. To include the RRSIG for all ZSK DNSKEYs, the authoritative name servers must have all private key material. We currently do not share private key material, and even if we did, AXFR does not support transferring private key material and thus key rotations would have to be done manually in a coordinated fashion.
 


### PR DESCRIPTION
The layout is broken because there is no `h1` tag.