### PR TITLE
Adds contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ Once you are done, run `rake clean`, `rake compile` and `nanoc view` (or `nanoc 
 When submitting a pull request, apply the label `articles` and set yourself as assignee. Select `@SarahCaminiti1` and `@deandre` for review and, if your PR makes more substantive changes to copy, select `@itsalyse` as well for copy editing.
 
 Once all approvals are given and the pipeline is green, merge the PR yourself and delete the source branch.
+
+### Support writing guidelines
+
+Reference our support writing guidelines, [here](https://support.dnsimple.com/articles/writing-guide/).

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ Once you are done, run `rake clean`, `rake compile` and `nanoc view` (or `nanoc 
 You can edit the order in which the articles appear in a category page by editing the file `priorities/articles.yaml`
 
 Once you are done, run `rake clean`, `rake compile` and `nanoc view` (or `nanoc live`) to see your changes.
+
+
+## Contributing
+
+When submitting a pull request, apply the label `articles` and set yourself as assignee. Select `@SarahCaminiti1` and `@deandre` for review and, if your PR makes more substantive changes to copy, select `@itsalyse` as well for copy editing.
+
+Once all approvals are given and the pipeline is green, merge the PR yourself and delete the source branch.


### PR DESCRIPTION
Since this repo is open source and the team is growing, there should be contribution guidelines. This PR adds a first round — we should refine these guidelines in the future and probably place them in their own file.