### PR TITLE
Remove ns4.dnsimple.com from hosted name servers

### DIFF
--- a/content/articles/delegating-dnsimple-hosted.markdown
+++ b/content/articles/delegating-dnsimple-hosted.markdown
@@ -19,7 +19,6 @@ Pointing the name servers to DNSimple will cause the domain to resolve using the
     - ns1.dnsimple.com
     - ns2.dnsimple.com
     - ns3.dnsimple.com
-    - ns4.dnsimple.com
     - ns4.dnsimple-edge.org
 </div>
 


### PR DESCRIPTION
We should no longer encourage people to use the old ns4