### PR TITLE
Fix typo in CNAME record docs

### DIFF
--- a/content/articles/cname-record.markdown
+++ b/content/articles/cname-record.markdown
@@ -40,7 +40,7 @@ The DNS A record is specified by [RFC 1035](https://tools.ietf.org/html/rfc1035)
 
 ## CNAME record format {#record-format}
 
-The structure of an A record follows the standard top-level format definition defined [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.2.1). The RDATA section is composed of one single element:
+The structure of a CNAME record follows the standard top-level format definition defined [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.2.1). The RDATA section is composed of one single element:
 
 | Element | Description |
 |:------------|:----------------------------------------------------------------------------|


### PR DESCRIPTION
While going through the https://support.dnsimple.com/articles/cname-record/#record-format, I noticed that there's a typo. This PR fixes this.