### PR TITLE
Link to header icon

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -86,8 +86,8 @@
         if (!heading.id || heading.id === 'toc') return;
         const link = document.createElement('a');
         link.setAttribute('href', '#' + heading.id);
-        link.className = 'f7 o-80 no-underline dib w2 ml1 ml0-ns nl4-ns fr fn-ns v-mid';
-        link.innerHTML = '📎';
+        link.className = 'f6 link gray no-underline dib w2 pl2 ml1 ml0-ns nl4-ns fr fn-ns v-mid';
+        link.innerHTML = "<i class='fa fa-link'></i>";
         heading.prepend(link);
       });
   </script>


### PR DESCRIPTION
This PR replaces our anchor links in headers from a paperclip emoji to a link icon.

The reasons for this change:
- Emojis are not consistent across OS.
- On OSX, there is poor contrast.

## Before

<img width="402" alt="Screen Shot 2021-02-24 at 6 17 09 PM" src="https://user-images.githubusercontent.com/80610/109039593-400e8a00-76cd-11eb-8d23-e5658d7b568a.png">

## After 

<img width="466" alt="Screen Shot 2021-02-24 at 6 17 25 PM" src="https://user-images.githubusercontent.com/80610/109039590-3edd5d00-76cd-11eb-95b9-19f909f58ec7.png">


