### PR TITLE
Remove mention contacts or having to choose a contact from certificate related processes

### DIFF
--- a/content/articles/ordering-lets-encrypt-certificate.markdown
+++ b/content/articles/ordering-lets-encrypt-certificate.markdown
@@ -49,7 +49,6 @@ The order is the first step into getting an SSL certificate. It will create an S
 
     1.  [Read this article](/articles/ssl-certificate-names) to determine the appropriate host name of your SSL certificate.
     1.  For different plans, the names available will differ. If you have the ability to select alternate names for your certificate, do so. Otherwise, continue to the next step.
-    1.  Select a Contact from your contact list. The contact information will be used to generate the certificate request (CSR). We will generate a private key that is used for your CSR. Make sure to read our [private key policy](https://dnsimple.com/private-key-policy) before you order your certificate.
     1.  Select whether you would like to automatically renew the certificate. If you do so, the certificate will be renewed 30 days prior to expiration as recommended by Let's Encrypt.
     1.  Submit the order.
 </div>

--- a/content/articles/ordering-standard-certificate.markdown
+++ b/content/articles/ordering-standard-certificate.markdown
@@ -55,9 +55,8 @@ The order is the first step into getting an SSL certificate. It will create an S
 
     1.  [Read this article](/articles/ssl-certificate-names) to determine the appropriate host name of your SSL certificate.
     1.  Enter the certificate common name. Use an `*` to order a wildcard certificate.
-    1.  Select a Contact from your contact list. The contact information will be used to generate the certificate request (CSR).
-    2.  Leave the CSR option unchecked, unless you really need to provide a [custom CSR](/articles/what-is-csr). The easiest thing to do is to have us automatically generate the CSR (and a new private key to go with it). Make sure to read our [private key policy](https://dnsimple.com/private-key-policy).
-    3.  Submit the order.
+    1.  Leave the CSR option unchecked, unless you really need to provide a [custom CSR](/articles/what-is-csr). The easiest thing to do is to have us automatically generate the CSR (and a new private key to go with it). Make sure to read our [private key policy](https://dnsimple.com/private-key-policy).
+    1.  Submit the order.
 
     ![Purchase a Certificate](/files/dnsimple-certificate-purchase.png)
 

--- a/content/articles/what-is-csr.markdown
+++ b/content/articles/what-is-csr.markdown
@@ -12,7 +12,7 @@ The **Certificate Signing Request** (also **CSR** or **certification request**) 
 The CSR contains information that will be included in your certificate, such as the [common name](/articles/what-is-common-name) and the company/owner details. It also contains the public key that will be embedded in the certificate.
 
 <info>
-We automatically generate the CSR for you using the information from the contact associated with the certificate along with an unique public/private encryption key pair. This works for the majority of cases, including hosting platforms such as Heroku or Amazon.
+We automatically generate the CSR for you using an unique public/private encryption key pair. This works for the majority of cases, including hosting platforms such as Heroku or Amazon.
 
 The private key associated with the certificate will be available to download, once generated; from your certificate page.
 


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-business/issues/1500

Our system no longer requires our customers to provide a contact to purchase certificates. We now use a stub contact instead.

This PR updates articles about requesting certificates to remove mentions about having to choose a contact or how contacts are used during the process.

