### PR TITLE
Updates title of multi-user account to match content of article

### DIFF
--- a/categories/account.yaml
+++ b/categories/account.yaml
@@ -16,7 +16,7 @@ Managing your account:
 - "Account Creation"
 - "Changing Email"
 - "Activity Tracking"
-- "Multi-User Accounts"
+- "Managing Multiple Members on One Account"
 - "Domain Access Control"
 - "Suspended Account"
 - "Google as an Identity Provider"

--- a/content/articles/account-users.markdown
+++ b/content/articles/account-users.markdown
@@ -1,5 +1,5 @@
 ---
-title: Multi-User Accounts
+title: Managing Multiple members on one account
 excerpt: How to manage the members on a multi-user DNSimple account.
 categories:
 - Account

--- a/content/articles/account-users.markdown
+++ b/content/articles/account-users.markdown
@@ -1,5 +1,5 @@
 ---
-title: Managing Multiple members on one account
+title: Managing Multiple Members on One Account
 excerpt: How to manage the members on a multi-user DNSimple account.
 categories:
 - Account
@@ -61,7 +61,7 @@ It's not possible to add a user whose email address is the same as the account. 
 
     ![Select the members tab](/files/add-member-account-link.png)
 
-1. Click the <label>Remove</label> button for the member you want to remove from the account, and confirm that you want to remove them. 
+1. Click the <label>Remove</label> button for the member you want to remove from the account, and confirm that you want to remove them.
 
 1. Once you've removed them from the account, that user should no longer show up on the members tab.
 


### PR DESCRIPTION
This PR updates the title of the existing "multi-user account" article to match the content of the article. We only talk about "multi-user" in the title and the excerpt, but the content of the article doesn't use that term.

This made finding this article through the category page and search much harder to locate since the title doesn't match what's in the page "Managing Multiple Members on One Account"

This PR changes the title from "Multi-User Accounts" to "Managing Multiple members on one account". I've kept the use of "multi-user" in the excerpt in case people use this term and to not hurt the SEO. But checking analytics shows that this page was not visited in 2022.