### PR TITLE
Link to 'what happens if I stop paying' in getting started guides

### DIFF
--- a/content/articles/getting-started-personal-plan.markdown
+++ b/content/articles/getting-started-personal-plan.markdown
@@ -81,6 +81,7 @@ Make sure to [check your nameservers](/articles/pointing-domain-to-dnsimple/). I
 - [Email forwards](/articles/email-forwarding/)
 - [Whois Privacy](/articles/whois-privacy/)
 - [Learn how DNS and HTTPS work](https://dnsimple.com/comics)
+- [What happens if I stop paying for my DNSimple subscription?](/articles/what-happens-if-i-stop-paying/)
 
 
 <center><iframe width="560" height="315" src="https://www.youtube.com/embed/3eqEl6scOvw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>

--- a/content/articles/getting-started.markdown
+++ b/content/articles/getting-started.markdown
@@ -21,6 +21,7 @@ categories:
 - [Account Activation](/articles/account-activation/)
 - [Customize billing information](/articles/billing-settings/#customizing-billing-information)
 - [Understanding Your DNSimple Invoice](/articles/understanding-invoice/)
+- [What happens if I stop paying for my DNSimple subscription?](/articles/what-happens-if-i-stop-paying/)
 
 ### DNS and Domains
 


### PR DESCRIPTION
A customer expressed frustration after their domains stopped resolving after three weeks of failed payment attempts. This PR adds links to the article explaining what happens if we're unable to collect payment to the getting started guides.

Reference: https://twitter.com/dnsimple/status/1371707138016477184