### PR TITLE
Document additional .GAY requirements

### DIFF
--- a/content/articles/domains-gay.markdown
+++ b/content/articles/domains-gay.markdown
@@ -1,0 +1,26 @@
+---
+title: .GAY Domains
+excerpt: This article explains the requirements and special procedures for .GAY domain names.
+categories:
+- Domains
+---
+
+# .GAY Domain Names
+
+* TOC
+{:toc}
+
+---
+
+This article explains the requirements and special procedures for .GAY domain names.
+
+
+## Registering a .GAY domain {#registering}
+
+### Additional terms and conditions for .GAY
+
+In order for a .GAY domain you need to agree and be willing to be compliant with the additional terms and conditions for .GAY:
+
+- [CentralNic Registrant Agreement (Appendix W)](https://www.hexonet.net/legal/gTLD_domain_registration_policies_eu#appendixw)
+- The use of .GAY for anti-LGBTQ content or to malign or harm LGBTQ individuals or groups is strictly prohibited and can result in immediate server-hold. Prohibited behavior includes harassment, threats, and hate speech.
+- Top Level Design donates 20% from each new .GAY domain registered to their partners, GLAAD and CenterLink.

--- a/content/articles/domains-gay.markdown
+++ b/content/articles/domains-gay.markdown
@@ -19,7 +19,7 @@ This article explains the requirements and special procedures for .GAY domain na
 
 ### Additional terms and conditions for .GAY
 
-In order for a .GAY domain you need to agree and be willing to be compliant with the additional terms and conditions for .GAY:
+In order to register a .GAY domain, you need to agree and be willing to be compliant with the additional terms and conditions for .GAY:
 
 - [CentralNic Registrant Agreement (Appendix W)](https://www.hexonet.net/legal/gTLD_domain_registration_policies_eu#appendixw)
 - The use of .GAY for anti-LGBTQ content or to malign or harm LGBTQ individuals or groups is strictly prohibited and can result in immediate server-hold. Prohibited behavior includes harassment, threats, and hate speech.


### PR DESCRIPTION
Registering a .GAY needs additional extended attributes to comply with the registry rules. This PR adds the documentation to link to from the registration process.