### PR TITLE
Update docs to make ICANN-lock for transfers between accounts more apparent

### DIFF
--- a/content/articles/transferring-domain-away.markdown
+++ b/content/articles/transferring-domain-away.markdown
@@ -21,6 +21,9 @@ This article describes the procedure to transfer a domain registered with DNSimp
 
 <warning>
 Once a domain transfer is started, you won't be able to change the name servers on the domain. If you want to change your name servers, you can do so after requesting the code. Once you provide the transfer code to the gaining registrar, you cannot make adjustments.
+<br /><br />
+    
+If you've recently had a domain transferred to your DNSimple account from another, you won't be able to transfer the domain away for 60 days due to an [ICAAN-imposed lock after change of registrant](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 
 To transfer a domain to another registrar, the standard procedure requires you to:

--- a/content/articles/transferring-domain-away.markdown
+++ b/content/articles/transferring-domain-away.markdown
@@ -21,9 +21,6 @@ This article describes the procedure to transfer a domain registered with DNSimp
 
 <warning>
 Once a domain transfer is started, you won't be able to change the name servers on the domain. If you want to change your name servers, you can do so after requesting the code. Once you provide the transfer code to the gaining registrar, you cannot make adjustments.
-<br /><br />
-    
-If you've recently had a domain transferred to your DNSimple account from another, you won't be able to transfer the domain away for 60 days due to an [ICAAN-imposed lock after change of registrant](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 
 To transfer a domain to another registrar, the standard procedure requires you to:

--- a/content/articles/transferring-domain-between-accounts.markdown
+++ b/content/articles/transferring-domain-between-accounts.markdown
@@ -23,7 +23,7 @@ Working with a Reseller? Follow the steps outlined [here](#accepting-a-transfer)
 
 <warning>
 Once the transfer is accepted, you'll no longer be able to manage the domain.
-<br /<br />
+<br /><br />
 Transfers between DNSimple accounts are also subject to an [ICAAN-imposed lock after change of registrant](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 

--- a/content/articles/transferring-domain-between-accounts.markdown
+++ b/content/articles/transferring-domain-between-accounts.markdown
@@ -23,6 +23,8 @@ Working with a Reseller? Follow the steps outlined [here](#accepting-a-transfer)
 
 <warning>
 Once the transfer is accepted, you'll no longer be able to manage the domain.
+<br /><br />
+When transferring a domain to another DNSimple account, the domain's registrant information will be updated to reflect the new account. This may result in the domain being [locked from further transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 
 ## Initiating a transfer

--- a/content/articles/transferring-domain-between-accounts.markdown
+++ b/content/articles/transferring-domain-between-accounts.markdown
@@ -23,7 +23,7 @@ Working with a Reseller? Follow the steps outlined [here](#accepting-a-transfer)
 
 <warning>
 Once the transfer is accepted, you'll no longer be able to manage the domain.
-
+<br /><br />
 When transferring a domain to another DNSimple account, the domain's registrant information will be updated to reflect the new account. This may result in the domain being [locked from further transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 

--- a/content/articles/transferring-domain-between-accounts.markdown
+++ b/content/articles/transferring-domain-between-accounts.markdown
@@ -23,8 +23,6 @@ Working with a Reseller? Follow the steps outlined [here](#accepting-a-transfer)
 
 <warning>
 Once the transfer is accepted, you'll no longer be able to manage the domain.
-<br /><br />
-Transfers between DNSimple accounts are also subject to an [ICAAN-imposed lock after change of registrant](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 
 ## Initiating a transfer

--- a/content/articles/transferring-domain-between-accounts.markdown
+++ b/content/articles/transferring-domain-between-accounts.markdown
@@ -23,6 +23,8 @@ Working with a Reseller? Follow the steps outlined [here](#accepting-a-transfer)
 
 <warning>
 Once the transfer is accepted, you'll no longer be able to manage the domain.
+<br /<br />
+Transfers between DNSimple accounts are also subject to an [ICAAN-imposed lock after change of registrant](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 
 ## Initiating a transfer

--- a/content/articles/transferring-domain-between-accounts.markdown
+++ b/content/articles/transferring-domain-between-accounts.markdown
@@ -23,7 +23,7 @@ Working with a Reseller? Follow the steps outlined [here](#accepting-a-transfer)
 
 <warning>
 Once the transfer is accepted, you'll no longer be able to manage the domain.
-<br /><br />
+
 When transferring a domain to another DNSimple account, the domain's registrant information will be updated to reflect the new account. This may result in the domain being [locked from further transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 


### PR DESCRIPTION
We've recently found that the 60-day lock also applies to domains transferred between DNSimple accounts. This came about because one reseller was waiving the lock while the other wasn't.

This change makes the lock a bit more explicit in a couple of relevant articles.

### References

- https://dnsimple.groovehq.com/tickets/103787