### PR TITLE
add coredns as an integrated DNS provider

### DIFF
--- a/categories/dns.yaml
+++ b/categories/dns.yaml
@@ -35,7 +35,7 @@ Zones:
 - "DNS Hosting"
 - "Domain Zone Files"
 - "Dynamic DNS"
-- "Integrated DNS Providers"
+- "Integrated DNS Providers at DNSimple"
 - "Managing Integrated Zones"
 - "Deployment Editor"
 - "Reverse DNS Zones"

--- a/categories/integrations.yaml
+++ b/categories/integrations.yaml
@@ -1,8 +1,10 @@
 Apps:
 - "Slack App"
 
-Amazon Route 53:
-- "Integrated DNS Providers"
+Integrated DNS Providers:
+- "Integrated DNS Providers at DNSimple"
+- "Amazon Route 53"
+- "CoreDNS"
 
 Let's Encrypt:
 - "Let's Encrypt and DNSimple"

--- a/content/articles/deployment-editor.markdown
+++ b/content/articles/deployment-editor.markdown
@@ -7,7 +7,7 @@ categories:
 
 # Deployment Editor
 
-From the Deployment editor page, you can view the records for a zone at DNSimple and [integrated DNS providers](/articles/integrated-dns-providers) and sync them. The Deployment editor page groups records together so you can easily see which records are at which DNS provider(s).
+From the Deployment editor page, you can view the records and sync state for zones at DNSimple and any configured [integrated DNS providers](/articles/integrated-dns-providers). The Deployment editor page groups records together so you can easily see which records are at which DNS provider(s).
 
 <div class="section-steps" markdown="1">
 ##### Accessing the Deployment Editor from the Zones page

--- a/content/articles/integrated-dns-provider-amazon-route53.markdown
+++ b/content/articles/integrated-dns-provider-amazon-route53.markdown
@@ -1,0 +1,64 @@
+---
+title: Amazon Route 53
+excerpt: Link your Amazon Route 53 account to manage zones at DNSimple.
+categories:
+- DNS
+- Integrations
+---
+
+# Amazon Route 53
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+DNSimple supports the ability to view and manage zones that are deployed at [Amazon Route 53](https://aws.amazon.com/route53/).
+
+## Video Walk-through
+
+<div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
+  <iframe src="https://www.youtube.com/embed/4LsTT0pgBaQ" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+</div>
+
+## Supported Features
+
+- **Import integrated zones**: When you link Route 53 to your DNSimple account, all the zones hosted on Route 53 will be imported into DNSimple and listed on the [Zones](/articles/managing-integrated-zones) page.
+- **Management of integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Deployment Editor](/articles/deployment-editor). (See: The list of supported record types for Route 53)
+- **2-way Syncing of Records**: Sync your zone records from Route 53 to DNSimple, or from DNSimple to Route 53, with the [Deployment Editor](/articles/deployment-editor#record-syncing).
+
+## Prerequisites
+
+To link [Amazon Route 53](https://aws.amazon.com/route53/) as an integrated DNS provider, you need:
+
+- An [AWS access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for an AWS user with permission to manage public hosted zones at Route 53, including these permissions:
+  - route53:ListHostedZones
+  - route53:ListHostedZonesByName
+  - route53:CreateHostedZone
+  - route53:ListResourceRecordSets
+  - route53:ChangeResourceRecordSets
+  - route53:GetHostedZone
+  - route53:DeleteHostedZone
+- Administrator access to a DNSimple account
+
+## Supported Record Types
+
+The following Route 53 record types are supported for syncing and management at DNSimple:
+
+- A
+- AAAA
+- CNAME
+- MX
+- NS
+- PTR
+- SOA
+- SPF
+- SRV
+- TXT
+- URL
+
+<note>
+[URL records](/articles/url-record) are a custom DNSimple record type and do not have an equivalent in Route 53. When synced from DNSimple to Route 53, a URL record will be translated into an A record that points to our [redirector](/articles/redirector).
+</note>

--- a/content/articles/integrated-dns-provider-coredns.markdown
+++ b/content/articles/integrated-dns-provider-coredns.markdown
@@ -26,9 +26,9 @@ One of the following:
 
 ## Supported Features
 
-- **Sync integrated zone records**: Sync your zone records from DNSimple to multiple CoreDNS instances and verify the sync state with the [Deployment Editor](/articles/deployment-editor#record-syncing).
+- **Sync integrated zone records**: Sync your zone records from DNSimple to multiple CoreDNS instances, and verify the sync state with the [Deployment Editor](/articles/deployment-editor#record-syncing).
 
-The CoreDNS integrated provider supports one-way syncing of zone records configured at DNSimple. All records configured for the zone at DNSimple will be synced to CoreDNS on startup and again during each refresh interval. Zone records for any other integrated DNS provider must first be synced to DNSimple before they will be aviailable to CoreDNS instances.
+The CoreDNS integrated provider supports one-way syncing of zone records configured at DNSimple. All records configured for the zone at DNSimple will be synced to CoreDNS on startup and again during each refresh interval. Zone records for any other integrated DNS provider must first be synced to DNSimple before they will be available to CoreDNS instances.
 
 #### Supported record types
 

--- a/content/articles/integrated-dns-provider-coredns.markdown
+++ b/content/articles/integrated-dns-provider-coredns.markdown
@@ -28,6 +28,8 @@ One of the following:
 
 - **Sync integrated zone records**: Sync your zone records from DNSimple to multiple CoreDNS instances and verify the sync state with the [Deployment Editor](/articles/deployment-editor#record-syncing).
 
+The CoreDNS integrated provider supports one-way syncing of zone records configured at DNSimple. All records configured for the zone at DNSimple will be synced to CoreDNS on startup and again during each refresh interval. Zone records for any other integrated DNS provider must first be synced to DNSimple before they will be aviailable to CoreDNS instances.
+
 #### Supported record types
 
 All DNSimple record types can be synced to CoreDNS:
@@ -47,5 +49,5 @@ All DNSimple record types can be synced to CoreDNS:
 - URL
 
 <note>
-[Regional records](/articles/regional-records) are a custom DNSimple record feature and do not have an equivalent in CoreDNS. When synced from DNSimple to CoreDNS, you may specify one or more regions for an integrated zone in CoreDNS. More information about configuring regional zones can be found in the [coredns-dnsimple](https://github.com/dnsimple/coredns-dnsimple) documentation.
+[Regional records](/articles/regional-records) are a custom DNSimple record feature and do not have an equivalent in CoreDNS. When synced from DNSimple to CoreDNS, you may specify one or more regions for an integrated zone in CoreDNS. More information about configuring zones with regional records can be found in the [coredns-dnsimple](https://github.com/dnsimple/coredns-dnsimple) documentation.
 </note>

--- a/content/articles/integrated-dns-provider-coredns.markdown
+++ b/content/articles/integrated-dns-provider-coredns.markdown
@@ -49,5 +49,5 @@ All DNSimple record types can be synced to CoreDNS:
 - URL
 
 <note>
-[Regional records](/articles/regional-records) are a custom DNSimple record feature and do not have an equivalent in CoreDNS. When synced from DNSimple to CoreDNS, you may specify one or more regions for an integrated zone in CoreDNS. More information about configuring zones with regional records can be found in the [coredns-dnsimple](https://github.com/dnsimple/coredns-dnsimple) documentation.
+[Regional records](/articles/regional-records) are a custom DNSimple record feature and do not have an equivalent in CoreDNS. When synced from DNSimple to CoreDNS, you may specify one or more regions for an integrated zone in CoreDNS. More information about configuring zones with regional records can be found in the [coredns-dnsimple](https://github.com/dnsimple/coredns-dnsimple#regional-records) documentation.
 </note>

--- a/content/articles/integrated-dns-provider-coredns.markdown
+++ b/content/articles/integrated-dns-provider-coredns.markdown
@@ -31,7 +31,7 @@ DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns
 
 The CoreDNS integrated provider supports one-way syncing of zone records configured at DNSimple. All records configured for the zone at DNSimple will be synced to CoreDNS on startup and again during each refresh interval. Zone records for any other integrated DNS provider must first be synced to DNSimple before they will be available to CoreDNS instances.
 
-#### Supported record types
+#### Supported Record Types
 
 All DNSimple record types can be synced to CoreDNS:
 

--- a/content/articles/integrated-dns-provider-coredns.markdown
+++ b/content/articles/integrated-dns-provider-coredns.markdown
@@ -15,17 +15,18 @@ categories:
 
 ---
 
-DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns.io/).
+DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns.io/). The CoreDNS integrated provider is configured per zone and returns the current sync state for all zone records to the [Deployment Editor](/articles/deployment-editor#record-syncing).
 
 ## Prerequisites
 
-One of the following:
-- [DNSimple CoreDNS Binary](https://github.com/dnsimple/coredns-dnsimple/releases)
-- [DNSimple CoreDNS Docker Container](https://hub.docker.com/r/dnsimple/coredns-dnsimple/tags)
+- CoreDNS binary compiled with the [coredns-dnsimple](https://github.com/dnsimple/coredns-dnsimple) plugin
+  - [DNSimple CoreDNS Binary](https://github.com/dnsimple/coredns-dnsimple/releases)
+  - [DNSimple CoreDNS Docker Container](https://hub.docker.com/r/dnsimple/coredns-dnsimple/tags)
 - Administrator access to a DNSimple account
 
 ## Supported Features
 
+- **Management of integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Deployment Editor](/articles/deployment-editor).
 - **Sync integrated zone records**: Sync your zone records from DNSimple to multiple CoreDNS instances, and verify the sync state with the [Deployment Editor](/articles/deployment-editor#record-syncing).
 
 The CoreDNS integrated provider supports one-way syncing of zone records configured at DNSimple. All records configured for the zone at DNSimple will be synced to CoreDNS on startup and again during each refresh interval. Zone records for any other integrated DNS provider must first be synced to DNSimple before they will be available to CoreDNS instances.
@@ -38,6 +39,7 @@ All DNSimple record types can be synced to CoreDNS:
 - AAAA
 - ALIAS
 - CNAME
+- HINFO
 - MX
 - NS
 - POOL
@@ -45,9 +47,6 @@ All DNSimple record types can be synced to CoreDNS:
 - SOA
 - SPF
 - SRV
+- SSHFP
 - TXT
 - URL
-
-<note>
-[Regional records](/articles/regional-records) are a custom DNSimple record feature and do not have an equivalent in CoreDNS. When synced from DNSimple to CoreDNS, you may specify one or more regions for an integrated zone in CoreDNS. More information about configuring zones with regional records can be found in the [coredns-dnsimple](https://github.com/dnsimple/coredns-dnsimple#regional-records) documentation.
-</note>

--- a/content/articles/integrated-dns-provider-coredns.markdown
+++ b/content/articles/integrated-dns-provider-coredns.markdown
@@ -17,6 +17,12 @@ categories:
 
 DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns.io/). The CoreDNS integrated provider is configured per zone and returns the current sync state for all zone records to the [Deployment Editor](/articles/deployment-editor#record-syncing).
 
+## Video Walk-through
+
+<div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
+  <iframe src="https://www.youtube.com/embed/9yO2Oo_N1ms" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+</div>
+
 ## Prerequisites
 
 - CoreDNS binary compiled with the [coredns-dnsimple](https://github.com/dnsimple/coredns-dnsimple) plugin

--- a/content/articles/integrated-dns-provider-coredns.markdown
+++ b/content/articles/integrated-dns-provider-coredns.markdown
@@ -1,0 +1,51 @@
+---
+title: CoreDNS
+excerpt: Sync your zones managed at DNSimple to one or more CoreDNS instances.
+categories:
+- DNS
+- Integrations
+---
+
+# CoreDNS
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns.io/).
+
+## Prerequisites
+
+One of the following:
+- [DNSimple CoreDNS Binary](https://github.com/dnsimple/coredns-dnsimple/releases)
+- [DNSimple CoreDNS Docker Container](https://hub.docker.com/r/dnsimple/coredns-dnsimple/tags)
+- Administrator access to a DNSimple account
+
+## Supported Features
+
+- **Sync integrated zone records**: Sync your zone records from DNSimple to multiple CoreDNS instances and verify the sync state with the [Deployment Editor](/articles/deployment-editor#record-syncing).
+
+#### Supported record types
+
+All DNSimple record types can be synced to CoreDNS:
+
+- A
+- AAAA
+- ALIAS
+- CNAME
+- MX
+- NS
+- POOL
+- PTR
+- SOA
+- SPF
+- SRV
+- TXT
+- URL
+
+<note>
+[Regional records](/articles/regional-records) are a custom DNSimple record feature and do not have an equivalent in CoreDNS. When synced from DNSimple to CoreDNS, you may specify one or more regions for an integrated zone in CoreDNS. More information about configuring regional zones can be found in the [coredns-dnsimple](https://github.com/dnsimple/coredns-dnsimple) documentation.
+</note>

--- a/content/articles/integrated-dns-providers.markdown
+++ b/content/articles/integrated-dns-providers.markdown
@@ -36,7 +36,7 @@ DNSimple supports zone integration with the providers listed below.
 - [Amazon Route 53](/articles/integrated-dns-provider-amazon-route53)
 - [CoreDNS](/articles/integrated-dns-provider-coredns)
 
-## Supported record types {#supported-record-types}
+## Supported Record Types {#supported-record-types}
 
 Supported record types can be [synced](/articles/deployment-editor#record-syncing) from/to DNSimple to/from an integrated DNS provider.
 However, record fields not supported by DNSimple or the destination provider may be ignored. For example, record fields, like [record notes](/articles/record-notes) and [regional records](/articles/regional-records) information, may not be supported depending on the integrated DNS provider.

--- a/content/articles/integrated-dns-providers.markdown
+++ b/content/articles/integrated-dns-providers.markdown
@@ -33,8 +33,8 @@ To manage [integrated zones](/articles/managing-integrated-zones) from DNSimple,
 
 DNSimple supports zone integration with the providers listed below.
 
-[Amazon Route 53](/articles/integrated-dns-provider-amazon-route53)
-[CoreDNS](/articles/integrated-dns-provider-coredns)
+- [Amazon Route 53](/articles/integrated-dns-provider-amazon-route53)
+- [CoreDNS](/articles/integrated-dns-provider-coredns)
 
 ## Supported record types {#supported-record-types}
 

--- a/content/articles/integrated-dns-providers.markdown
+++ b/content/articles/integrated-dns-providers.markdown
@@ -1,6 +1,6 @@
 ---
-title: Integrated DNS Providers
-excerpt: Link an integrated DNS provider to your DNSimple account to manage zones at other authoritative DNS providers within DNSimple.
+title: Integrated DNS Providers at DNSimple
+excerpt: Link an integrated DNS provider to your DNSimple account to synchronize, manage, and view zones at other authoritative DNS providers within DNSimple.
 categories:
 - DNS
 - Integrations
@@ -15,75 +15,39 @@ categories:
 
 ---
 
-DNSimple supports the ability to view and manage zones that are deployed in other DNS providers external to DNSimple. DNSimple calls such providers "integrated DNS providers" and zones ["integrated zones"](/articles/managing-integrated-zones).
-
-## Video walk-through
-
-<div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/4LsTT0pgBaQ" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
-</div>
+DNSimple supports the ability to synchronize, manage, and view zones that are deployed in other DNS providers external to DNSimple. DNSimple calls such providers "integrated DNS providers" and zones ["integrated zones"](/articles/managing-integrated-zones).
 
 ## Supported Features
 
-- **Import integrated zones**: When you link an integrated DNS provider to your DNSimple account, all the zones hosted on that integrated DNS provider will be imported into DNSimple and listed on the [Zones](/articles/managing-integrated-zones) page.
-- **Management of integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Deployment Editor](/articles/deployment-editor). (Note: The list of supported record types differs based on the provider)
-- **2-way Syncing of Records**: Sync your zone records from the integrated zone to DNSimple, or from DNSimple to the integrated zone, with the [Deployment Editor](/articles/deployment-editor#record-syncing).
+- **Import integrated zones**: When you link an integrated DNS provider to your DNSimple account, zones hosted on that integrated DNS provider will be imported into DNSimple and listed on the [Zones](/articles/managing-integrated-zones) page.
+- **Manage integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Deployment Editor](/articles/deployment-editor).
+- **Sync integrated zone records**: Sync your zone records from the integrated zone to DNSimple, or from DNSimple to the integrated zone, with the [Deployment Editor](/articles/deployment-editor#record-syncing).
+
+<info>
+The list of supported features and record types differs for each integrated provider. See the provider page for more information.
+</info>
 
 ## Supported Integrated DNS Providers
 
 To manage [integrated zones](/articles/managing-integrated-zones) from DNSimple, you first have to link an integrated DNS provider to your DNSimple account.
 
-DNSimple supports the management of zones from the authoritative DNS providers listed below.
+DNSimple supports zone integration with the providers listed below.
 
-### Amazon Route 53
-
-DNSimple supports [Amazon Route 53](https://aws.amazon.com/route53/) as an integrated DNS provider.
-
-#### Prerequisites for linking Amazon Route 53 as an integrated DNS provider
-
-To link [Amazon Route 53](https://aws.amazon.com/route53/) as an integrated DNS provider, you need:
-
-- An [AWS access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for an AWS user with permission to manage public hosted zones at Route 53, including these permissions:
-  - route53:ListHostedZones
-  - route53:ListHostedZonesByName
-  - route53:CreateHostedZone
-  - route53:ListResourceRecordSets
-  - route53:ChangeResourceRecordSets
-  - route53:GetHostedZone
-  - route53:DeleteHostedZone
-- Administrator access to a DNSimple account
+[Amazon Route 53](/articles/integrated-dns-provider-amazon-route53)
+[CoreDNS](/articles/integrated-dns-provider-coredns)
 
 ## Supported record types {#supported-record-types}
 
-Records of supported record types can be [synced](/articles/deployment-editor#record-syncing) from/to DNSimple to/from an integrated DNS provider.
-However, record fields not supported by DNSimple or the destination provider will be ignored. For example, record fields, like [record notes](/articles/record-notes) and [regional record](/articles/regional-records) information, are only supported in DNSimple records. They will not be synced to the integrated DNS provider.
-
-#### Supported Route 53 record types
-
-The following Route 53 record types are supported for syncing and management at DNSimple:
-
-- A
-- AAAA
-- CNAME
-- MX
-- NS
-- PTR
-- SOA
-- SPF
-- SRV
-- TXT
-- URL
-
-<note>
-[URL records](/articles/url-record) are a custom DNSimple record type and do not have an equivalent in Route 53. When synced from DNSimple to Route 53, a URL record will be translated into an A record that points to our [redirector](/articles/redirector).
-</note>
+Supported record types can be [synced](/articles/deployment-editor#record-syncing) from/to DNSimple to/from an integrated DNS provider.
+However, record fields not supported by DNSimple or the destination provider may be ignored. For example, record fields, like [record notes](/articles/record-notes) and [regional records](/articles/regional-records) information, may not be supported depending on the integrated DNS provider.
 
 ## Linking an Integrated DNS Provider to your account
 
 1. At DNSimple, go to the <label>Account</label> page, and click the <label>Integrated Providers</label> tab.
-1. Under <label>Add an integrated DNS provider<label>, click the link button for the integrated DNS provider you want to link to your DNSimple account.
+1. Under <label>Add an integrated provider<label>, click the link button for the integrated DNS provider you want to link to your DNSimple account.
 ![Link an integrated DNS provider](/files/account-integrated-provider-link.png)
-1. Fill in the necessary credentials for your account at the integrated DNS provider and a nickname to identify this provider.
+1. Fill in any required paramaters for the integrated DNS provider configuration.
+1. Fill in any necessary credentials for your account at the integrated DNS provider.
 ![Enter integrated DNS provider credentials](/files/account-external-provider-link-credentials.png)
 1. After successfully linking the integrated DNS provider, you will arrive back on the DNSimple Integrated Providers page with the integrated DNS provider newly linked to your account, listed under "Linked providers". You can view the imported integrated zones from the [Zones](/articles/managing-integrated-zones) page, and manage and sync integrated zone records from the [Deployment Editor](/articles/deployment-editor).
 ![Account integrated providers list](/files/account-integrated-providers.png)

--- a/content/articles/managing-integrated-zones.markdown
+++ b/content/articles/managing-integrated-zones.markdown
@@ -7,7 +7,7 @@ categories:
 
 # Managing Integrated Zones
 
-From the Zones page, you can view the refreshed state of your DNSimple zones alongside zones imported from [integrated DNS providers](/articles/integrated-dns-providers).
+From the Zones page, you can view the refreshed state of your DNSimple zones alongside zones from [integrated DNS providers](/articles/integrated-dns-providers).
 
 <div class="section-steps" markdown="1">
 ##### Accessing the Zones page
@@ -18,15 +18,15 @@ From the Zones page, you can view the refreshed state of your DNSimple zones alo
 
     ![Zones link](/files/zones-domains-link.png)
 
-1.  In the popup menu, click the <label>Zones</label> link to navigate to the <label>Zones</label> page.
+1.  In the popup menu, click the <label>View as Zones</label> link to navigate to the <label>Zones</label> page.
 
     ![Zones link menu](/files/zones-domains-link-menu.png)
 
-1.  On the <label>Zones</label> page, the zones in your DNSimple account as well as integrated zones imported from [integrated DNS providers](/articles/integrated-dns-providers) will be listed. You can click any linked zone to enter the [Deployment Editor](/articles/deployment-editor) and manage the zone's records. The labels under the Providers column indicate which DNS provider(s) the zone can be managed at.
+1.  On the <label>Zones</label> page, the zones in your DNSimple account as well as zones from [integrated DNS providers](/articles/integrated-dns-providers) will be listed. You can click any linked zone to enter the [Deployment Editor](/articles/deployment-editor) and manage the zone's records. The labels under the Providers column indicate which DNS provider(s) the zone can be managed at.
 
     ![Zones page](/files/zones-page.png)
 </div>
 
 ## Refreshing and importing integrated zones {#refreshing-and-importing-integrated-zones}
 
-Loading the Zones page automatically [refreshes](/articles/deployment-editor#refreshing-integrated-zone-records) the current state of integrated zones and imports any new zones and their records from linked integrated DNS providers. The new zones and zone records will be fetched in the background upon page load, and the Zones page will automatically update to reflect them once ready.
+Loading the Zones page automatically [refreshes](/articles/deployment-editor#refreshing-integrated-zone-records) the current state of integrated zones and imports any new zones and their records from linked integrated DNS providers that support import. The new zones and zone records will be fetched in the background upon page load, and the Zones page will automatically update to reflect them once ready.


### PR DESCRIPTION
- Update categories page Integrations -> Integrated DNS Providers
- Moves general information about integrated DNS providers to Integrated DNS Providers at DNSimple
- Create new pages for:
  - Amazon Route 53
  - CoreDNS