### PR TITLE
Add "What is DNSimple" link

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -38,7 +38,7 @@
           </div>
         </div>
         <div class="dn db-ns self-center w-40 tr">
-          <a href="https://dnsimple.com/about" class="link br2 ph3 pv2 dib white bg-silver hover-white b">What is DNSimple?</a>
+          <a href="https://dnsimple.com/" class="link br2 ph3 pv2 dib white bg-silver hover-white b">What is DNSimple?</a>
           <a href="https://dnsimple.com/campaign/support" class="link br2 ph3 pv2 dib white bg-blue hover-white b">Free Trial</a>
         </div>
       </div>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -38,7 +38,8 @@
           </div>
         </div>
         <div class="dn db-ns self-center w-40 tr">
-          <a href="https://dnsimple.com/campaign/support" class="link br2 ph4 pv2 dib white bg-blue hover-white b">Free Trial</a>
+          <a href="https://dnsimple.com/about" class="link br2 ph3 pv2 dib white bg-silver hover-white b">What is DNSimple?</a>
+          <a href="https://dnsimple.com/campaign/support" class="link br2 ph3 pv2 dib white bg-blue hover-white b">Free Trial</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR adds a "What is DNSimple" link to the header.

Belongs to https://github.com/dnsimple/dnsimple-marketing/issues/391

## After Deploy

- [ ] Make sure tracking is in place
- [ ] Set a calendar reminder to track the analytics in 2 months time