### PR TITLE
Update CAA instructions for Sectigo and wildcard

### DIFF
--- a/content/articles/caa-record.markdown
+++ b/content/articles/caa-record.markdown
@@ -107,18 +107,6 @@ beta.example.com.   CAA 0 issue "comodoca.com"
 
 In the example above, Let's Encrypt is the default CA for the example.com domain. However, only Comodo can issue a certificate for `alpha.example.com`. Both Comodo and Let's Encrypt can issue certificates for `beta.example.com`. And what about `foo.example.com`? Because no record exists for `foo.example.com`, but there's a record for `example.com`, in this case only Let's Encrypt is allowed to issue for `foo.example.com`.
 
-<note>
-#### Comodo Wildcard Certificates
-
-Customers who purchase a Comodo wildcard certificate from us need to make sure they have an `issue` and `issuewild` CAA record, because they add an additional single-name to the certificate to cover the non-wildcard name. For example, buying a certificate for `*.example.com` issues a certificate with both `example.com` and `*.example.com` in the certificate names. This means you need to configure your CAA records:
-
-    example.com.  CAA 0 issue "comodoca.com"
-    example.com.  CAA 0 issuewild "comodoca.com"
-
-The above rules also apply to subdomain wildcard certificates.
-</note>
-
-
 ## Querying CAA records
 
 The CAA record is a relatively new resource record (RR), and not all tools support it. A notable example is `dig` – it doesn't support the standard syntax for querying CAA records. To query the CAA record for a domain with `dig`, you must specify the RR type (257) directly.

--- a/content/articles/caa-record.markdown
+++ b/content/articles/caa-record.markdown
@@ -77,7 +77,7 @@ example.com.  CAA 0 issue "letsencrypt.org"
 To allow both Let's Encrypt and Comodo, add 2 CAA records, one for each CA:
 
 ```
-example.com.  CAA 0 issue "comodoca.com"
+example.com.  CAA 0 issue "sectigo.com"
 example.com.  CAA 0 issue "letsencrypt.org"
 ```
 
@@ -85,7 +85,7 @@ To allow Let's Encrypt and Comodo only for wildcard, use `issuewild`:
 
 ```
 example.com.  CAA 0 issue "letsencrypt.org"
-example.com.  CAA 0 issuewild "comodoca.com"
+example.com.  CAA 0 issuewild "sectigo.com"
 ```
 
 The presence of issuewild overrides the `issue`. Let's Encrypt _is not allowed_ to issue wildcard certificates.
@@ -100,9 +100,9 @@ The records are inherited by child hostnames, which are offshoots of the parent 
 
 ```
 example.com.        CAA 0 issue "letsencrypt.org"
-alpha.example.com.  CAA 0 issue "comodoca.com"
+alpha.example.com.  CAA 0 issue "sectigo.com"
 beta.example.com.   CAA 0 issue "letsencrypt.org"
-beta.example.com.   CAA 0 issue "comodoca.com"
+beta.example.com.   CAA 0 issue "sectigo.com"
 ```
 
 In the example above, Let's Encrypt is the default CA for the example.com domain. However, only Comodo can issue a certificate for `alpha.example.com`. Both Comodo and Let's Encrypt can issue certificates for `beta.example.com`. And what about `foo.example.com`? Because no record exists for `foo.example.com`, but there's a record for `example.com`, in this case only Let's Encrypt is allowed to issue for `foo.example.com`.

--- a/content/articles/how-long-to-issue-ssl-certificate.markdown
+++ b/content/articles/how-long-to-issue-ssl-certificate.markdown
@@ -19,11 +19,11 @@ Occasionally, the issuance may take longer and require up to several days. This 
 - [CAA records](/articles/caa-record) preventing the validation and issuance
 - issues in the email approval
 
-<warning>
+<note>
 #### Remember to approve the certificate!
 
 In most cases, the purchase process can get stuck because the certificate is never approved by the owner. Once you submit the certificate, please monitor the approval email inbox and make sure to **click on the link contained in the email sent from the Certificate Authority** in order to validate and approve the certificate. Be sure to monitor your spam folder in case these emails are accidentally marked as spam.
-</warning>
+</note>
 
 <note>
 #### Sectigo Wildcard Certificates and CAA

--- a/content/articles/how-long-to-issue-ssl-certificate.markdown
+++ b/content/articles/how-long-to-issue-ssl-certificate.markdown
@@ -25,6 +25,18 @@ Occasionally, the issuance may take longer and require up to several days. This 
 In most cases, the purchase process can get stuck because the certificate is never approved by the owner. Once you submit the certificate, please monitor the approval email inbox and make sure to **click on the link contained in the email sent from the Certificate Authority** in order to validate and approve the certificate. Be sure to monitor your spam folder in case these emails are accidentally marked as spam.
 </warning>
 
+<note>
+#### Sectigo Wildcard Certificates and CAA
+
+Customers who purchase a Sectigo wildcard certificate from us need to make sure they have both `issuewild` and `issue` [CAA records](/articles/caa-record), because they add an additional single-name to the certificate to cover the non-wildcard name.
+
+For example, buying a certificate for `*.example.com` issues a certificate with both `example.com` and `*.example.com` in the certificate names. This means you need to configure your CAA records:
+
+    example.com.  CAA 0 issue "sectigo.com"
+    example.com.  CAA 0 issuewild "sectigo.com"
+
+The above rules also apply to subdomain wildcard certificates.
+</note>
 ## Let's Encrypt certificates
 
 For [Let's Encrypt](/articles/ssl-certificates#letsencrypt) certificates the issuance is generally between 30 minutes and 1 hour.


### PR DESCRIPTION
Comodo is now Sectigo. I also moved the warning block about CAA closer to where it can be searched (in the troubleshooting).

We are probably missing some information in the instructions to purchase a new certificate. But for now, I think this is a better fit than having Sectigo-specific instructions buried into a generic CAA article.
