### PR TITLE
Add Heroku Connector video to article

### DIFF
--- a/content/articles/heroku-connector.markdown
+++ b/content/articles/heroku-connector.markdown
@@ -3,6 +3,7 @@ title: Heroku Connector
 excerpt: How to connect a Heroku app to your domain using DNSimple's Heroku Connector
 categories:
 - Services
+- Heroku and DNSimple
 ---
 
 # Heroku Connector

--- a/content/articles/heroku-connector.markdown
+++ b/content/articles/heroku-connector.markdown
@@ -20,7 +20,7 @@ categories:
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/Z1I0L1aSIA8" class="aspect-ratio--object" frameborder="0" allow="accelero    meter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe src="https://www.youtube.com/embed/Z1I0L1aSIA8" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Creating a connection

--- a/content/articles/heroku-connector.markdown
+++ b/content/articles/heroku-connector.markdown
@@ -16,6 +16,12 @@ categories:
 
 [Heroku](https://www.heroku.com) is a platform as a service (PaaS) that enables developers to build, run, and operate applications entirely in the cloud. With DNSimple's Heroku Connector, you can easily connect your domains to Heroku, and set up the required DNS records.
 
+## Video walk-through
+
+<div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
+  <iframe src="https://www.youtube.com/embed/Z1I0L1aSIA8" class="aspect-ratio--object" frameborder="0" allow="accelero    meter; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+</div>
+
 ## Creating a connection
 
 1. Head to the "Connections" tab for the domain you want to connect to Heroku. From there, click the "Add" button next to the Heroku connector.  


### PR DESCRIPTION
This PR adds the demo video to the Heroku support article.

![2021-06-11-16-59-deploy-preview-785--dnsimple-support netlify app](https://user-images.githubusercontent.com/900449/121742588-67e7f900-cad6-11eb-9d00-2955d9f1d6e5.png)

## QA

- The article should be on the "Heroku and DNSimple" category page: https://deploy-preview-785--dnsimple-support.netlify.app/categories/heroku-and-dnsimple/
- You should see the walk-through video at the top of the page: https://deploy-preview-785--dnsimple-support.netlify.app/articles/heroku-connector/