### PR TITLE
Fixes TLD agreements page

### DIFF
--- a/content/articles/tlds-registry-agreements.markdown
+++ b/content/articles/tlds-registry-agreements.markdown
@@ -267,7 +267,7 @@ Each TLD registry maintains its own policies that registrants must adhere to. Th
 | .social | [https://donuts.domains/about/policies/](https://donuts.domains/about/policies/) |
 | .software | [https://donuts.domains/about/policies/](https://donuts.domains/about/policies/) |
 | .solutions | [https://donuts.domains/about/policies/](https://donuts.domains/about/policies/) |
-| .spa | | [https://www.nic.spa/doc/REGISTRATION%20POLICY.pdf](https://www.nic.spa/doc/REGISTRATION%20POLICY.pdf) |
+| .spa | [https://www.nic.spa/doc/REGISTRATION%20POLICY.pdf](https://www.nic.spa/doc/REGISTRATION%20POLICY.pdf) |
 | .space | [https://radix.website/policies](https://radix.website/policies) |
 | .store | [https://radix.website/policies](https://radix.website/policies) |
 | .stream | [http://nic.stream/](http://nic.stream/) |


### PR DESCRIPTION
Removes a typo that creates an extra row.

## Before
<img width="1324" alt="Screenshot 2023-01-05 at 15 36 25" src="https://user-images.githubusercontent.com/80610/210804937-020003e8-62e3-48dc-9fd0-25a692e3adac.png">

## After
<img width="993" alt="Screenshot 2023-01-05 at 15 37 04" src="https://user-images.githubusercontent.com/80610/210805066-53a061dd-c03c-4a2a-afe2-26c36580fe28.png">
