### PR TITLE
Updates bundler version in lock file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,4 +150,4 @@ DEPENDENCIES
   systemu
 
 BUNDLED WITH
-   2.1.4
+   2.2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,3 +148,6 @@ DEPENDENCIES
   rouge
   sass
   systemu
+
+BUNDLED WITH
+   2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ desc "Compile the site"
 task compile: [:clean] do
   puts "Compiling site"
 
-  stdout, stderr, status = Bundler.with_clean_env do
+  stdout, stderr, status = Bundler.with_unbundled_env do
     Open3.capture3("yarn && yarn build && bundle exec nanoc compile")
   end
   if status.success?
@@ -39,7 +39,7 @@ end
 
 desc "Run the site"
 task run: [:compile] do
-  Bundler.with_clean_env do
+  Bundler.with_unbundled_env do
     sh("bundle exec nanoc live")
   end
 end


### PR DESCRIPTION
Locks the bundler version to latest. It also updates the previously revert bundler API change as the old method is deprecated.