### PR TITLE
Adds information about proration and billing cycle changes

### DIFF
--- a/content/articles/changing-plans.markdown
+++ b/content/articles/changing-plans.markdown
@@ -10,11 +10,11 @@ categories:
 As a DNSimple customer, you might require features that aren't available on your current plan. This article discusses how to switch to the most appropriate subscription to meet your current needs.
 
 <info>
-When you change your plan, you'll receive a prorated discount corresponding to the remaining days in your current subscription plan. This discount doesn't consider extras, like email forwards or extra zones, which you'll be billed for again as part of the plan change.
+When you change your plan, you'll receive a prorated discount corresponding to the remaining days in your current subscription plan. This discount doesn't consider extras, like email forwards or extra zones, which you'll be billed for again as part of the plan change. Read more about [subscription proration](/articles/understanding-invoice).
 </info>
 
 <warning>
-When changing from a yearly plan to a monthly plan, you'll receive a [credit to your DNSimple account balance](/articles//account-subscription-balance).
+When changing from a yearly plan to a monthly plan, you'll receive a [credit to your DNSimple account balance](/articles/account-subscription-balance).
 </warning>
 
 <div class="section-steps" markdown="1">
@@ -39,4 +39,12 @@ When changing from a yearly plan to a monthly plan, you'll receive a [credit to 
     ![Verify charges](/files/change-plan-3.png)
 
 1.  Once the change is complete, you'll receive the corresponding invoice.
+
+<info>
+When a plan change happens it may or may not be billed immediately:
+
+- If the plan change causes a [billing cycle](/articles/yearly-billing) change (monthly to yearly or yearly to monthly) it is billed immediately, updating the billing cycle.
+- If the plan change does _not_ change the billing cycle, it will be billed along the renewal of the plan, adhering to the existing billing cycle.
+</info>
+
 </div>

--- a/content/articles/changing-plans.markdown
+++ b/content/articles/changing-plans.markdown
@@ -44,7 +44,7 @@ When changing from a yearly plan to a monthly plan, you'll receive a [credit to 
 When a plan change happens it may or may not be billed immediately:
 
 - If the plan change causes a [billing cycle](/articles/yearly-billing) change (monthly to yearly or yearly to monthly) it is billed immediately, updating the billing cycle.
-- If the plan change does _not_ change the billing cycle, it will be billed along the renewal of the plan, adhering to the existing billing cycle.
+- If the plan change does _not_ change the billing cycle, it will be billed along with the renewal of the plan, adhering to the existing billing cycle.
 </info>
 
 </div>

--- a/content/articles/understanding-invoice.markdown
+++ b/content/articles/understanding-invoice.markdown
@@ -69,11 +69,11 @@ When you change your plan, you'll receive a proration discount corresponding to 
 
 ### Difference between "Unused time" and "Remaining time"
 
-**Unused time** refers to the amount of time on the old plan that you paid for, but you are not going to use. **Remaining time** refers to the amount of time that you are going to be on the new plan until the next billing cycle starts.
+**Unused time** refers to the amount of time on the old plan that you paid for but aren't going to use. **Remaining time** refers to the amount of time that you're going to be on the new plan until the next billing cycle starts.
 
 Example:
 
-Your billing cycle starts on the 1st of the month. You are on the Personal monthly plan. On the 10th you switch to Professional:
+Your billing cycle starts on the 1st of the month. You're on the Personal monthly plan. On the 10th you switch to Professional:
 
 - You will be returned 20 days of unused time on the Personal plan.
 - You will be paying 20 days of remaining time on the Professional plan.

--- a/content/articles/understanding-invoice.markdown
+++ b/content/articles/understanding-invoice.markdown
@@ -67,6 +67,17 @@ When you change your plan, you'll receive a proration discount corresponding to 
 
 ![Prorated invoice](/files/prorated-invoice.png)
 
+### Difference between "Unused time" and "Remaining time"
+
+**Unused time** refers to the amount of time on the old plan that you paid for, but you are not going to use. **Remaining time** refers to the amount of time that you are going to be on the new plan until the next billing cycle starts.
+
+Example:
+
+Your billing cycle starts on the 1st of the month. You are on the Personal monthly plan. On the 10th you switch to Professional:
+
+- You will be returned 20 days of unused time on the Personal plan.
+- You will be paying 20 days of remaining time on the Professional plan.
+
 
 ## Additional resources
 


### PR DESCRIPTION
A user asked about the difference between "unused time" and "remaining time" on their invoice (ticket 135138).  This PR documents that information, as well as clarifies when a plan change will be billed.