### PR TITLE
Add resource for identifying web host

### DIFF
--- a/content/articles/web-hosting.markdown
+++ b/content/articles/web-hosting.markdown
@@ -1,6 +1,6 @@
 ---
 title: Web Hosting Support
-excerpt: We focus primarily on domain management services and we don't provide web hosting.
+excerpt: We focus primarily on domain management services. We don't provide web hosting.
 categories:
 - DNSimple
 - Domains
@@ -12,9 +12,9 @@ We focus primarily on [domain management services](/articles/dnsimple-services),
 
 If you want to transfer your domain, and your registrar currently provides web hosting, these are your options:
 
-1. Use a _platform as a service_ provider such as [Heroku](https://heroku.com/), [Azure](https://azure.microsoft.com/en-us/) or [Google Platform](https://cloud.google.com/)
-1. Use a cloud provider such as [Amazon EBS](https://aws.amazon.com/ebs/) or [DigitalOcean](https://www.digitalocean.com/)
-1. If you want to host a static site, use a cloud hosting solution such as [Amazon S3](https://aws.amazon.com/s3/), [GitHub Pages](https://pages.github.com/) or [GitLab Pages](https://pages.gitlab.io/)
+1. Use a _platform as a service_ provider such as [Heroku](https://heroku.com/), [Azure](https://azure.microsoft.com/en-us/) or [Google Platform](https://cloud.google.com/).
+1. Use a cloud provider such as [Amazon EBS](https://aws.amazon.com/ebs/) or [DigitalOcean](https://www.digitalocean.com/).
+1. If you want to host a static site, use a cloud hosting solution such as [Amazon S3](https://aws.amazon.com/s3/), [GitHub Pages](https://pages.github.com/) or [GitLab Pages](https://pages.gitlab.io/).
 
 
 ## FTP credentials
@@ -24,8 +24,6 @@ Because we don't host your application or files directly, we can't provide any F
 
 ## Why DNSimple doesn't provide web hosting services
 
-Here's some reasons why we decided to not offer web hosting:
-
 - We focus on offering the best domain management platform by enabling our customers to set up and connect their domains to popular services that already exist, rather than trying to create our own top-to-bottom solution.
 - The web is diverse and complex, and there are myriad technologies available for creating websites. These require several pieces of software to work: database servers, web servers, caching services, load balancers, etc. Websites have heavier hardware requirements than just a few Megabytes of hard disk.
 - There are many useful websites for people who need personal sites.
@@ -33,4 +31,4 @@ Here's some reasons why we decided to not offer web hosting:
 
 ## Identifying your web host
 
-You can determine your web host using a tool such as [Hosting Checker](https://hostingchecker.com).
+You can determine your web host using a tool like [Hosting Checker](https://hostingchecker.com).

--- a/content/articles/web-hosting.markdown
+++ b/content/articles/web-hosting.markdown
@@ -1,6 +1,6 @@
 ---
 title: Web Hosting Support
-excerpt: We focus primarily on domain management services and we don't provide web hosting. 
+excerpt: We focus primarily on domain management services and we don't provide web hosting.
 categories:
 - DNSimple
 - Domains
@@ -29,3 +29,8 @@ Here's some reasons why we decided to not offer web hosting:
 - We focus on offering the best domain management platform by enabling our customers to set up and connect their domains to popular services that already exist, rather than trying to create our own top-to-bottom solution.
 - The web is diverse and complex, and there are myriad technologies available for creating websites. These require several pieces of software to work: database servers, web servers, caching services, load balancers, etc. Websites have heavier hardware requirements than just a few Megabytes of hard disk.
 - There are many useful websites for people who need personal sites.
+
+
+## Identifying your web host
+
+You can determine your web host using a tool such as [Hosting Checker](https://hostingchecker.com).


### PR DESCRIPTION
We sometimes get questions from users who confuse us for their web host. While our docs explain why we don't offer web hosting, there's a missed opportunity to help folks figure out who their host is. This PR adds such a resource.