### PR TITLE
Adds some text to the Managing DS records section

### DIFF
--- a/content/articles/dnssec.markdown
+++ b/content/articles/dnssec.markdown
@@ -69,7 +69,8 @@ Click on the "Disable DNSSEC" button to remove the zone signing and the DS recor
 
 ## Managing DS records
 
-Details on how to add and remove DS records can be found in this [support article](/articles/manage-ds-record/).
+Depending on whether the TLD of the domain requires the DS records to be set up with the DS-Data interface or the KEY-Data interface you will be able to manage your
+records. For more details on how to add and remove DS records can be found in this [support article](/articles/manage-ds-record/).
 
 ## Key rotation
 

--- a/content/articles/dnssec.markdown
+++ b/content/articles/dnssec.markdown
@@ -69,8 +69,7 @@ Click on the "Disable DNSSEC" button to remove the zone signing and the DS recor
 
 ## Managing DS records
 
-Depending on whether the TLD of the domain requires the DS records to be set up with the DS-Data interface or the KEY-Data interface you will be able to manage your
-records. For more details on how to add and remove DS records can be found in this [support article](/articles/manage-ds-record/).
+Whether the TLD of the domain requires the DS records to be set up with the DS-Data interface or the KEY-Data interface, you'll be able to manage your records. More details on how to add and remove DS records can be found in this [support article](/articles/manage-ds-record/).
 
 ## Key rotation
 


### PR DESCRIPTION
There is a lack of symetry in the DNSSEC page. To rememdy this I've added some text to the manage ds records section.

At some point we could have a better look at the content in our support page (from a high level view).