### PR TITLE
Add article pointing to rate limit info

### DIFF
--- a/content/articles/api-rate-limit.markdown
+++ b/content/articles/api-rate-limit.markdown
@@ -5,6 +5,6 @@ categories:
 - API
 ---
 
-# API Documentation
+# API Rate Limit
 
 You can find more information about our API rate limit in our [Developer Documentation](https://developer.dnsimple.com/v2/#rate-limiting).

--- a/content/articles/api-rate-limit.markdown
+++ b/content/articles/api-rate-limit.markdown
@@ -1,0 +1,10 @@
+---
+title: API Rate Limit
+excerpt: You can find our API rate limit at the developer site.
+categories:
+- API
+---
+
+# API Documentation
+
+You can find more information about our API rate limit in our [Developer Documentation](https://developer.dnsimple.com/v2/#rate-limiting).


### PR DESCRIPTION
In 141602 a customer asks about increasing their rate limit. While this info is documented in the developer site, it's a bit buried. This PR cross-references the link to that site in the support articles.