### PR TITLE
Introduce API Errors article

### DIFF
--- a/categories/api.yaml
+++ b/categories/api.yaml
@@ -8,5 +8,6 @@ Webhooks:
 - "Webhooks and API events"
 
 Troubleshooting:
+- "API Errors"
 - "API Rate Limit"
 - "Can I use DNSimple for drop catching?"

--- a/content/articles/api-errors.markdown
+++ b/content/articles/api-errors.markdown
@@ -1,0 +1,10 @@
+---
+title: API Errors
+excerpt: You can find more information about API errors in our developer site.
+categories:
+- API
+---
+
+# API Errors
+
+You can find more information about API errors in our [Developer Documentation](https://developer.dnsimple.com/v2/#errors).


### PR DESCRIPTION
Simple page that cross-links our developer documentation.
It has been listed under the _Troubleshooting_ section within the API category.