### PR TITLE
Improve layout

### DIFF
--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -202,18 +202,3 @@
   color: $accent-color;
   border-left: 5px solid $accent-color;
 }
-
-.articles-list {
-  list-style-type: none;
-  padding: 0;
-}
-
-.articles-list-item {
-  padding: 5px 0;
-
-  &:before {
-    margin-right: 10px;
-    color: #dddddd;
-    @include font-awesome("\f054");
-  }
-}

--- a/content/assets/css/_template.scss
+++ b/content/assets/css/_template.scss
@@ -28,11 +28,6 @@ body {
   background-size: 900px 10px;
 }
 
-.sticky {
-  position: sticky;
-  top: 0;
-}
-
 .sidebar {
   display: none;
   z-index: 100;

--- a/content/assets/css/_template.scss
+++ b/content/assets/css/_template.scss
@@ -27,3 +27,27 @@ body {
   background-repeat: repeat-x;
   background-size: 900px 10px;
 }
+
+.sticky {
+  position: sticky;
+  top: 0;
+}
+
+.sidebar {
+  display: none;
+  z-index: 100;
+  background: white;
+}
+
+.is-active {
+  display: block;
+}
+
+@media (min-width: 1260px) {
+  .sidebar {
+    display: block;
+  }
+  #logo-nav, .sidebar-toggle {
+    display: none;
+  }
+}

--- a/content/assets/css/_typography.scss
+++ b/content/assets/css/_typography.scss
@@ -26,6 +26,7 @@ h1 {
   line-height: 1.3;
   margin-top: $base-unit;
   margin-bottom: $base-unit/1.5;
+  font-weight: bold;
 }
 
 h2 {

--- a/content/search/results.js
+++ b/content/search/results.js
@@ -16,7 +16,6 @@
     var $ul = document.createElement('ul');
 
     $h1.innerText = 'Search results';
-    $ul.className = 'articles-list';
 
     if (q.length)
       $h1.innerText += ' for "' + q + '"';
@@ -25,7 +24,6 @@
       var $li = document.createElement('li');
 
       $li.innerText = 'No results found';
-      $li.className = 'articles-list-item';
 
       $ul.appendChild($li);
     }
@@ -36,7 +34,6 @@
 
       $a.href = result.id;
       $a.innerHTML = result.title;
-      $li.className = 'articles-list-item';
 
       $li.appendChild($a);
       $ul.append($li);

--- a/layouts/category_index.html
+++ b/layouts/category_index.html
@@ -1,7 +1,6 @@
 <h1><%= @item[:h1] %></h1>
-
-<ul class="articles-list">
+<ul class="pl3">
   <% prioritize(:articles, @item[:items]).each do |item| %>
-    <li class="articles-list-item"><a href="<%= relative_path_to(@items[item.identifier]) %>"><%= item.attributes[:title] %></a></li>
+    <li><a href="<%= relative_path_to(@items[item.identifier]) %>" class="dib link pb1 underline"><%= item.attributes[:title] %></a></li>
   <% end %>
 </ul>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -21,62 +21,58 @@
 
 <body>
 
-  <header class="bg-white shadow-1">
-    <div class="mw8 center ph2">
-      <div class="flex justify-between pv2">
-        <div class="self-center w-80-ns w-100">
-          <div class="flex-ns">
-            <a href="/" title="DNSimple Help" class="self-center">
-              <img src="/assets/images/dnsimple-logo-support.svg" class="v-mid" alt="DNSimple Help">
-            </a>
-            <form action="/search/" class="relative w-100 w-70-ns js-search-form pl3-ns pt2 pt0-ns" method="get">
-              <input type="search" name="q" value="" id="input-search" class="input-search input-reset outline-0 w-100 ba br-pill b--black-20 pv2 ph3" placeholder="Search anything in our support docs" autocomplete="off">
-              <button type="submit" class="button-reset pv2 mt2 mt0-ns btn-input-search">
-                <i class="fa fa-search v-mid"></i>
-              </button>
-            </form>
+  <div class="mw9 center">
+    <nav class="sidebar pa3 pr4 fixed top-0 bottom-0 bw1 br b--light-gray">
+      <a href="/" title="DNSimple Help" class="dib pt2 self-center">
+        <img id="logo-sidebar" src="/assets/images/dnsimple-logo-support.svg" class="v-mid" alt="DNSimple Help">
+      </a>
+      <%= render "/sidebar.*" %>
+    </nav>
+    <div id="content" class="pa3 mw8 center">
+      <div class="flex-ns justify-between items-center">
+        <svg class="sidebar-toggle dib v-mid bg-white pointer" pointer-events="all" viewBox="0 0 100 80" width="20" height="40">
+          <rect width="100" height="10"></rect>
+          <rect y="30" width="100" height="10"></rect>
+          <rect y="60" width="100" height="10"></rect>
+        </svg>
+        <div class="flex-shrink-0 dib">
+          <img id="logo-nav" src="/assets/images/dnsimple-logo-support.svg" class="dib v-mid" alt="DNSimple Help">
+        </div>
+        <form action="/search/" class="relative w-100 w-60-ns js-search-form pt2 pt0-ns db dib-ns" method="get">
+          <input type="search" name="q" value="" id="input-search" class="input-search input-reset outline-0 w-100 ba br-pill b--black-20 pv2 ph3" placeholder="Search anything in our support docs" autocomplete="off">
+          <button type="submit" class="button-reset pv2 mt2 mt0-ns btn-input-search">
+            <i class="fa fa-search v-mid"></i>
+          </button>
+        </form>
+        <a href="https://dnsimple.com/campaign/support?utm_source=support&utm_medium=web&utm_content=cta-header" class="link br2 ph4 pv2 dn dib-l white bg-blue hover-white b">Free Trial</a>
+      </div>
+      <div id="main" class="pa3 mw7 center min-vh-100">
+        <%= yield %>
+      </div>
+      <footer class="pt5 pb5 mt6">
+        <div class="mw7 center ph2">
+          <div class="flex flex-wrap justify-between items-bottom">
+            <div class="w-100 w-70-ns tc tl-ns">
+              <img src="/assets/images/dnsimple-footer.svg" alt="DNSimple Help">
+              <h2 class="ma0 pt2 pb3 b">Get Help From Developers</h2>
+              <p class="measure">Everyone at DNSimple enjoys writing support docs.<br>We love answering your emails, too.</p>
+              <a href="https://dnsimple.com/campaign/support?utm_source=support&utm_medium=web&utm_content=cta-footer" class="link grow br2 ph4 pv3 mb2 dib white bg-blue hover-white b">Try us free for 30 days</a>
+            </div>
+            <div class="w-100 w-30-ns tc tr-ns">
+              <nav>
+                <a href="https://dnsimple.com/campaign/support?utm_source=support&utm_medium=web&utm_content=link-footer" class="pb2 db link">DNSimple.com</a>
+                <a href="https://blog.dnsimple.com/" class="pb2 db link">Blog</a>
+                <a href="https://dnsimple.com/contact" class="pb2 db link">Contact</a>
+                <a href="http://dnsimplestatus.com/" class="pb2 db link">Status</a>
+                <a href="https://developer.dnsimple.com/" class="db link">API</a>
+              </nav>
+              <p class="white-50 pt4 f6">&copy; <%= Time.now.year %> DNSimple Corporation</p>
+            </div>
           </div>
         </div>
-        <div class="dn db-ns self-center w-40 tr">
-          <a href="https://dnsimple.com/campaign/support?utm_source=support&utm_medium=web&utm_content=cta-header" class="link br2 ph4 pv2 dib white bg-blue hover-white b">Free Trial</a>
-        </div>
-      </div>
-    </div>
-  </header>
-
-  <div class="mw8 center ph2">
-    <div class="flex flex-wrap-reverse flex-wrap-ns">
-      <aside id="sidebar" class="w-100 w-30-ns" role="sidebar">
-        <%= render "/sidebar.*" %>
-      </aside>
-      <main id="main" class="w100 w-70-ns">
-        <%= yield %>
-      </main>
+      </footer>
     </div>
   </div>
-
-  <footer class="bg-navy bg-pipes pt5 pb5 mt6 white-80">
-    <div class="mw8 center ph2">
-      <div class="flex flex-wrap justify-between">
-        <div class="w-100 w-70-ns tc tl-ns">
-          <img src="/assets/images/dnsimple-footer.svg" alt="DNSimple Help">
-          <h2 class="white ma0 pt2 pb3 b">Get Help From Developers</h2>
-          <p class="measure">Everyone at DNSimple enjoys writing support docs.<br>We love answering your emails, too.</p>
-          <a href="https://dnsimple.com/campaign/support?utm_source=support&utm_medium=web&utm_content=cta-footer" class="link grow br2 ph4 pv3 mb2 dib white bg-blue hover-white b">Try us free for 30 days</a>
-        </div>
-        <div class="w-100 w-30-ns tc tl-ns">
-          <nav>
-            <a href="https://dnsimple.com/campaign/support?utm_source=support&utm_medium=web&utm_content=link-footer" class="pb2 db link white-80 hover-white">DNSimple.com</a>
-            <a href="https://blog.dnsimple.com/" class="pb2 db link white-80 hover-white">Blog</a>
-            <a href="https://dnsimple.com/contact" class="pb2 db link white-80 hover-white">Contact</a>
-            <a href="http://dnsimplestatus.com/" class="pb2 db link white-80 hover-white">Status</a>
-            <a href="https://developer.dnsimple.com/" class="db link white-80 hover-white">API</a>
-          </nav>
-          <p class="white-50 pt4 f6">&copy; <%= Time.now.year %> DNSimple Corporation</p>
-        </div>
-      </div>
-    </div>
-  </footer>
 
   <script type="text/javascript">
     document

--- a/layouts/sidebar.html
+++ b/layouts/sidebar.html
@@ -1,7 +1,5 @@
-<div class="sticky">
-  <ul class="pt2 pl0 list">
-  <% prioritize(:categories, all_categories) { |c| category_identifier(c) }.each do |category| %>
-    <li><%= link_to_category(category, class: "dib link pb1 black-60 hover-black underline-hover") %></li>
-  <% end %>
-  </ul>
-</div>
+<ul class="pt2 pl0 list">
+<% prioritize(:categories, all_categories) { |c| category_identifier(c) }.each do |category| %>
+  <li><%= link_to_category(category, class: "dib link pb1 black-60 hover-black underline-hover") %></li>
+<% end %>
+</ul>

--- a/layouts/sidebar.html
+++ b/layouts/sidebar.html
@@ -1,6 +1,7 @@
-<h4 class="sidebar-title">Categories</h4>
-<ul class="nav-list">
-<% prioritize(:categories, all_categories) { |c| category_identifier(c) }.each do |category| %>
-  <li <% if has_category?(category, item) %>class="active"<% end %>><%= link_to_category(category) %></li>
-<% end %>
-</ul>
+<div class="sticky">
+  <ul class="pt2 pl0 list">
+  <% prioritize(:categories, all_categories) { |c| category_identifier(c) }.each do |category| %>
+    <li><%= link_to_category(category, class: "dib link pb1 black-60 hover-black underline-hover") %></li>
+  <% end %>
+  </ul>
+</div>

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', (event) => {
+  const sidebarToggle = document.querySelector('.sidebar-toggle');
+  const sidebar = document.querySelector('.sidebar');
+  const content = document.querySelector('#content');
+
+  // show sidebar
+  sidebarToggle.addEventListener('click', () => {
+    sidebar.classList.toggle('is-active');
+    content.classList.toggle('o-30');
+  });
+
+  // click-away
+  content.addEventListener('click', (event) => {
+    if (sidebar.classList.contains('is-active') && !event.target.classList.contains('sidebar-toggle')) {
+      sidebar.classList.toggle('is-active');
+      content.classList.toggle('o-30');
+    }
+  });
+});


### PR DESCRIPTION
Before I start working on https://github.com/dnsimple/dnsimple-marketing/issues/544, I want to propose an improvement to the layout for this site. If approved, I'll be happy to deploy it also on the developer site. This is a spike and should be treated as such.

# Current layout issues

## A narrow container

The width of the main container is 1008px wide, which is narrow for today's standards. Line length on articles is good, but this width makes it harder to add new elements like I'm trying to do on https://github.com/dnsimple/dnsimple-marketing/issues/544
<img width="1205" alt="Screenshot 2022-09-26 at 16 48 52" src="https://user-images.githubusercontent.com/80610/192308951-9db4ffab-4cc4-455f-9637-c8327bf46dbe.png">

## Not really responsive

Navigation is poor. The categories shift from the left of the page to the bottom on smaller screen which is not a standard experience on mobile.

<img width="453" alt="Screenshot 2022-09-26 at 16 53 36" src="https://user-images.githubusercontent.com/80610/192309587-bed34468-ab01-4faf-a184-e3cb653a5d49.png">

## Confusing navigation

Articles that belong to different categories are good! But this feels like a bug and doesn't help the user.

<img width="878" alt="Screenshot 2022-09-26 at 15 34 55" src="https://user-images.githubusercontent.com/80610/192309919-bd75b107-e69c-4dff-afac-99f7acbb2f01.png">


# Proposal

- A responsive sidebar. It appears as fixed on mobile and tucked away in mobile.
- Do not highlight the different categories that an article belong to on the sidebar.

These are small changes, but I think they improve the experience with the support site. You can browse the full site on Netlify's preview link.

## QA

- Open https://deploy-preview-943--dnsimple-support.netlify.app/
- Find an article
- Use the sidebar
- Resize your viewport
- Toggle the sidebar
- Click away from the sidebar
