### PR TITLE
Fix yarn tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,17 @@ language: ruby
 rvm:
   - 2.7.0
 
-node_js:
-  - 12.13.1
-
 cache:
   bundler: true
   yarn: true
   directories:
     - node_modules
+
+install:
+  - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
+  - nvm install $(grep 'node' .tool-versions | cut -d ' ' -f2)
+  - npm i -g yarn
+  - yarn
 
 notifications:
   email: false

--- a/content/search/results.js
+++ b/content/search/results.js
@@ -16,21 +16,28 @@
     var $ul = document.createElement('ul');
 
     $h1.innerText = 'Search results';
+    $ul.className = 'articles-list';
 
     if (q.length)
       $h1.innerText += ' for "' + q + '"';
 
     if (results.length === 0) {
       var $li = document.createElement('li');
+
       $li.innerText = 'No results found';
+      $li.className = 'articles-list-item';
+
       $ul.appendChild($li);
     }
 
     results.forEach(function (result) {
       var $li = document.createElement('li');
       var $a = document.createElement('a');
+
       $a.href = result.id;
       $a.innerHTML = result.title;
+      $li.className = 'articles-list-item';
+
       $li.appendChild($a);
       $ul.append($li);
     });

--- a/spec/search/index.spec.js
+++ b/spec/search/index.spec.js
@@ -3,8 +3,9 @@
 // search.js. As a result, we have to be creative here.
 
 const fs = require('fs');
-const subject = eval(
-  fs.readFileSync(__dirname + '/../../templates/search.js.erb')
+const path = require('path');
+const subject = eval( // eslint-disable-line no-eval
+  fs.readFileSync(path.join(__dirname, '/../../templates/search.js.erb'))
     .toString()
     .replace(/<%= articles %>/, '[]')
     .replace(/<%= dictionary %>/, '{}')

--- a/spec/search/index.spec.js
+++ b/spec/search/index.spec.js
@@ -1,4 +1,14 @@
-const subject = require('../../content/search.js');
+// To save a network request on the support widget, we inject
+// the articles directly into the production version of
+// search.js. As a result, we have to be creative here.
+
+const fs = require('fs');
+const subject = eval(
+  fs.readFileSync(__dirname + '/../../templates/search.js.erb')
+    .toString()
+    .replace(/<%= articles %>/, '[]')
+    .replace(/<%= dictionary %>/, '{}')
+);
 
 describe('Search', () => {
   describe('.articleScore', () => {

--- a/templates/search.js.erb
+++ b/templates/search.js.erb
@@ -81,9 +81,15 @@ var search = function search (q, articles, dictionary) {
     category = q.slice(4).trim();
     q = category;
 
-    return articles.filter(function (article) {
-      return !category || article.categories.indexOf(category) !== -1;
-    });
+    return articles
+      .filter(function (article) {
+        return !category || article.categories.toString().toLowerCase().indexOf(category) !== -1
+      })
+      .sort(function (a, b) {
+        if (a.title > b.title) return 1;
+        if (a.title < b.title) return -1;
+        return 0;
+      });
   }
 
   return articles

--- a/templates/search.js.erb
+++ b/templates/search.js.erb
@@ -1,121 +1,121 @@
-(function () {
-  var ARTICLES = <%= articles %>;
-  var DICTIONARY = <%= dictionary %>;
-  var MAX_RESULTS = 30;
-  var MIN_SCORE = 15;
-  var PUNCTUATION = /['";:.()?-]/g;
-  var WHITESPACE = /\s+/;
-  var rootURL = 'https://support.dnsimple.com';
+var ARTICLES = <%= articles %>;
+var DICTIONARY = <%= dictionary %>;
+var MAX_RESULTS = 30;
+var MIN_SCORE = 15;
+var PUNCTUATION = /['";.()?-]/g;
+var WHITESPACE = /\s+/;
+var rootURL = 'https://support.dnsimple.com';
 
-  var articleScore = function articleScore (article, q) {
-    if (!q) return 0;
+var articleScore = function articleScore (article, q) {
+  if (!q) return 0;
 
-    var score = 0;
+  var score = 0;
 
-    if (article.searchTitle.indexOf(q) !== -1)
-      score += 75;
+  if (article.searchTitle.indexOf(q) !== -1)
+    score += 75;
 
-    if (article.searchBody.indexOf(q) !== -1)
-      score += 50;
+  if (article.searchBody.indexOf(q) !== -1)
+    score += 50;
 
-    var words = q.split(WHITESPACE).filter(function (str) {
-      return str.length > 1;
+  var words = q.split(WHITESPACE).filter(function (str) {
+    return str.length > 1;
+  });
+
+  for (var i = words.length - 1; i >= 0; i--) {
+    if (article.searchTitle.indexOf(words[i]) !== -1)
+      score += 15;
+
+    if (article.searchBody.indexOf(words[i]) !== -1)
+      score += 5;
+  }
+
+  return score;
+};
+
+var loadArticles = function loadArticles (articles) {
+  return articles.map(function (article) {
+    article.searchTitle = article.searchTitle || (article.title || '').toLowerCase().replace(PUNCTUATION, '');
+    article.searchBody = article.searchBody || (article.body || '').toLowerCase().replace(PUNCTUATION, '');
+    article.body = fixRelativeImgSrcs(article.body || '');
+    article.categories = article.categories || [];
+
+    return article;
+  });
+};
+
+var fixRelativeImgSrcs = function fixRelativeImgSrcs (str) {
+  return str.replace(
+    /src=["']?(\/[^"'\s>]+)["'\s>]?/g,
+    'src="' + rootURL + '$1"'
+  );
+};
+
+var dictionaryTermMatches = function dictionaryTermMatches (q, term) {
+  var matches = term.indexOf(q) === 0 || q.indexOf(term) === 0;
+  var firstSpace = term.indexOf(' ');
+  var termHasSpace = firstSpace !== -1;
+
+  return (!termHasSpace && matches) || (termHasSpace && matches && firstSpace < q.length);
+};
+
+var applyDictionary = function applyDictionary (dictionary, q) {
+  if (q.length >= 3)
+    for (var term in dictionary)
+      if (dictionaryTermMatches(q, term))
+        return dictionary[term];
+
+  return q;
+};
+
+var search = function search (q, articles, dictionary) {
+  q = (q || '').toLowerCase().trim().replace(PUNCTUATION, '');
+  q = applyDictionary(dictionary || DICTIONARY, q);
+
+  if (!q) return [];
+
+  articles = (articles || ARTICLES);
+
+  var category;
+
+  if (q.slice(0, 4) === 'cat:') {
+    category = q.slice(4).trim();
+    q = category;
+
+    return articles.filter(function (article) {
+      return !category || article.categories.indexOf(category) !== -1;
     });
+  }
 
-    for (var i = words.length - 1; i >= 0; i--) {
-      if (article.searchTitle.indexOf(words[i]) !== -1)
-        score += 15;
-
-      if (article.searchBody.indexOf(words[i]) !== -1)
-        score += 5;
-    }
-
-    return score;
-  };
-
-  var loadArticles = function loadArticles (articles) {
-    return articles.map(function (article) {
-      article.searchTitle = article.searchTitle || (article.title || '').toLowerCase().replace(PUNCTUATION, '');
-      article.searchBody = article.searchBody || (article.body || '').toLowerCase().replace(PUNCTUATION, '');
-      article.body = fixRelativeImgSrcs(article.body || '');
-      article.categories = article.categories || [];
-
-      return article;
+  return articles
+    .filter(function (article) {
+      article.score = articleScore(article, q);
+      return article.score > MIN_SCORE;
+    })
+    .filter(function (article, index) {
+      return index <= MAX_RESULTS;
+    })
+    .sort(function (a, b) {
+      if (a.score > b.score) return -1;
+      if (a.score < b.score) return 1;
+      return 0;
     });
+};
+
+if (typeof module === 'object' && typeof module.exports === 'object')
+  module.exports = {
+    search: search,
+    applyDictionary: applyDictionary,
+    articleScore: articleScore,
+    loadArticles: loadArticles,
+    fixRelativeImgSrcs: fixRelativeImgSrcs,
+    dictionaryTermMatches: dictionaryTermMatches
   };
-
-  var fixRelativeImgSrcs = function fixRelativeImgSrcs (str) {
-    return str.replace(
-      /src=["']?(\/[^"'\s>]+)["'\s>]?/g,
-      'src="' + rootURL + '$1"'
-    );
-  };
-
-  var dictionaryTermMatches = function dictionaryTermMatches (q, term) {
-    var matches = term.indexOf(q) === 0 || q.indexOf(term) === 0;
-    var firstSpace = term.indexOf(' ');
-    var termHasSpace = firstSpace !== -1;
-
-    return (!termHasSpace && matches) || (termHasSpace && matches && firstSpace < q.length);
-  };
-
-  var applyDictionary = function applyDictionary (dictionary, q) {
-    if (q.length >= 3)
-      for (var term in dictionary)
-        if (dictionaryTermMatches(q, term))
-          return dictionary[term];
-
-    return q;
-  };
-
-  var search = function search (q, articles, dictionary) {
-    q = (q || '').toLowerCase().trim().replace(PUNCTUATION, '');
-    q = applyDictionary(dictionary || DICTIONARY, q);
-
-    if (!q) return [];
-
-    articles = (articles || ARTICLES);
-
-    var category;
-
-    if (q.slice(0, 4) === 'cat:') {
-      category = q.slice(4).trim();
-      q = category;
-
-      return articles.filter(function (article) {
-        return !category || article.categories.indexOf(category) !== -1;
-      });
-    }
-
-    return articles
-      .filter(function (article) {
-        article.score = articleScore(article, q);
-        return article.score > MIN_SCORE;
-      })
-      .filter(function (article, index) {
-        return index <= MAX_RESULTS;
-      })
-      .sort(function (a, b) {
-        if (a.score > b.score) return -1;
-        if (a.score < b.score) return 1;
-        return 0;
-      });
-  };
-
-  if (typeof module === 'object' && typeof module.exports === 'object')
-    module.exports = {
-      search: search,
-      applyDictionary: applyDictionary,
-      articleScore: articleScore,
-      loadArticles: loadArticles,
-      fixRelativeImgSrcs: fixRelativeImgSrcs,
-      dictionaryTermMatches: dictionaryTermMatches
-    };
-  else {
+else {
+  (function () {
     window.DNSimpleSupport = window.DNSimpleSupport || {};
     window.DNSimpleSupport.search = search;
     window.DNSimpleSupport.articles = ARTICLES;
 
     loadArticles(ARTICLES);
-  }
-})();
+  })();
+}


### PR DESCRIPTION
This PR fixes tests for `search.js.erb`. 

To save an extra network request on the support widget, we inject the articles directly into the production version of `search.js`. As a result, we have to be creative in how we test it.