### PR TITLE
Billing information (not email) can be customized on any plan

### DIFF
--- a/content/articles/billing-settings.markdown
+++ b/content/articles/billing-settings.markdown
@@ -19,7 +19,7 @@ Until you provide us with further information, your invoices will reflect the em
 ![Example Invoice Without Billing Information](/files/account-billing-settings-invoice-1.png)
 
 
-## Customize billing information
+## Customizing billing information
 
 You can replace the billing details with custom information on all your invoices:
 
@@ -50,7 +50,7 @@ You can modify this information any time, as many times as you need to. The new 
 
 All future invoices will display the information you provided.
 
-## Change the billing email
+## Changing the billing email
 
 We can deliver your invoices to a different email address from the one you use to manage your domains.
 

--- a/content/articles/billing-settings.markdown
+++ b/content/articles/billing-settings.markdown
@@ -19,6 +19,37 @@ Until you provide us with further information, your invoices will reflect the em
 ![Example Invoice Without Billing Information](/files/account-billing-settings-invoice-1.png)
 
 
+## Customize billing information
+
+You can replace the billing details with custom information on all your invoices:
+
+![Example Invoice With Billing Information](/files/account-billing-settings-invoice-2.png)
+
+<info>
+You can modify this information any time, as many times as you need to. The new billing information will only be used for future invoices. If you need to change the billing information of an existing invoice, please [contact support](https://dnsimple.com/contact).
+</info>
+
+
+### Changing your billing settings
+
+<div class="section-steps" markdown="1">
+##### To update your billing settings
+
+1.  Log in to DNSimple with your user credentials.
+1.  [Find the account](https://dnsimple.com/user) on the account list. Click on the account to enter the account page.
+1.  Scroll down to the invoices section. Click on the <label>Edit</label> link.
+
+    ![Change billing settings](/files/account-billing-settings-link.png)
+
+1.  You'll see your current billing information (it'll be empty if this is the first time you're editing it). Click on the <label>Edit</label> link.
+1.  Fill in the form and click <label>Save</label> when you're done.
+
+    ![Change payment details](/files/account-billing-settings-update.png)
+</div>
+
+
+All future invoices will display the information you provided.
+
 ## Change the billing email
 
 We can deliver your invoices to a different email address from the one you use to manage your domains.
@@ -41,36 +72,3 @@ We can deliver your invoices to a different email address from the one you use t
 <info>
 You can customize your billing email only if you're subscribed to one of the following [plans](https://dnsimple.com/pricing): Professional or Business.
 </info>
-
-
-## Customize billing information
-
-You can replace the billing email with custom information on all your invoices:
-
-![Example Invoice With Billing Information](/files/account-billing-settings-invoice-2.png)
-
-<info>
-You can customize your billing information only if you're subscribed to one of the following [plans](https://dnsimple.com/pricing): Professional or Business.    
-<br /><br />
-You can modify this information any time, as many times as you need to. The new billing information will only be used for future invoices. If you need to change the billing information of an existing invoice, please [contact support](https://dnsimple.com/contact).
-</info>
-
-### Changing your billing settings
-
-<div class="section-steps" markdown="1">
-##### To update your billing settings
-
-1.  Log in to DNSimple with your user credentials.
-1.  [Find the account](https://dnsimple.com/user) on the account list. Click on the account to enter the account page.
-1.  Scroll down to the invoices section. Click on the <label>Edit</label> link.
-
-    ![Change billing settings](/files/account-billing-settings-link.png)
-
-1.  You'll see your current billing information (it'll be empty if this is the first time you're editing it). Click on the <label>Edit</label> link.
-1.  Fill in the form and click <label>Save</label> when you're done.
-
-    ![Change payment details](/files/account-billing-settings-update.png)
-</div>
-
-
-All future invoices will display the information you provided.

--- a/content/articles/billing-settings.markdown
+++ b/content/articles/billing-settings.markdown
@@ -50,6 +50,8 @@ You can replace the billing email with custom information on all your invoices:
 ![Example Invoice With Billing Information](/files/account-billing-settings-invoice-2.png)
 
 <info>
+You can customize your billing information only if you're subscribed to one of the following [plans](https://dnsimple.com/pricing): Professional or Business.    
+
 You can modify this information any time, as many times as you need to. The new billing information will only be used for future invoices. If you need to change the billing information of an existing invoice, please [contact support](https://dnsimple.com/contact).
 </info>
 

--- a/content/articles/billing-settings.markdown
+++ b/content/articles/billing-settings.markdown
@@ -51,7 +51,7 @@ You can replace the billing email with custom information on all your invoices:
 
 <info>
 You can customize your billing information only if you're subscribed to one of the following [plans](https://dnsimple.com/pricing): Professional or Business.    
-
+<br /><br />
 You can modify this information any time, as many times as you need to. The new billing information will only be used for future invoices. If you need to change the billing information of an existing invoice, please [contact support](https://dnsimple.com/contact).
 </info>
 


### PR DESCRIPTION
Edit: following the chat in #695, the ability to change the billing information (company name, address, tax ID) is available for _any_ plan. The billing email can only be changed with Professional and higher, however.

This support article led me to believe that a higher plan is required in order to change such details, but that's not the case. This PR swaps the order of the two sections so as to present a less causal relationship, hopefully clarifying that changing billing details is a go across all tiers.

~`@jacegu` Sarah suggested I ping you to chat about this, hope you don't mind if we take this async. More context is in issue #695, but our basic question is whether it's even possible to add customized billing information to invoices where an account is on a Personal plan.~

~If it's not at all possible, we should definitely clarify such in the documentation, which is what this PR does.~

~If it is possible, is it something we'd want to do (maybe on a case by case basis) or should we encourage users to upgrade to an appropriate plan?~

Closes #695.