### PR TITLE
Amazon Route 53 Integration Demo

### DIFF
--- a/categories/integrations.yaml
+++ b/categories/integrations.yaml
@@ -9,6 +9,7 @@ Integrated Domain Providers:
 Integrated DNS Providers:
 - "Integrated DNS Providers at DNSimple"
 - "Amazon Route 53"
+- "Amazon Route 53 Integration Demo"
 - "CoreDNS"
 
 Let's Encrypt:

--- a/content/articles/amazon-route-53-integration-demo.markdown
+++ b/content/articles/amazon-route-53-integration-demo.markdown
@@ -25,25 +25,25 @@ This section will prepare your AWS account for integrating with DNS, by setting 
 
 1. Create a new IAM policy using the [AWS console](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/policies/create?step=addPermissions) with the following JSON definition:
   ```json
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Sid": "",
-        "Effect": "Allow",
-        "Action": [
-          "route53:ChangeResourceRecordSets",
-          "route53:CreateHostedZone",
-          "route53:DeleteHostedZone",
-          "route53:GetHostedZone",
-          "route53:ListHostedZones",
-          "route53:ListHostedZonesByName",
-          "route53:ListResourceRecordSets"
-        ],
-        "Resource": "*"
-      }
-    ]
-  }
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "route53:ChangeResourceRecordSets",
+        "route53:CreateHostedZone",
+        "route53:DeleteHostedZone",
+        "route53:GetHostedZone",
+        "route53:ListHostedZones",
+        "route53:ListHostedZonesByName",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
   ```
 1. Create a new IAM user in the [AWS console](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/users/create) for this integration, attaching the previously-created policy directly.
 1. In the *Security credentials* tab for the IAM user that has just been created:

--- a/content/articles/amazon-route-53-integration-demo.markdown
+++ b/content/articles/amazon-route-53-integration-demo.markdown
@@ -17,7 +17,7 @@ categories:
 
 DNSimple can act as the central control plane and source of truth for all of your DNS zones and records, providing an easy, scalable way to gain visibility and management of all your DNS requirements across many services at scale. Many customers and organizations use multiple DNS vendors and on-premise DNS solutions for security, availability, and redundancy. Our integrations feature makes this simple, allowing you to leverage DNSimple's user friendly and powerful interface in conjunction with your existing DNS infrastructure and setup, wherever it may be. Learn more in our [blog post](https://blog.dnsimple.com/2023/06/manage-aws-routes-in-dnsimple/).
 
-In this demo, we'll demonstrate this power and flexibility by setting up an integration with Amazon Route 53. You'll need an AWS account with permissions to create new IAM users and policies, as well as Route 53 zones. Step-by-step instructions are provided in detail, and we'll do everything through UIs in the browser, so no APIs or CLIs are needed.
+We'll demonstrate this power and flexibility by setting up an integration with Amazon Route 53. You'll need an AWS account with permissions to create new IAM users and policies, as well as Route 53 zones. Step-by-step instructions are provided in detail, and we'll do everything through UIs in the browser, so no APIs or CLIs are needed.
 
 ## Setting up AWS
 
@@ -46,7 +46,7 @@ This section will prepare your AWS account for integrating with DNS by setting u
 }
   ```
 1. Create a new IAM user in the [AWS console](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/users/create) for this integration, attaching the previously-created policy directly.
-1. In the *Security credentials* tab for the IAM user that has just been created:
+1. In the *Security credentials* tab for the IAM user you just created:
   - Press *Create access key* to generate a new pair of credentials for the integration.
   - Select *Other* for the use case.
   - Provide a description for the credentials, e.g. "DNSimple Route 53 Integration".
@@ -68,14 +68,14 @@ To demonstrate the synchronization, we'll create a Route 53 zone with some popul
 
 We need to prepare our DNSimple account and inform it of our AWS account to establish the connection.
 
-1. Go to your DNSimple account settings and select *Integrated Providers*.
+1. Go to your DNSimple account settings, and select *Integrated Providers*.
 1. Next, go to *Route53*, and select *Link*.
 1. Provide the AWS credentials and a nickname for the integration.
 1. You should now see your AWS hosted zones listed in your DNSimple account.
 
 ## Syncing DNS records from Route 53
 
-Let's transfer our zones and records from Route 53 to DNSimple to show how easy it is to get started quickly and set up DNSimple as your control plane.
+Let's transfer our zones and records from Route 53 to DNSimple to show how easy it is to get started and set up DNSimple as your control plane.
 
 1. In your DNSimple account, go to the relevant zone.
 1. Select *Sync records*.
@@ -86,7 +86,7 @@ Let's transfer our zones and records from Route 53 to DNSimple to show how easy 
 
 ## Updating your zone
 
-Now we can use DNSimple as our central control plane and source of truth for all our DNS management needs across all services. Let's see how we can do this, by making a change in the central control plane and having it propagate to Route 53 seamlessly.
+Now we can use DNSimple as our central control plane and source of truth for all our DNS management needs across all services. Let's see it in action — we'll make a change in the central control plane and have it propagate to Route 53 seamlessly.
 
 1. In your DNSimple zone, add a few records, and make some changes to existing ones.
 1. Now, you can propagate them to Route 53 to keep your zone there in sync. Select *Sync records*.
@@ -101,11 +101,11 @@ You should manage your DNS records exclusively through the DNSimple app and your
 
 1. Using the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#), make some changes to the records in your Amazon Route 53 zone.
 1. Using the DNSimple app, go to your DNSimple zone, and select *Refresh records*.
-1. You should see those Route 53 zone changes now. To copy them over to your DNSimple zone as a one-off, follow the instructions under [**Sync DNS records from Route 53**](#sync-dns-records-from-route-53).
+1. You should see the Route 53 zone changes. To copy them over to your DNSimple zone as a one-off, follow the instructions under [**Sync DNS records from Route 53**](#sync-dns-records-from-route-53).
 
 ## Next steps
 
-You can now build on this simple setup to experiment a bit and see what you can achieve with DNSimple as your control plane. Some examples:
+You can now build on this simple setup to experiment a bit, and see what you can achieve with DNSimple as your control plane. Some examples:
 
 - Try creating in reverse; i.e. create a new DNSimple zone first, and then synchronize it to Route 53.
 - Add more integrations, for example [GoDaddy](https://support.dnsimple.com/articles/integrated-domain-provider-godaddy/).

--- a/content/articles/amazon-route-53-integration-demo.markdown
+++ b/content/articles/amazon-route-53-integration-demo.markdown
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-DNSimple can act as the central control plane and source of truth for all of your DNS zones and records, providing an easy, scalable way to gain visibility and management of all your DNS requirements across many services at scale. Many customers and organisations use multiple DNS vendors and on-premise DNS solutions for security, availability, and redundancy. Our integrations feature makes this simple, allowing you to leverage DNSimple's user friendly and powerful interface in conjunction with your existing DNS infrastructure and setup, wherever it may be. Learn more on our [blog post](https://blog.dnsimple.com/2023/06/manage-aws-routes-in-dnsimple/).
+DNSimple can act as the central control plane and source of truth for all of your DNS zones and records, providing an easy, scalable way to gain visibility and management of all your DNS requirements across many services at scale. Many customers and organizations use multiple DNS vendors and on-premise DNS solutions for security, availability, and redundancy. Our integrations feature makes this simple, allowing you to leverage DNSimple's user friendly and powerful interface in conjunction with your existing DNS infrastructure and setup, wherever it may be. Learn more on our [blog post](https://blog.dnsimple.com/2023/06/manage-aws-routes-in-dnsimple/).
 
 In this demo, we will demonstrate this power and flexibility by setting up an integration with Amazon Route 53. You will need an AWS account with permissions to create new IAM users and policies, as well as Route 53 zones. Step-by-step instructions are provided in detail, and all will be done through UIs in the browser, so no APIs or CLIs are needed.
 

--- a/content/articles/amazon-route-53-integration-demo.markdown
+++ b/content/articles/amazon-route-53-integration-demo.markdown
@@ -15,13 +15,13 @@ categories:
 
 ---
 
-DNSimple can act as the central control plane and source of truth for all of your DNS zones and records, providing an easy, scalable way to gain visibility and management of all your DNS requirements across many services at scale. Many customers and organizations use multiple DNS vendors and on-premise DNS solutions for security, availability, and redundancy. Our integrations feature makes this simple, allowing you to leverage DNSimple's user friendly and powerful interface in conjunction with your existing DNS infrastructure and setup, wherever it may be. Learn more on our [blog post](https://blog.dnsimple.com/2023/06/manage-aws-routes-in-dnsimple/).
+DNSimple can act as the central control plane and source of truth for all of your DNS zones and records, providing an easy, scalable way to gain visibility and management of all your DNS requirements across many services at scale. Many customers and organizations use multiple DNS vendors and on-premise DNS solutions for security, availability, and redundancy. Our integrations feature makes this simple, allowing you to leverage DNSimple's user friendly and powerful interface in conjunction with your existing DNS infrastructure and setup, wherever it may be. Learn more in our [blog post](https://blog.dnsimple.com/2023/06/manage-aws-routes-in-dnsimple/).
 
-In this demo, we will demonstrate this power and flexibility by setting up an integration with Amazon Route 53. You will need an AWS account with permissions to create new IAM users and policies, as well as Route 53 zones. Step-by-step instructions are provided in detail, and all will be done through UIs in the browser, so no APIs or CLIs are needed.
+In this demo, we'll demonstrate this power and flexibility by setting up an integration with Amazon Route 53. You'll need an AWS account with permissions to create new IAM users and policies, as well as Route 53 zones. Step-by-step instructions are provided in detail, and we'll do everything through UIs in the browser, so no APIs or CLIs are needed.
 
 ## Setting up AWS
 
-This section will prepare your AWS account for integrating with DNS, by setting up the users and permissions as necessary for the integration to work.
+This section will prepare your AWS account for integrating with DNS by setting up the users and permissions necessary for the integration to work.
 
 1. Create a new IAM policy using the [AWS console](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/policies/create?step=addPermissions) with the following JSON definition:
   ```json
@@ -49,12 +49,12 @@ This section will prepare your AWS account for integrating with DNS, by setting 
 1. In the *Security credentials* tab for the IAM user that has just been created:
   - Press *Create access key* to generate a new pair of credentials for the integration.
   - Select *Other* for the use case.
-  - Provide a description for the credentials e.g. "DNSimple Route 53 Integration".
-  - Take note of the access key and secret access key, they'll be used soon.
+  - Provide a description for the credentials, e.g. "DNSimple Route 53 Integration".
+  - Note the access key and secret access key, they'll be used soon.
 
 ## Creating a Route 53 zone
 
-To demonstrate the synchronization, we'll create a Route 53 zone with some populated data, and then see how we can synchronize it with DNSimple.
+To demonstrate the synchronization, we'll create a Route 53 zone with some populated data, then see how we can synchronize it with DNSimple.
 
 1. In the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#CreateHostedZone), create a new hosted zone.
   - Enter the domain name.
@@ -69,8 +69,8 @@ To demonstrate the synchronization, we'll create a Route 53 zone with some popul
 We need to prepare our DNSimple account and inform it of our AWS account to establish the connection.
 
 1. Go to your DNSimple account settings and select *Integrated Providers*.
-1. Next to *Route53* select *Link*.
-1. Provide the AWS credentials, and a nickname for the integration.
+1. Next, go to *Route53*, and select *Link*.
+1. Provide the AWS credentials and a nickname for the integration.
 1. You should now see your AWS hosted zones listed in your DNSimple account.
 
 ## Syncing DNS records from Route 53
@@ -86,20 +86,20 @@ Let's transfer our zones and records from Route 53 to DNSimple to show how easy 
 
 ## Updating your zone
 
-Now that all our zones and records are in DNS, we can use DNSimple as our central control plane and source of truth for all our DNS management needs across all services. Let's see how we can do this, by making a change in the central control plane and having it propagate to Route 53 seamlessly.
+Now we can use DNSimple as our central control plane and source of truth for all our DNS management needs across all services. Let's see how we can do this, by making a change in the central control plane and having it propagate to Route 53 seamlessly.
 
 1. In your DNSimple zone, add a few records, and make some changes to existing ones.
 1. Now, you can propagate them to Route 53 to keep your zone there in sync. Select *Sync records*.
 1. Choose *DNSimple* for *Source*.
 1. Choose *Route53 - AWS* for *Destination*.
 1. Confirm the synchronization.
-1. Check the corresponding Route 53 zone in the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#) to ensure that the changes have been applied there as well.
+1. Check the corresponding Route 53 zone in the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#) to ensure the changes have been applied there as well.
 
 ## Synchronizing external changes
 
-You should manage your DNS records exclusively through the DNSimple app and your DNSimple zone, as your central control plane and source of truth. However, if you update your Amazon Route 53 zone (accidentally or intentionally), you can reflect those changes back into your DNSimple zone to restore it as the central source.
+You should manage your DNS records exclusively through the DNSimple app and your DNSimple zone as your central control plane and source of truth. However, if you update your Amazon Route 53 zone (accidentally or intentionally), you can reflect those changes back into your DNSimple zone to restore it as the central source.
 
-1. Using the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#), In your Amazon Route 53 zone, make some changes to the records.
+1. Using the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#), make some changes to the records in your Amazon Route 53 zone.
 1. Using the DNSimple app, go to your DNSimple zone, and select *Refresh records*.
 1. You should see those Route 53 zone changes now. To copy them over to your DNSimple zone as a one-off, follow the instructions under [**Sync DNS records from Route 53**](#sync-dns-records-from-route-53).
 
@@ -107,7 +107,7 @@ You should manage your DNS records exclusively through the DNSimple app and your
 
 You can now build on this simple setup to experiment a bit and see what you can achieve with DNSimple as your control plane. Some examples:
 
-- Try creating in reverse i.e. create a new DNSimple zone first, and then synchronize it to Route 53.
+- Try creating in reverse; i.e. create a new DNSimple zone first, and then synchronize it to Route 53.
 - Add more integrations, for example [GoDaddy](https://support.dnsimple.com/articles/integrated-domain-provider-godaddy/).
 - Link another AWS account.
 - Use our [CoreDNS integration](https://support.dnsimple.com/articles/integrated-dns-provider-coredns/) for self-hosted DNS in your private on-premise network.

--- a/content/articles/amazon-route-53-integration-demo.markdown
+++ b/content/articles/amazon-route-53-integration-demo.markdown
@@ -1,12 +1,12 @@
 ---
-title: AWS Route 53 integration demo
-excerpt: An introductory demo to integrating AWS Route 53 with DNSimple.
+title: Amazon Route 53 Integration Demo
+excerpt: An introductory demo to integrating Amazon Route 53 with DNSimple.
 categories:
 - DNS
 - Integrations
 ---
 
-# AWS Route 53 Integration Demo
+# Amazon Route 53 Integration Demo
 
 ### Table of Contents {#toc}
 
@@ -17,7 +17,7 @@ categories:
 
 DNSimple can act as the central control plane and source of truth for all of your DNS zones and records, providing an easy, scalable way to gain visibility and management of all your DNS requirements across many services at scale. Many customers and organisations use multiple DNS vendors and on-premise DNS solutions for security, availability, and redundancy. Our integrations feature makes this simple, allowing you to leverage DNSimple's user friendly and powerful interface in conjunction with your existing DNS infrastructure and setup, wherever it may be. Learn more on our [blog post](https://blog.dnsimple.com/2023/06/manage-aws-routes-in-dnsimple/).
 
-In this demo, we will demonstrate this power and flexibility by setting up an integration with AWS Route 53. You will need an AWS account with permissions to create new IAM users and policies, as well as Route 53 zones. Step-by-step instructions are provided in detail, and all will be done through UIs in the browser, so no APIs or CLIs are needed.
+In this demo, we will demonstrate this power and flexibility by setting up an integration with Amazon Route 53. You will need an AWS account with permissions to create new IAM users and policies, as well as Route 53 zones. Step-by-step instructions are provided in detail, and all will be done through UIs in the browser, so no APIs or CLIs are needed.
 
 ## Setting up AWS
 
@@ -97,9 +97,9 @@ Now that all our zones and records are in DNS, we can use DNSimple as our centra
 
 ## Synchronizing external changes
 
-You should manage your DNS records exclusively through the DNSimple app and your DNSimple zone, as your central control plane and source of truth. However, if you update your AWS Route 53 zone (accidentally or intentionally), you can reflect those changes back into your DNSimple zone to restore it as the central source.
+You should manage your DNS records exclusively through the DNSimple app and your DNSimple zone, as your central control plane and source of truth. However, if you update your Amazon Route 53 zone (accidentally or intentionally), you can reflect those changes back into your DNSimple zone to restore it as the central source.
 
-1. Using the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#), In your AWS Route 53 zone, make some changes to the records.
+1. Using the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#), In your Amazon Route 53 zone, make some changes to the records.
 1. Using the DNSimple app, go to your DNSimple zone, and select *Refresh records*.
 1. You should see those Route 53 zone changes now. To copy them over to your DNSimple zone as a one-off, follow the instructions under [**Sync DNS records from Route 53**](#sync-dns-records-from-route-53).
 

--- a/content/articles/amazon-route-53-integration-demo.markdown
+++ b/content/articles/amazon-route-53-integration-demo.markdown
@@ -73,7 +73,7 @@ We need to prepare our DNSimple account and inform it of our AWS account to esta
 1. Provide the AWS credentials, and a nickname for the integration.
 1. You should now see your AWS hosted zones listed in your DNSimple account.
 
-## Sync DNS records from Route 53
+## Syncing DNS records from Route 53
 
 Let's transfer our zones and records from Route 53 to DNSimple to show how easy it is to get started quickly and set up DNSimple as your control plane.
 
@@ -84,7 +84,7 @@ Let's transfer our zones and records from Route 53 to DNSimple to show how easy 
 1. Confirm the synchronization.
 1. The records you entered previously in the AWS console for your Route 53 zone should now be the only records in your DNSimple zone, as shown.
 
-## Update your zone
+## Updating your zone
 
 Now that all our zones and records are in DNS, we can use DNSimple as our central control plane and source of truth for all our DNS management needs across all services. Let's see how we can do this, by making a change in the central control plane and having it propagate to Route 53 seamlessly.
 

--- a/content/articles/route53-integration-demo.markdown
+++ b/content/articles/route53-integration-demo.markdown
@@ -54,7 +54,7 @@ This section will prepare your AWS account for integrating with DNS, by setting 
 
 ## Creating a Route 53 zone
 
-To demonstrate the synchronisation, we'll create a Route 53 zone with some populated data, and then see how we can synchronise it with DNSimple.
+To demonstrate the synchronization, we'll create a Route 53 zone with some populated data, and then see how we can synchronize it with DNSimple.
 
 1. In the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#CreateHostedZone), create a new hosted zone.
   - Enter the domain name.
@@ -81,7 +81,7 @@ Let's transfer our zones and records from Route 53 to DNSimple to show how easy 
 1. Select *Sync records*.
 1. Choose *Route53 - AWS* for *Source*.
 1. Choose *DNSimple* for *Destination*.
-1. Confirm the synchronisation.
+1. Confirm the synchronization.
 1. The records you entered previously in the AWS console for your Route 53 zone should now be the only records in your DNSimple zone, as shown.
 
 ## Update your zone

--- a/content/articles/route53-integration-demo.markdown
+++ b/content/articles/route53-integration-demo.markdown
@@ -1,0 +1,113 @@
+---
+title: AWS Route 53 integration demo
+excerpt: An introductory demo to integrating AWS Route 53 with DNSimple.
+categories:
+- DNS
+- Integrations
+---
+
+# AWS Route 53 Integration Demo
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+DNSimple can act as the central control plane and source of truth for all of your DNS zones and records, providing an easy, scalable way to gain visibility and management of all your DNS requirements across many services at scale. Many customers and organisations use multiple DNS vendors and on-premise DNS solutions for security, availability, and redundancy. Our integrations feature makes this simple, allowing you to leverage DNSimple's user friendly and powerful interface in conjunction with your existing DNS infrastructure and setup, wherever it may be. Learn more on our [blog post](https://blog.dnsimple.com/2023/06/manage-aws-routes-in-dnsimple/).
+
+In this demo, we will demonstrate this power and flexibility by setting up an integration with AWS Route 53. You will need an AWS account with permissions to create new IAM users and policies, as well as Route 53 zones. Step-by-step instructions are provided in detail, and all will be done through UIs in the browser, so no APIs or CLIs are needed.
+
+## Setting up AWS
+
+This section will prepare your AWS account for integrating with DNS, by setting up the users and permissions as necessary for the integration to work.
+
+1. Create a new IAM policy using the [AWS console](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/policies/create?step=addPermissions) with the following JSON definition:
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "",
+        "Effect": "Allow",
+        "Action": [
+          "route53:ChangeResourceRecordSets",
+          "route53:CreateHostedZone",
+          "route53:DeleteHostedZone",
+          "route53:GetHostedZone",
+          "route53:ListHostedZones",
+          "route53:ListHostedZonesByName",
+          "route53:ListResourceRecordSets"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+1. Create a new IAM user in the [AWS console](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/users/create) for this integration, attaching the previously-created policy directly.
+1. In the *Security credentials* tab for the IAM user that has just been created:
+  - Press *Create access key* to generate a new pair of credentials for the integration.
+  - Select *Other* for the use case.
+  - Provide a description for the credentials e.g. "DNSimple Route 53 Integration".
+  - Take note of the access key and secret access key, they'll be used soon.
+
+## Creating a Route 53 zone
+
+To demonstrate the synchronisation, we'll create a Route 53 zone with some populated data, and then see how we can synchronise it with DNSimple.
+
+1. In the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#CreateHostedZone), create a new hosted zone.
+  - Enter the domain name.
+  - Choose *Public hosted zone* for the type.
+1. Create one or more records for the newly created zones. Some examples include:
+  - `A www 1.1.1.1`
+  - `CNAME static mybucket.s3.amazonaws.com`
+  - `MX mail smtp.messaging-engine.com`
+
+## Setting up the integration
+
+We need to prepare our DNSimple account and inform it of our AWS account to establish the connection.
+
+1. Go to your DNSimple account settings and select *Integrated Providers*.
+1. Next to *Route53* select *Link*.
+1. Provide the AWS credentials, and a nickname for the integration.
+1. You should now see your AWS hosted zones listed in your DNSimple account.
+
+## Sync DNS records from Route 53
+
+Let's transfer our zones and records from Route 53 to DNSimple to show how easy it is to get started quickly and set up DNSimple as your control plane.
+
+1. In your DNSimple account, go to the relevant zone.
+1. Select *Sync records*.
+1. Choose *Route53 - AWS* for *Source*.
+1. Choose *DNSimple* for *Destination*.
+1. Confirm the synchronisation.
+1. The records you entered previously in the AWS console for your Route 53 zone should now be the only records in your DNSimple zone, as shown.
+
+## Update your zone
+
+Now that all our zones and records are in DNS, we can use DNSimple as our central control plane and source of truth for all our DNS management needs across all services. Let's see how we can do this, by making a change in the central control plane and having it propagate to Route 53 seamlessly.
+
+1. In your DNSimple zone, add a few records, and make some changes to existing ones.
+1. Now, you can propagate them to Route 53 to keep your zone there in sync. Select *Sync records*.
+1. Choose *DNSimple* for *Source*.
+1. Choose *Route53 - AWS* for *Destination*.
+1. Confirm the synchronization.
+1. Check the corresponding Route 53 zone in the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#) to ensure that the changes have been applied there as well.
+
+## Synchronizing external changes
+
+You should manage your DNS records exclusively through the DNSimple app and your DNSimple zone, as your central control plane and source of truth. However, if you update your AWS Route 53 zone (accidentally or intentionally), you can reflect those changes back into your DNSimple zone to restore it as the central source.
+
+1. Using the [AWS console](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones?region=us-east-1#), In your AWS Route 53 zone, make some changes to the records.
+1. Using the DNSimple app, go to your DNSimple zone, and select *Refresh records*.
+1. You should see those Route 53 zone changes now. To copy them over to your DNSimple zone as a one-off, follow the instructions under [**Sync DNS records from Route 53**](#sync-dns-records-from-route-53).
+
+## Next steps
+
+You can now build on this simple setup to experiment a bit and see what you can achieve with DNSimple as your control plane. Some examples:
+
+- Try creating in reverse i.e. create a new DNSimple zone first, and then synchronize it to Route 53.
+- Add more integrations, for example [GoDaddy](https://support.dnsimple.com/articles/integrated-domain-provider-godaddy/).
+- Link another AWS account.
+- Use our [CoreDNS integration](https://support.dnsimple.com/articles/integrated-dns-provider-coredns/) for self-hosted DNS in your private on-premise network.


### PR DESCRIPTION
This article is a demo for the Amazon Route 53 integration.

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/13 and https://github.com/dnsimple/dnsimple-external-integrations/issues/9.