### PR TITLE
Use dependabot for handling GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     labels:
       - task
       - dependencies
-      - backlog-dependencies
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This PR configures dependabot to take care of the versions used in the GitHub actions

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1400


## :mag: QA

- N/A

## :shipit: Pre/Post tasks

- N/A


## :shipit: Verification

- [ ] Ensure we have PR's for GitHub actions