### PR TITLE
Updates WHOIS privacy to mention no auto-renew

### DIFF
--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -123,6 +123,8 @@ Once you disable the WHOIS Privacy protection, the contact details of your domai
 
 ## Renew WHOIS Privacy {#renew}
 
+<info> There currently is no auto-renewal for WHOIS Privacy. It must be renewed manually. </info> 
+
 While we will send an email reminder when the WHOIS Privacy on a domain is due to expire, it's possible to renew it manually before that notice is sent:
 
 <div class="section-steps" markdown="1">

--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -19,7 +19,7 @@ The [WHOIS Privacy protection service](/articles/what-is-whois-privacy) keeps yo
 You can purchase WHOIS Privacy protection for any of your domains any time, as long as the domain is registered with us and the TLD (Top Level Domain) supports the WHOIS Privacy service. You can check if a TLD supports WHOIS Privacy from the [list of supported TLDs](https://dnsimple.com/tlds).
 
 <info>
-For [new plans](/articles/new-plans), the price for the WHOIS Privacy service starts at **$3/year per domain**, and is based on the currently subscribed plan. For all [legacy plans](/articles/new-plans/#newer-plans-vs-legacy-plans), the price hasn't changed, and is $8/year per domain.
+For [current plans](/articles/new-plans), the price for the WHOIS Privacy service starts at **$3/year per domain**, and is based on the currently subscribed plan. For all [legacy plans](/articles/new-plans/#newer-plans-vs-legacy-plans), the price hasn't changed, and is $8/year per domain.
 </info>
 
 
@@ -62,13 +62,13 @@ When you enable the service for the first time, a service cost will be charged t
 
     ![WHOIS Privacy card](/files/whoisprivacy-domain-card-disabled.png)
 
-1.  Click on the <label>Turn WHOIS Privacy on</label> button. You will be taken to a confirmation page.
+1.  Click on the <label>Turn WHOIS Privacy on</label> button. This takes you to a confirmation page.
 
 1.  To enable the WHOIS Privacy service, click on the <label>Enable WHOIS Privacy</label> button.
 
     ![Enable WHOIS Privacy](/files/whoisprivacy-enable-page.png)
 
-    If this is the first time you are enabling the service for this domain, you will need to purchase the service. The page will provide you with the purchase information. Click on <label>Purchase WHOIS Privacy</label> to immediately purchase and enable the WHOIS Privacy service for the domain.
+    If this is the first time you're enabling the service for this domain, you'll need to purchase the service. The page will provide you with the purchase information. Click on <label>Purchase WHOIS Privacy</label> to immediately purchase and enable the WHOIS Privacy service for the domain.
 
     ![Purchase WHOIS Privacy](/files/whoisprivacy-purchase-page.png)
 
@@ -93,7 +93,7 @@ Once you disable the WHOIS Privacy protection, the contact details of your domai
 
     ![Whois privacy in domain list](/files/whoisprivacy-domain-list.png)
 
-1.  Click on the right arrow icon to open the domain feature menu, and click <label>Disable WHOIS Privacy</label>. You will be taken to a confirmation page.
+1.  Click on the right arrow icon to open the domain feature menu, and click <label>Disable WHOIS Privacy</label>. This takes you to a confirmation page.
 
     ![Disable WHOIS Privacy](/files/whoisprivacy-domain-list-disable.png)
 
@@ -113,7 +113,7 @@ Once you disable the WHOIS Privacy protection, the contact details of your domai
 
     ![WHOIS Privacy card](/files/whoisprivacy-domain-card-enabled.png)
 
-1.  Click on the <label>Turn WHOIS Privacy off</label> link. You will be taken to a confirmation page.
+1.  Click on the <label>Turn WHOIS Privacy off</label> link. This takes you to a confirmation page.
 
 1.  To disable the WHOIS Privacy service click on the <label>Disable WHOIS Privacy</label> button.
 
@@ -125,12 +125,12 @@ Once you disable the WHOIS Privacy protection, the contact details of your domai
 
 <info> There currently is no auto-renewal for WHOIS Privacy. It must be renewed manually. </info> 
 
-While we will send an email reminder when the WHOIS Privacy on a domain is due to expire, it's possible to renew it manually before that notice is sent:
+We'll send an email reminder when the WHOIS Privacy on a domain is due to expire, but you can renew it manually before that notice is sent:
 
 <div class="section-steps" markdown="1">
 1.  Log in to DNSimple with your user credentials.
 1.  If you have more than one account, select the relevant one.
-1.  On the header click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
+1.  On the header, click the <label>Domains</label> tab, locate the relevant domain and click on the name to access the domain page.
 1.  Scroll down to the _Contact_ card.
 
     ![WHOIS Privacy card](/files/whoisprivacy-domain-card-renew.png)
@@ -144,6 +144,6 @@ While we will send an email reminder when the WHOIS Privacy on a domain is due t
 
 ## WHOIS Privacy and GDPR {#gdpr}
 
-For generic TLDs (gTLDs) like .com, .net, and .org, WHOIS privacy is not necessary at this time as it will be redacted through GDPR. This also applies to new TLDs (nTLDs) like .app, .dev, and others.
+For generic TLDs (gTLDs) like .com, .net, and .org, WHOIS privacy isn't necessary, because the information will be redacted through GDPR. This also applies to new TLDs (nTLDs) like .app, .dev, and others.
 
-For country code TLDs (ccTLDs) you will need to look at the policies for the TLD to determine their stance on WHOIS data. With ccTLDs, please research any TLD you plan on using to determine their stance on WHOIS data, and apply WHOIS privacy when it is available, as you see fit.
+For country code TLDs (ccTLDs), check the policies for the specific TLD to determine their stance on WHOIS data. With ccTLDs, you should research any TLD you plan on using to determine their stance on WHOIS data, and apply WHOIS privacy when it's available.

--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -123,7 +123,9 @@ Once you disable the WHOIS Privacy protection, the contact details of your domai
 
 ## Renew WHOIS Privacy {#renew}
 
-<info> There currently is no auto-renewal for WHOIS Privacy. It must be renewed manually. </info> 
+<info>
+There currently is no auto-renewal for WHOIS Privacy. It must be renewed manually.
+</info> 
 
 We'll send an email reminder when the WHOIS Privacy on a domain is due to expire, but you can renew it manually before that notice is sent:
 


### PR DESCRIPTION
Closes #653

Updates the WHOIS privacy article under the Renewal heading to explicitly state that we currently do not offer automatic renewal of WHOIS privacy, and that it must be renewed manually.