### PR TITLE
DNSimple as secondary DNS video walk-through

### DIFF
--- a/content/articles/secondary-dns-dnsimple-as-secondary.markdown
+++ b/content/articles/secondary-dns-dnsimple-as-secondary.markdown
@@ -14,15 +14,7 @@ For an overview of Secondary DNS, have a look at [our introduction article](/art
 * TOC
 {:toc}
 
----
-
-<warning>
-  Don't add DNSimple as a secondary DNS server to domains with DNSSEC. We do not import external RRSIG records, which will produce resolution failures in DNSSEC aware resolutors.
-
-  Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS. You can read more about why [here](/articles/dnssec-and-secondary-dns).
-</warning>
-
-## Video tour
+## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
   <iframe src="https://www.youtube.com/embed/NPlkDqLL2Vo" class="aspect-ratio--object" frameborder="0" allow="accelero    meter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -32,6 +24,13 @@ For an overview of Secondary DNS, have a look at [our introduction article](/art
 ## Requirements
 
 Adding DNSimple as a Secondary DNS provider is available for an additional fee on the [Professional, Business](https://dnsimple.com/pricing), and [Master reseller](https://dnsimple.com/reseller) plans. If you aren't subscribed to one of these plans, and want to add DNSimple as secondary DNS, we'll prompt you to upgrade your plan.
+
+<warning>
+  Don't add DNSimple as a secondary DNS server to domains with DNSSEC. We do not import external RRSIG records, which will produce resolution failures in DNSSEC aware resolutors.
+
+  Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS. You can read more about why [here](/articles/dnssec-and-secondary-dns).
+</warning>
+
 
 ## Adding a Secondary Zone
 

--- a/content/articles/secondary-dns-dnsimple-as-secondary.markdown
+++ b/content/articles/secondary-dns-dnsimple-as-secondary.markdown
@@ -22,6 +22,13 @@ For an overview of Secondary DNS, have a look at [our introduction article](/art
   Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS. You can read more about why [here](/articles/dnssec-and-secondary-dns).
 </warning>
 
+## Video tour
+
+<div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
+  <iframe src="https://www.youtube.com/embed/NPlkDqLL2Vo" class="aspect-ratio--object" frameborder="0" allow="accelero    meter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+
 ## Requirements
 
 Adding DNSimple as a Secondary DNS provider is available for an additional fee on the [Professional, Business](https://dnsimple.com/pricing), and [Master reseller](https://dnsimple.com/reseller) plans. If you aren't subscribed to one of these plans, and want to add DNSimple as secondary DNS, we'll prompt you to upgrade your plan.


### PR DESCRIPTION
Adds the video walk-through to the top of the support article for DNSimple as Secondary DNS provider.

<img width="1119" alt="Screen Shot 2021-06-11 at 12 00 31 PM" src="https://user-images.githubusercontent.com/80610/121669562-b84a6100-caac-11eb-85ff-3d67286e9801.png">
