### PR TITLE
redirect old changing email articles

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -112,3 +112,5 @@
 /questions/32923-CloudFlare-Current-Best-Practices                        https://dnsimple.com/tlds/cloud-domains
 /questions/32923-CloudFlare-Current-Best-Practices/                       https://dnsimple.com/tlds/cloud-domains
 /questions/32923-CloudFlare-Current-Best-Practices/index.html             https://dnsimple.com/tlds/cloud-domains
+/articles/changing-account-email/                                         /articles/changing-email/
+/articles/changing-user-email/                                            /articles/changing-email/


### PR DESCRIPTION
Redirects `/articles/changing-account-email/` and `/articles/changing-user-email/` to `/articles/changing-email/`.

Ref: https://dnsimple.groovehq.com/tickets/114506