### PR TITLE
Updates dictionary to match annual to yearly

### DIFF
--- a/templates/dictionary.json.erb
+++ b/templates/dictionary.json.erb
@@ -10,8 +10,7 @@
   "letsencrypt": "lets encrypt",
   "membership": "share management",
   "team": "member",
-  "two": "2fa",
-  "annual": "yearly"
-  "remove": "deleting"
+  "annual": "yearly",
+  "remove": "deleting",
   "delete": "deleting"
 }

--- a/templates/dictionary.json.erb
+++ b/templates/dictionary.json.erb
@@ -12,4 +12,6 @@
   "team": "member",
   "two": "2fa",
   "annual": "yearly"
+  "remove": "deleting"
+  "delete": "deleting"
 }

--- a/templates/dictionary.json.erb
+++ b/templates/dictionary.json.erb
@@ -10,5 +10,6 @@
   "letsencrypt": "lets encrypt",
   "membership": "share management",
   "team": "member",
-  "two": "2fa"
+  "two": "2fa",
+  "annual": "yearly"
 }


### PR DESCRIPTION
Fixes #662 

A small dictionary update. Updates the search on the support site to have matching for matching annual -> yearly. This change will affect both the support website, and the support widget in the app.

Expected outcome: when searching with the world "annual", "yearly billing" will appear in the search. This can be verified by checking out this branch, and running `yarn live` . Alternatively, you can visit https://deploy-preview-663--dnsimple-support.netlify.app/