### PR TITLE
Remove 'newer plan' verbiage

### DIFF
--- a/content/articles/dnssec.markdown
+++ b/content/articles/dnssec.markdown
@@ -11,10 +11,6 @@ categories:
 This article describes a feature in Public Beta.
 </info>
 
-<info>
-This article describes a feature only available on [newer plans](/articles/new-plans#newer-plans-only).
-</info>
-
 <warning>
   You cannot enable DNSSEC if you have set up [Secondary DNS enabled](/articles/secondary-dns), as they will not work in conjunction. Please ensure that you are not currently using Secondary DNS, or disable Secondary DNS before using DNSSEC. You can read more about why [here](/articles/dnssec-and-secondary-dns).
 </warning>

--- a/content/articles/letsencrypt.markdown
+++ b/content/articles/letsencrypt.markdown
@@ -12,10 +12,6 @@ categories:
 This article describes a feature in Public Beta.
 </info>
 
-<info>
-This article describes a feature only available on [current plans](/articles/new-plans#newer-plans-only).
-</info>
-
 ### Table of Contents {#toc}
 
 * TOC

--- a/content/articles/manage-caa-record.markdown
+++ b/content/articles/manage-caa-record.markdown
@@ -14,10 +14,6 @@ categories:
 
 ---
 
-<info>
-This article describes a feature only available on [newer plans](/articles/new-plans#newer-plans-only).
-</info>
-
 You can manage [CAA records](/articles/caa-record) in DNSimple using the [DNS record editor](/articles/record-editor).
 
 The instructions in this article assume you're familiar with the [CAA record format](/articles/caa-record#record-format) and usage.

--- a/content/articles/ordering-lets-encrypt-certificate.markdown
+++ b/content/articles/ordering-lets-encrypt-certificate.markdown
@@ -11,10 +11,6 @@ categories:
 This article describes a feature in Public Beta.
 </info>
 
-<info>
-This article describes a feature that is only available to the [new plans](/articles/new-plans#newer-plans-only).
-</info>
-
 ### Table of Contents {#toc}
 
 * TOC

--- a/content/articles/regional-records.markdown
+++ b/content/articles/regional-records.markdown
@@ -7,6 +7,10 @@ categories:
 
 # Regional Records
 
+<info>
+This article describes a feature only available on the following plans: Professional and Business.
+</info>
+
 Regional records lets you select geographical regions where you want a record to appear.
 
 We have 6 points of presence:

--- a/content/articles/regional-records.markdown
+++ b/content/articles/regional-records.markdown
@@ -7,10 +7,6 @@ categories:
 
 # Regional Records
 
-<info>
-This article describes a feature only available on the following [newer plans](/articles/new-plans#newer-plans-some): Professional and Business.
-</info>
-
 Regional records lets you select geographical regions where you want a record to appear.
 
 We have 6 points of presence:
@@ -27,4 +23,3 @@ When creating a new record, select the point of presence for this record. **If y
 This feature is enabled by default on all Professional and Business plans. [See our pricing and features](https://dnsimple.com/pricing)
 
 ![Regional record selection](/files/regional-records.png)
-

--- a/content/articles/setting-up-accounts-for-clients.markdown
+++ b/content/articles/setting-up-accounts-for-clients.markdown
@@ -15,7 +15,7 @@ categories:
 ---
 
 <info>
-This article describes a feature only available on the following [plans](/articles/new-plans#newer-plans-some): Professional and Business.
+This article describes a feature only available on the following plans: Professional and Business.
 </info>
 
 Creating a separate account is a flexible and secure way for agencies and freelancers to share domain management with their clients.
@@ -32,7 +32,7 @@ Each customer must have a separate account. If you add more than one customer to
 ## Creating a separate account for your client
 
 You can add another account to your user profile by taking [these steps](/articles/account-multi/#creating-a-separate-account).
-  
+
 ## Inviting your client to DNSimple
 
 Verify your client has __registered__ with DNSimple.
@@ -46,5 +46,3 @@ Your client doesn't need to have an active subscription. They only need to be si
 ## Adding clients to the new account
 
 Once you've subscribed the new account to an eligible plan, [add your client to the new account](/articles/account-users/#adding-members-to-an-account).
-  
-


### PR DESCRIPTION
Since we've gotten rid of Legacy plans, there's no need to call out feature availability for newer plans.