### PR TITLE
Allow margin for p in markers

### DIFF
--- a/content/articles/transferring-domain-between-accounts.markdown
+++ b/content/articles/transferring-domain-between-accounts.markdown
@@ -23,7 +23,7 @@ Working with a Reseller? Follow the steps outlined [here](#accepting-a-transfer)
 
 <warning>
 Once the transfer is accepted, you'll no longer be able to manage the domain.
-<br /><br />
+
 When transferring a domain to another DNSimple account, the domain's registrant information will be updated to reflect the new account. This may result in the domain being [locked from further transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
 </warning>
 

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -24,9 +24,6 @@
   h4 {
     margin-top: 0px;
   }
-  p {
-    margin: 0;
-  }
 
   &:before {
     display: block;

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -25,6 +25,12 @@
     margin-top: 0px;
   }
 
+  p {
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
   &:before {
     display: block;
     float: left;


### PR DESCRIPTION
Otherwise we are forced to use HTML as in https://github.com/dnsimple/dnsimple-support/pull/702

This rule was added in https://github.com/dnsimple/dnsimple-support/pull/451 but I cannot find exactly why we needed it (it is incorporated in a bunch of other changes).

Also this rule doesn't exist on the developer site, and I'm confident the style for the markers could/should be the same
https://github.com/dnsimple/dnsimple-developer/blob/master/content/assets/css/_application.scss
In fact, should we sync the marker definition between these two projects?

<img width="831" alt="Screenshot 2021-01-04 at 15 22 44" src="https://user-images.githubusercontent.com/5387/103544650-b7c7f180-4ea0-11eb-8c88-f3b639945d1b.png">
