### PR TITLE
Do not cancel jobs when a new commit is pushed to the branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     name: Test


### PR DESCRIPTION
This PR removes the concurrency settings from GitHub actions so that the job is not cancelled when a new commit is pushed to a branch

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1400

## :mag: QA

- N/A

## :shipit: Pre/Post tasks

- N/A

## :shipit: Verification

- [ ] CI runs are not cancelled when a new commit is pushed to same branch