### PR TITLE
Mention Domain Access Control in Personal vs Pro diff page

### DIFF
--- a/content/articles/personal-vs-pro.markdown
+++ b/content/articles/personal-vs-pro.markdown
@@ -48,7 +48,7 @@ This article describes the differences between the *Personal* plan and the *Prof
 
 **Personal:** No - Sharing login credentials is unprofessional and a security risk.
 
-**Professional:** Yes - You can invite others to help manage your domains. This also includes access to your full activity log, which provides 100% transparency into account and domain changes.
+**Professional:** Yes - You can invite others to help manage your domains. This also includes [fine-grained access setup for domains](/articles/domain-access-control), and access to your full activity log, which provides 100% transparency into account and domain changes.
 
 ## Am I covered by an SLA?
 


### PR DESCRIPTION
This PR adds the mention to Domain Access Control in the Personal vs Pro diff page