### PR TITLE
Support Widget: Search by URL

### DIFF
--- a/spec/search/index.spec.js
+++ b/spec/search/index.spec.js
@@ -68,7 +68,7 @@ describe('Search', () => {
     };
 
     test('finds an article by a URL', () => {
-      const articles = subject.loadArticles([{ url: '/articles/my-article', title: 'My Article' }, { url: '/not-a-match' }]);
+      const articles = subject.loadArticles([{ id: '/articles/my-article', title: 'My Article' }, { id: '/not-a-match' }]);
       const results = subject.search('/articles/my-article', articles, {});
 
       expect(results).toHaveLength(1);

--- a/spec/search/index.spec.js
+++ b/spec/search/index.spec.js
@@ -67,6 +67,14 @@ describe('Search', () => {
       close: 'unsubscribe'
     };
 
+    test('finds an article by a URL', () => {
+      const articles = subject.loadArticles([{ url: '/articles/my-article', title: 'My Article' }, { url: '/not-a-match' }]);
+      const results = subject.search('/articles/my-article', articles, {});
+
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toContain('My Article');
+    });
+
     test('finds the best article', () => {
       const articles = subject.loadArticles([{ title: 'Unsubscribe Your Account' }]);
       const results = subject.search('clo', articles, dictionary);

--- a/templates/search.js.erb
+++ b/templates/search.js.erb
@@ -59,7 +59,7 @@ var dictionaryTermMatches = function dictionaryTermMatches (q, term) {
 };
 
 var applyDictionary = function applyDictionary (dictionary, q) {
-  q = q.replace(PUNCTUATION, '')
+  q = q.replace(PUNCTUATION, '');
 
   if (q.length >= 3)
     for (var term in dictionary)
@@ -71,23 +71,23 @@ var applyDictionary = function applyDictionary (dictionary, q) {
 
 var findByUrl = function findByUrl (url, articles) {
   return articles.filter(function (article) {
-    return article.url === url
-  })
-}
+    return article.url === url;
+  });
+};
 
 var findByCategory = function findByCategory (category, articles) {
   return articles
     .filter(function (article) {
-      return !category || article.categories.toString().toLowerCase().indexOf(category) !== -1
+      return !category || article.categories.toString().toLowerCase().indexOf(category) !== -1;
     })
     .sort(function (a, b) {
       if (a.title > b.title) return 1;
       if (a.title < b.title) return -1;
       return 0;
     });
-}
+};
 
-var findByScore =function findByScore (q, articles) {
+var findByScore = function findByScore (q, articles) {
   return articles
     .filter(function (article) {
       article.score = articleScore(article, q);
@@ -101,23 +101,21 @@ var findByScore =function findByScore (q, articles) {
       if (a.score < b.score) return 1;
       return 0;
     });
-}
+};
 
 var search = function search (q, articles, dictionary) {
-  q = (q || '').toLowerCase().trim()
+  q = (q || '').toLowerCase().trim();
   articles = articles || ARTICLES;
 
-  if (q[0] === '/') {
-    return findByUrl(q, articles)
-  }
+  if (q[0] === '/')
+    return findByUrl(q, articles);
 
-  if (q.slice(0, 4) === 'cat:') {
-    return findByCategory(q.slice(4).trim(), articles)
-  }
+  if (q.slice(0, 4) === 'cat:')
+    return findByCategory(q.slice(4).trim(), articles);
 
   q = applyDictionary(dictionary || DICTIONARY, q);
 
-  return findByScore(q, articles)
+  return findByScore(q, articles);
 };
 
 if (typeof module === 'object' && typeof module.exports === 'object')
@@ -129,7 +127,7 @@ if (typeof module === 'object' && typeof module.exports === 'object')
     fixRelativeImgSrcs: fixRelativeImgSrcs,
     dictionaryTermMatches: dictionaryTermMatches
   };
-else {
+else
   (function () {
     window.DNSimpleSupport = window.DNSimpleSupport || {};
     window.DNSimpleSupport.search = search;
@@ -137,4 +135,3 @@ else {
 
     loadArticles(ARTICLES);
   })();
-}

--- a/templates/search.js.erb
+++ b/templates/search.js.erb
@@ -59,6 +59,8 @@ var dictionaryTermMatches = function dictionaryTermMatches (q, term) {
 };
 
 var applyDictionary = function applyDictionary (dictionary, q) {
+  q = q.replace(PUNCTUATION, '')
+
   if (q.length >= 3)
     for (var term in dictionary)
       if (dictionaryTermMatches(q, term))
@@ -67,31 +69,19 @@ var applyDictionary = function applyDictionary (dictionary, q) {
   return q;
 };
 
-var search = function search (q, articles, dictionary) {
-  q = (q || '').toLowerCase().trim().replace(PUNCTUATION, '');
-  q = applyDictionary(dictionary || DICTIONARY, q);
+var findByCategory = function findByCategory (category, articles) {
+  return articles
+    .filter(function (article) {
+      return !category || article.categories.toString().toLowerCase().indexOf(category) !== -1
+    })
+    .sort(function (a, b) {
+      if (a.title > b.title) return 1;
+      if (a.title < b.title) return -1;
+      return 0;
+    });
+}
 
-  if (!q) return [];
-
-  articles = (articles || ARTICLES);
-
-  var category;
-
-  if (q.slice(0, 4) === 'cat:') {
-    category = q.slice(4).trim();
-    q = category;
-
-    return articles
-      .filter(function (article) {
-        return !category || article.categories.toString().toLowerCase().indexOf(category) !== -1
-      })
-      .sort(function (a, b) {
-        if (a.title > b.title) return 1;
-        if (a.title < b.title) return -1;
-        return 0;
-      });
-  }
-
+var findByScore =function findByScore (q, articles) {
   return articles
     .filter(function (article) {
       article.score = articleScore(article, q);
@@ -105,6 +95,19 @@ var search = function search (q, articles, dictionary) {
       if (a.score < b.score) return 1;
       return 0;
     });
+}
+
+var search = function search (q, articles, dictionary) {
+  q = (q || '').toLowerCase().trim()
+  articles = articles || ARTICLES;
+
+  if (q.slice(0, 4) === 'cat:') {
+    return findByCategory(q.slice(4).trim(), articles)
+  }
+
+  q = applyDictionary(dictionary || DICTIONARY, q);
+
+  return findByScore(q, articles)
 };
 
 if (typeof module === 'object' && typeof module.exports === 'object')

--- a/templates/search.js.erb
+++ b/templates/search.js.erb
@@ -69,6 +69,12 @@ var applyDictionary = function applyDictionary (dictionary, q) {
   return q;
 };
 
+var findByUrl = function findByUrl (url, articles) {
+  return articles.filter(function (article) {
+    return article.url === url
+  })
+}
+
 var findByCategory = function findByCategory (category, articles) {
   return articles
     .filter(function (article) {
@@ -100,6 +106,10 @@ var findByScore =function findByScore (q, articles) {
 var search = function search (q, articles, dictionary) {
   q = (q || '').toLowerCase().trim()
   articles = articles || ARTICLES;
+
+  if (q[0] === '/') {
+    return findByUrl(q, articles)
+  }
 
   if (q.slice(0, 4) === 'cat:') {
     return findByCategory(q.slice(4).trim(), articles)

--- a/templates/search.js.erb
+++ b/templates/search.js.erb
@@ -71,7 +71,7 @@ var applyDictionary = function applyDictionary (dictionary, q) {
 
 var findByUrl = function findByUrl (url, articles) {
   return articles.filter(function (article) {
-    return article.url === url;
+    return article.id === url;
   });
 };
 


### PR DESCRIPTION
The support widget's default state is showing no results in some cases. This is because `dnsimple-app` is expecting to be able to supply a URL to search by. This PR will unlock the ability for `dnsimple-app` to specify a URL on a per-page basis. I took the opportunity to extract a couple methods for clarity.

To review: 
- Search for `/articles/whois-privacy/` – a _single_ item should appear.