### PR TITLE
Document Cloudflare one-click service deprecation

### DIFF
--- a/content/articles/cloudflare-service.markdown
+++ b/content/articles/cloudflare-service.markdown
@@ -20,10 +20,7 @@ categories:
 
 ## Cloudflare Integration
 
-Cloudflare has two integration methods:
-
-- Change your name servers to those supplied by Cloudflare. This method is available if you create an account via their website. To use this method first configure your DNS at Cloudflare. Next, "Manage" your domain at DNSimple, follow "Change Name Servers", and enter Cloudflare supplied name servers.
-- Through third-party "Certified Hosting Provider Partners". In this case DNSimple manages automatic provisioning and configuration of your Cloudflare account and DNS template. This greatly simplifies Cloudflare integration for your domain and allows you to continue using DNSimple as your [DNS service provider](https://dnsimple.com/about). "Manage" your domain, press the "One-Click Services" button near the top of the page, and "Add" Cloudflare.
+Currently the only way to use Cloudflare services is by means of [direct integraiton](#direct-integration).
 
 ### Direct Integration
 
@@ -33,37 +30,22 @@ If your domain is registered with DNSimple, follow these instructions to [config
 
 Furthermore, the direct integration doesn't allow selectively delegating only certain DNS records to Cloudflare. If you want to use Cloudflare only for a specific DNS record (e.g. for the main website) and use DNSimple for all the other records (e.g. MX email configurations), then use the one-click DNSimple integration.
 
-### DNSimple one-click integration
-
-DNSimple one-click integration allows you to use Cloudflare to proxy only a specific DNS record of a domain. This is the preferred option, for example, if you want to take advantage of Cloudflare's CDN and protection for the main website, maintaining the other DNS records in DNSimple.
-
-However, this approach has some limitations. For instance, Cloudflare doesn't allow to use the Universal SSL feature for domains or subdomains managed from a third-party provider. More information below.
-
-
-## DNS limitations
-
-Cloudflare caches your site content at locations across the globe. It uses DNS to route your requests to one of these locations depending on various factors. To support this technology within DNS limitations it is best to use a host name (i.e. www.example.com) rather than your domain apex (i.e. example.com). CNAME records at a domain apex are disallowed or will cause your DNS respond incorrectly. You may wish to use DNSimple's URL redirection record to forward requests from your domain apex to "www" for instance.
-
-
-## ALIAS record limitations
-
-DNSimple offers a virtual record type called an ALIAS record. This allows sites to work around a limitation of CNAME records at the domain apex by resolving to an A record at the name server. Our ALIAS record cannot be used with the Cloudflare service at this time. If you need this functionality then you may either use another CDN provider, or you may use Cloudflare directly by creating an account with them and delegating your registered domain to their name servers.
-
-
-## Universal SSL limitations
-
-[Cloudflare Universal SSL](https://www.cloudflare.com/ssl) is currently available only if you use Cloudflare directly (first integration method). It's not possible to use Cloudflare Universal SSL if you enable Cloudflare using DNSimple one-click service.
-
-
-## Enabling Cloudflare service {#enable}
+## DNSimple one-click integration (Deprecated)
 
 <warning>
-The Cloudflare service is deprecated as of December 2021.
+The Cloudflare one-click service is deprecated as of December 2021.
 </warning>
 
+DNSimple one-click integration allowed you to use Cloudflare to proxy only a specific DNS record of a domain. This was the preferred option, for example, if you want to take advantage of Cloudflare's CDN and protection for the main website, maintaining the other DNS records in DNSimple.
 
-## Disabling ClouldFlare service {#disable}
+However, this approach had some limitations. For instance, Cloudflare doesn't allow to use the Universal SSL feature for domains or subdomains managed from a third-party provider.
+
+## Disabling Clouldflare service {#disable}
 
 <warning>
-A known bug currently prevents the possibility to disable the Cloudflare service from the UI. Please [contact us](https://dnsimple.com/contact) if you want to disable the service.
+Removing the service will also remove any records created by the service. Thefore it is best to update your DNS records manually before removing the service to avoid any distruptions.<br>
+In case you are experiencing any issues in removing the service please [contact us](https://dnsimple.com/contact) and we can assist.
 </warning>
+
+1. Go to the DNS settings page of the domain you want to remove the service from.
+2. Under the "One-click services" section you should see the Cloudflare service. Click on the remove button for the Cloudflare service.

--- a/content/articles/cloudflare-service.markdown
+++ b/content/articles/cloudflare-service.markdown
@@ -20,7 +20,7 @@ categories:
 
 ## Cloudflare Integration
 
-Currently the only way to use Cloudflare services is by means of [direct integraiton](#direct-integration).
+You can use Cloudflare services with DNSimple via [direct integraiton](#direct-integration).
 
 ### Direct Integration
 


### PR DESCRIPTION
This PR documents the deprecation of the Cloudflare one-click service. It removes some of the technical considerations that were relevant to the service. It leaves the service description for historic reference while customers are still decommissioning the service in their accounts. It further adds instructions and notes on how to deactivate the service.

[Preview](https://deploy-preview-938--dnsimple-support.netlify.app/articles/cloudflare-service/)