### PR TITLE
Fixes a typo within our Unsubscribe from your DNSimple plan article

### DIFF
--- a/content/articles/cancel-subscription.markdown
+++ b/content/articles/cancel-subscription.markdown
@@ -7,7 +7,7 @@ categories:
 
 # Unsubscribe from your DNSimple plan
 
-After you unsubscribe from you DNSimple plan, we'll no longer charge you a monthly/yearly fee, and your domains will no longer resolve with us. You may resubscribe at any time, and your domains will resolve again.
+After you unsubscribe from your DNSimple plan, we'll no longer charge you a monthly/yearly fee, and your domains will no longer resolve with us. You may resubscribe at any time, and your domains will resolve again.
 
 <info>
 All your domains and records will remain in your account.


### PR DESCRIPTION
`After you unsubscribe from you DNSimple plan` should be `After you unsubscribe from your DNSimple plan`