### PR TITLE
Add information about auth&capture

### DIFF
--- a/content/articles/ordering-standard-certificate.markdown
+++ b/content/articles/ordering-standard-certificate.markdown
@@ -61,6 +61,11 @@ The order is the first step into getting an SSL certificate. It will create an S
 
     ![Purchase a Certificate](/files/dnsimple-certificate-purchase.png)
 
+    <info>
+    The certificate price will be held on your card immediately. Your card will be charged once the certificate is issued.
+    Should anything go wrong during the issuance, funds will be released.
+    </info>
+
 </div>
 
 

--- a/content/articles/ordering-standard-certificate.markdown
+++ b/content/articles/ordering-standard-certificate.markdown
@@ -62,8 +62,9 @@ The order is the first step into getting an SSL certificate. It will create an S
     ![Purchase a Certificate](/files/dnsimple-certificate-purchase.png)
 
     <info>
-    The certificate price will be held on your card immediately. Your card will be charged once the certificate is issued.
-    Should anything go wrong during the issuance, funds will be released.
+    The certificate price will be held on your card immediately.
+    Your card will be charged once the certificate is issued.
+    If the issuance fails, funds will be released.
     </info>
 
 </div>

--- a/content/articles/registering-domain.markdown
+++ b/content/articles/registering-domain.markdown
@@ -20,6 +20,11 @@ When applicable, we recommend opting for our "auto-renew" feature to avoid your 
 1. Choose whether you'd like Whois Privacy Protection or auto-renewal on the domain (if applicable).
 1. Click Register Domain.
 1. Provide contact details for the registrant of the domain, or choose a contact from those you've already created.
-1. Click Register Domain. You'll be charged immediately for the registration.
+1. Click Register Domain.
+
+<info>
+The total registration price will be held on your card immediately. Your card will be charged once the registration completes.
+Should anything go wrong during the registration, funds will be released.
+</info>
 
 </div>

--- a/content/articles/registering-domain.markdown
+++ b/content/articles/registering-domain.markdown
@@ -23,8 +23,9 @@ When applicable, we recommend opting for our "auto-renew" feature to avoid your 
 1. Click Register Domain.
 
 <info>
-The total registration price will be held on your card immediately. Your card will be charged once the registration completes.
-Should anything go wrong during the registration, funds will be released.
+The total registration price will be held on your card immediately.
+Your card will be charged once the registration completes.
+If the registration fails, funds will be released.
 </info>
 
 </div>

--- a/content/articles/renewing-domain.markdown
+++ b/content/articles/renewing-domain.markdown
@@ -23,5 +23,9 @@ By default, newly registered domains are set to auto-renew. If you've turned off
 
     ![Renew domain form](/files/renew-domain-form.png)
 
+<info>
+The total renewal price will be held on your card immediately. Your card will be charged once the renewal completes.
+Should anything go wrong during the renewal, funds will be released.
+</info>
 
 </div>

--- a/content/articles/renewing-domain.markdown
+++ b/content/articles/renewing-domain.markdown
@@ -24,8 +24,9 @@ By default, newly registered domains are set to auto-renew. If you've turned off
     ![Renew domain form](/files/renew-domain-form.png)
 
 <info>
-The total renewal price will be held on your card immediately. Your card will be charged once the renewal completes.
-Should anything go wrong during the renewal, funds will be released.
+The total renewal price will be held on your card immediately.
+Your card will be charged once the renewal completes.
+If renewal fails, funds will be released.
 </info>
 
 </div>

--- a/content/articles/renewing-standard-ssl-certificate.markdown
+++ b/content/articles/renewing-standard-ssl-certificate.markdown
@@ -39,6 +39,11 @@ These are the steps to renew your standard certificate:
 
     ![Renew a Certificate](/files/dnsimple-certificate-renewal.png)
 
+    <info>
+    The certificate renewal price will be held on your card immediately. Your card will be charged once the new certificate is issued.
+    Should anything go wrong during the issuance, funds will be released.
+    </info>
+
 </div>
 
 ## What's next?

--- a/content/articles/renewing-standard-ssl-certificate.markdown
+++ b/content/articles/renewing-standard-ssl-certificate.markdown
@@ -40,8 +40,9 @@ These are the steps to renew your standard certificate:
     ![Renew a Certificate](/files/dnsimple-certificate-renewal.png)
 
     <info>
-    The certificate renewal price will be held on your card immediately. Your card will be charged once the new certificate is issued.
-    Should anything go wrong during the issuance, funds will be released.
+    The certificate renewal price will be held on your card immediately.
+    Your card will be charged once the new certificate is issued.
+    If the issuance fails, funds will be released.
     </info>
 
 </div>

--- a/content/articles/transferring-domain.markdown
+++ b/content/articles/transferring-domain.markdown
@@ -64,7 +64,8 @@ Follow the instructions in the email. We cannot issue the transfer request to th
 Once you've authorized the transfer, you may have to **wait up to seven days for your domain transfer to complete.**
 
 <info>
-We will only charge your credit card for the transfer once it has completed.
+The total transfer price will be held on your card immediately. Your card will be charged once the transfer completes.
+Should anything go wrong during the transfer, funds will be released.
 </info>
 
 ## Transfer status

--- a/content/articles/transferring-domain.markdown
+++ b/content/articles/transferring-domain.markdown
@@ -64,8 +64,9 @@ Follow the instructions in the email. We cannot issue the transfer request to th
 Once you've authorized the transfer, you may have to **wait up to seven days for your domain transfer to complete.**
 
 <info>
-The total transfer price will be held on your card immediately. Your card will be charged once the transfer completes.
-Should anything go wrong during the transfer, funds will be released.
+The total transfer price will be held on your card immediately.
+Your card will be charged once the transfer completes.
+If the transfer fails, funds will be released.
 </info>
 
 ## Transfer status

--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -51,8 +51,9 @@ When you enable the service for the first time, a service cost will be charged t
     ![Purchase WHOIS Privacy](/files/whoisprivacy-purchase-page.png)
 
     <info>
-    The whois privacy price will be held on your card immediately. Your card will be charged once the whois privacy is enabled.
-    Should anything go wrong enabling whois privacy for your domain, funds will be released.
+    The whois privacy price will be held on your card immediately.
+    Your card will be charged once the whois privacy is enabled.
+    If whois privacy cannot be enabled on your domain, funds will be released.
     </info>
 
 </div>
@@ -78,8 +79,9 @@ When you enable the service for the first time, a service cost will be charged t
     ![Purchase WHOIS Privacy](/files/whoisprivacy-purchase-page.png)
 
     <info>
-    The whois privacy price will be held on your card immediately. Your card will be charged once the whois privacy is enabled.
-    Should anything go wrong enabling whois privacy for your domain, funds will be released.
+    The whois privacy price will be held on your card immediately.
+    Your card will be charged once the whois privacy is enabled.
+    If whois privacy cannot be enabled on your domain, funds will be released.
     </info>
 
 </div>
@@ -153,8 +155,9 @@ We'll send an email reminder when the WHOIS Privacy on a domain is due to expire
     ![Renew WHOIS Privacy](/files/whoisprivacy-renew-page.png)
 
     <info>
-    The whois privacy price will be held on your card immediately. Your card will be charged once the whois privacy service is renewed.
-    Should anything go wrong renewing whois privacy for your domain, funds will be released.
+    The whois privacy price will be held on your card immediately.
+    Your card will be charged once the whois privacy service is renewed.
+    If whois privacy cannot be renewed for your domain, funds will be released.
     </info>
 
 </div>

--- a/content/articles/whois-privacy.markdown
+++ b/content/articles/whois-privacy.markdown
@@ -50,6 +50,11 @@ When you enable the service for the first time, a service cost will be charged t
 
     ![Purchase WHOIS Privacy](/files/whoisprivacy-purchase-page.png)
 
+    <info>
+    The whois privacy price will be held on your card immediately. Your card will be charged once the whois privacy is enabled.
+    Should anything go wrong enabling whois privacy for your domain, funds will be released.
+    </info>
+
 </div>
 
 <div class="section-steps" markdown="1">
@@ -71,6 +76,11 @@ When you enable the service for the first time, a service cost will be charged t
     If this is the first time you're enabling the service for this domain, you'll need to purchase the service. The page will provide you with the purchase information. Click on <label>Purchase WHOIS Privacy</label> to immediately purchase and enable the WHOIS Privacy service for the domain.
 
     ![Purchase WHOIS Privacy](/files/whoisprivacy-purchase-page.png)
+
+    <info>
+    The whois privacy price will be held on your card immediately. Your card will be charged once the whois privacy is enabled.
+    Should anything go wrong enabling whois privacy for your domain, funds will be released.
+    </info>
 
 </div>
 
@@ -141,6 +151,11 @@ We'll send an email reminder when the WHOIS Privacy on a domain is due to expire
 1. To renew the WHOIS Privacy service, click on the <label>Renew WHOIS Privacy for 1 Year</label> button
 
     ![Renew WHOIS Privacy](/files/whoisprivacy-renew-page.png)
+
+    <info>
+    The whois privacy price will be held on your card immediately. Your card will be charged once the whois privacy service is renewed.
+    Should anything go wrong renewing whois privacy for your domain, funds will be released.
+    </info>
 
 </div>
 


### PR DESCRIPTION
Adds an  info block to explain how purchases will be charged on the affected pages:
- Domain registration
- Domain renewal
- Domain transfer
- Standard SSL certificate purchase
- Standard SSL certificate renewal
- Whois privacy (purchase and renewal)