### PR TITLE
Small TXT record doc improvements

### DIFF
--- a/content/articles/txt-record.markdown
+++ b/content/articles/txt-record.markdown
@@ -18,4 +18,4 @@ Common uses for TXT records:
 | [`SPF` record](/articles/spf-record/) | This record is used to indicate to mail exchanges which hosts are authorized to send mail for a domain. TXT records should be used instead of the special SPF record type. |
 | Site Verification Records | This record proves ownership of a domain and can be used to associate services such as Microsoft 365 and G-Suite to a specific domain. |
 
-TXT record content that is longer than 255 characters will automatically be broken into quoted strings of 255 characters maximum. If you have TXT record content that is longer than 255 characters, such as a DKIM value, our system will automatically handle those records, you do not need to break the record into quoted strings.
+TXT record content longer than 255 characters will automatically be broken into quoted strings of 255 characters maximum. If you have TXT record content that is longer than 255 characters, such as a DKIM value, our system will automatically handle those records; you do not need to break the record into quoted strings.

--- a/content/articles/txt-record.markdown
+++ b/content/articles/txt-record.markdown
@@ -15,7 +15,7 @@ Common uses for TXT records:
 |------|-------------|
 | [`DKIM` records](/articles/dkim-record) | This record stores important information used in the validation of email in transit. |
 | DMARC records | Domain-based Message Authentication Reporting and Conformance records mitigate phishing and spoofing email attacks. |
-| [`SPF` record](/articles/spf-record/) | This record is used to indicate to mail exchanges which hosts are authorized to send mail for a domain. |
+| [`SPF` record](/articles/spf-record/) | This record is used to indicate to mail exchanges which hosts are authorized to send mail for a domain. TXT records should be used instead of the special SPF record type. |
 | Site Verification Records | This record proves ownership of a domain and can be used to associate services such as Microsoft 365 and G-Suite to a specific domain. |
 
-TXT records have replaced SPF records.
+TXT record content that is longer than 255 characters will automatically be broken into quoted strings of 255 characters maximum. If you have TXT record content that is longer than 255 characters, such as a DKIM value, our system will automatically handle those records, you do not need to break the record into quoted strings.


### PR DESCRIPTION
- Add a note about TXT record handling when values are more than 255 characters
- Move the note about SPF records into the SPF row in the table.