### PR TITLE
Upgrade to Ruby v2.7.2 and NodeJS v14.15.3 LTS

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 # Update also: .travis.yml
-nodejs 12.13.1
+nodejs 14.15.3
 ruby 2.7.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 # Update also: .travis.yml
-ruby 2.7.0
 nodejs 12.13.1
+ruby 2.7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.7.0
+  - 2.7.2
 
 cache:
   bundler: true


### PR DESCRIPTION
This PR aims to upgrade:
- Ruby to v2.7.2
- NodeJS to current LTS => 14.15.3

Test run ok locally and in Travis and running the site locally also shows no problems