### PR TITLE
Add external domains documentation

### DIFF
--- a/content/articles/integrated-domain-provider-godaddy.markdown
+++ b/content/articles/integrated-domain-provider-godaddy.markdown
@@ -40,7 +40,7 @@ To link [GoDaddy](https://www.godaddy.com) as an integrated domain provider, you
 
 ## Invoice and billing
 
-For operations concerning the domain’s registration such as:
+For operations concerning the registration of your domain such as
 
 - registering the domain
 - renewing the domain
@@ -49,12 +49,12 @@ For operations concerning the domain’s registration such as:
 
 Your GoDaddy account will be charged. Please reach out to them if you have any billing or invoice concerns regarding these operations.
 
-For any other value-added services that DNSimple provides such as:
+For any other value-added services that DNSimple provides such as
 
-- Zone hosting
+- zone hosting
 - SSL certificates
-- Email forwarding
-- Integrations
-- One-click services
+- email forwarding
+- integrations
+- one-click-services
 
 Your DNSimple account will be charged. Please reach out to our customer support team if you have any concerns regarding these.

--- a/content/articles/integrated-domain-provider-godaddy.markdown
+++ b/content/articles/integrated-domain-provider-godaddy.markdown
@@ -26,7 +26,9 @@ DNSimple supports the ability to manage domains that are registered through [GoD
 ## Supported Features
 
 - **Import integrated domains**: When you link an integrated domain provider to your DNSimple account, domains registered via that integrated domain provider will be imported into DNSimple and listed on the Domains page.
-- **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also [transfer](/articles/domain-transfer) your domain to DNSimple easily.
+- **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, name servers from the DNSimple dashboard.
+- **Register domains via DNSimple**: You can [register](/articles/registering-domain) a domain on GoDaddy via DNSimple.
+- **Transfer your domain to DNSimple easily**: You can [transfer](/articles/integrated-domain-provider-transfer-domain) your domain to DNSimple easily.
 - **Domain expiration notices**: Get email notifications when your integrated domains are near expiry.
 
 ## Prerequisites
@@ -35,3 +37,24 @@ To link [GoDaddy](https://www.godaddy.com) as an integrated domain provider, you
 
 - An [API key and API secret](https://developer.godaddy.com/keys) for the Production GoDaddy environment
 - The [customer number](https://godaddy.com/help/what-is-my-customer-number-20038) of your GoDaddy account
+
+## Invoice and billing
+
+For operations concerning the domain’s registration such as:
+
+- registering the domain
+- renewing the domain
+- turning auto renewal on and off
+- turning whois privacy on and off
+
+Your GoDaddy account will be charged. Please reach out to them if you have any billing or invoice concerns regarding these operations.
+
+For any other value-added services that DNSimple provides such as:
+
+- Zone hosting
+- SSL certificates
+- Email forwarding
+- Integrations
+- One-click services
+
+Your DNSimple account will be charged. Please reach out to our customer support team if you have any concerns regarding these.

--- a/content/articles/integrated-domain-provider-godaddy.markdown
+++ b/content/articles/integrated-domain-provider-godaddy.markdown
@@ -26,9 +26,9 @@ DNSimple supports the ability to manage domains that are registered through [GoD
 ## Supported Features
 
 - **Import integrated domains**: When you link an integrated domain provider to your DNSimple account, domains registered via that integrated domain provider will be imported into DNSimple and listed on the Domains page.
-- **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, name servers from the DNSimple dashboard.
-- **Register domains via DNSimple**: You can [register](/articles/registering-domain) a domain on GoDaddy via DNSimple.
-- **Transfer your domain to DNSimple easily**: You can [transfer](/articles/integrated-domain-provider-transfer-domain) your domain to DNSimple easily.
+- **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, and name servers from the DNSimple dashboard.
+- **Register domains via DNSimple**: Learn how to [register](/articles/registering-domain) a domain on GoDaddy via DNSimple.
+- **Transfer your domain to DNSimple easily**: Read more about [transferring](/articles/integrated-domain-provider-transfer-domain) domains.
 - **Domain expiration notices**: Get email notifications when your integrated domains are near expiry.
 
 ## Prerequisites
@@ -40,21 +40,21 @@ To link [GoDaddy](https://www.godaddy.com) as an integrated domain provider, you
 
 ## Invoice and billing
 
-For operations concerning the registration of your domain such as
+For operations concerning the registration of your domain, like:
 
-- registering the domain
-- renewing the domain
-- turning auto renewal on and off
-- turning whois privacy on and off
+- Registering the domain
+- Renewing the domain
+- Turning auto renewal on and off
+- Turning whois privacy on and off
 
-Your GoDaddy account will be charged. Please reach out to them if you have any billing or invoice concerns regarding these operations.
+Your GoDaddy account will be charged. Please reach out to them with any billing or invoice concerns regarding these operations.
 
-For any other value-added services that DNSimple provides such as
+For any other value-added services that DNSimple provides, like:
 
-- zone hosting
+- Zone hosting
 - SSL certificates
-- email forwarding
-- integrations
-- one-click-services
+- Email forwarding
+- Integrations
+- One-click-services
 
-Your DNSimple account will be charged. Please reach out to our customer support team if you have any concerns regarding these.
+Your DNSimple account will be charged. Please [reach out to our customer support team](https://dnsimple.com/feedback) with any concerns regarding these services. 

--- a/content/articles/integrated-domain-provider-transfer-domain.markdown
+++ b/content/articles/integrated-domain-provider-transfer-domain.markdown
@@ -1,0 +1,88 @@
+---
+title: Transfer an Integrated Provider Domain to DNSimple
+excerpt: How to transfer your integrated provider domain to DNSimple.
+categories:
+- Domain Transfers
+---
+
+# Transfer an Integrated Provider Domain to DNSimple
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+Transferring a domain name to DNSimple is the process of moving your [domain registration](https://dnsimple.com/tlds) to DNSimple. DNSimple will act as a domain registrar, and you will be able to manage your entire domain configuration in your DNSimple account.
+
+## Before starting
+
+<warning>
+To avoid the possibility of downtime, you should [point the name servers for the domain to DNSimple (or another provider) before you begin the transfer](/articles/before-transferring-domain). This will prevent downtime and allow you to perform changes to the DNS records during the domain transfer. You should also [remove any existing DS records](/articles/ds-records-changing-dns) from your domain if you are changing DNS providers.
+</warning>
+
+## Caveats
+
+- A domain can only be transferred if it was registered more than 60 days ago and has not been transferred within the last 60 days.
+- It can take up to seven (7) days for a transfer to complete, depending on the domain's Top Level Domain (TLD). To learn more about how to avoid downtime during this period, check out [this article](/articles/before-transferring-domain).
+- Most registrars will not allow an expired domain to be transferred. However, if the domain expires during the transfer, the registrar may not block the transfer due to the expiration.
+
+## Starting the transfer
+
+At DNSimple:
+
+1. Log in to DNSimple and click on your integrated domain.
+1. Select <label>Transfer to DNSimple</label>.
+1. Select a registrant and fill in any extended attributes.
+1. Press "Transfer Domain".
+
+## Approving the transfer
+
+Your domain transfer request will now be issued if there are no missing fields. For most domain extensions, the current registrant will receive an email from `donotreply@name-services.com` to authorize the transfer.
+
+Follow the instructions in the email. We cannot issue the transfer request to the registry without approval of this email.
+
+Once you've authorized the transfer, you may have to **wait up to seven days for your domain transfer to complete.**
+
+<info>
+The total transfer price will be held on your card immediately.
+Your card will be charged once the transfer completes.
+If the transfer fails, funds will be released.
+</info>
+
+## Transfer status
+
+You can go to your domain list to check on the status of pending transfers. Click on "transfer in process" to view detailed information about the transfer request.
+
+## Canceling the transfer
+
+If the domain is still in the transfer process, you can cancel the transfer, and the domain won't be moved away from your current registrar. To do this, navigate to your domain. Under the "Transferring" card, click "View status", then "Cancel transfer".
+
+## After the transfer
+
+When the transfer is completed, you will receive a confirmation email from DNSimple. Congratulations! Your domain is now transferred to DNSimple and you can manage it from your DNSimple account.
+
+### Changing name servers
+
+**We don't automatically point your domain to our name servers** when the transfer completes.
+
+To avoid unexpected downtime and confusion, we don't change the domain name servers upon a successful transfer. When the domain is transferred to us, we will keep using the same name servers previously configured for the domain.
+
+You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered) in one click or [manually configure the name servers](/articles/setting-name-servers).
+
+<warning>
+We suggest pointing [your domain to our name servers before the transfer](/articles/before-transferring-domain) to avoid downtime during the transfer. Some DNS providers will stop serving the DNS for the domain as soon as the transfer is completed.
+</warning>
+
+### Expiration extension
+
+Most transferred domains will be extended the minimum required extension period. For example, `.com` domains will always be extended one year when they are transferred.
+
+The price of this extension is included in the transfer fee.
+
+### Ensure DNSSEC is disabled
+
+If you are currently using DNSSEC, make sure to disable it at your registrar before changing the name servers.
+
+Then you must [remove the current DS record](/articles/ds-records-changing-dns) before transferring your domain away from your current provider.

--- a/content/articles/integrated-domain-provider-transfer-domain.markdown
+++ b/content/articles/integrated-domain-provider-transfer-domain.markdown
@@ -61,7 +61,7 @@ If the domain is still in the transfer process, you can cancel the transfer, and
 
 ## After the transfer
 
-When the transfer is completed, you will receive a confirmation email from DNSimple. Congratulations! Your domain is now transferred to DNSimple and you can manage it from your DNSimple account.
+When the transfer is completed, you will receive a confirmation email from DNSimple. That means your domain is now transferred to DNSimple, and you can manage it from your DNSimple account.
 
 ### Changing name servers
 
@@ -69,7 +69,7 @@ When the transfer is completed, you will receive a confirmation email from DNSim
 
 To avoid unexpected downtime and confusion, we don't change the domain name servers upon a successful transfer. When the domain is transferred to us, we will keep using the same name servers previously configured for the domain.
 
-You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered) in one click or [manually configure the name servers](/articles/setting-name-servers).
+You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered) in one click, or [manually configure the name servers](/articles/setting-name-servers).
 
 <warning>
 We suggest pointing [your domain to our name servers before the transfer](/articles/before-transferring-domain) to avoid downtime during the transfer. Some DNS providers will stop serving the DNS for the domain as soon as the transfer is completed.
@@ -81,7 +81,7 @@ Most transferred domains will be extended the minimum required extension period.
 
 The price of this extension is included in the transfer fee.
 
-### Ensure DNSSEC is disabled
+### Ensuring DNSSEC is disabled
 
 If you are currently using DNSSEC, make sure to disable it at your registrar before changing the name servers.
 

--- a/content/articles/integrated-domain-providers.markdown
+++ b/content/articles/integrated-domain-providers.markdown
@@ -21,8 +21,8 @@ DNSimple supports the ability to manage domains that are registered with other d
 
 - **Import integrated domains**: When you link an integrated domain provider to your DNSimple account, domains registered via that integrated domain provider will be imported into DNSimple and listed on the Domains page.
 - **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, name servers from the DNSimple dashboard.
-- **Register domains via DNSimple**: You can [register](/articles/registering-domain) a domain on your integrated provider via DNSimple.
-- **Transfer your domain to DNSimple easily**: You can [transfer](/articles/integrated-domain-provider-transfer-domain) your domain to DNSimple easily.
+- **Register domains via DNSimple**: Learn how to [register](/articles/registering-domain) a domain on your integrated provider via DNSimple.
+- **Transfer your domain to DNSimple easily**: Read more about [transferring](/articles/integrated-domain-provider-transfer-domain) your domains.
 - **Domain expiration notices**: Get email notifications when your integrated domains are near expiry.
 
 ## Supported Integrated Domain Providers

--- a/content/articles/integrated-domain-providers.markdown
+++ b/content/articles/integrated-domain-providers.markdown
@@ -20,7 +20,9 @@ DNSimple supports the ability to manage domains that are registered with other d
 ## Supported Features
 
 - **Import integrated domains**: When you link an integrated domain provider to your DNSimple account, domains registered via that integrated domain provider will be imported into DNSimple and listed on the Domains page.
-- **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also [transfer](/articles/domain-transfer) your domain to DNSimple easily.
+- **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, name servers from the DNSimple dashboard.
+- **Register domains via DNSimple**: You can [register](/articles/registering-domain) a domain on your integrated provider via DNSimple.
+- **Transfer your domain to DNSimple easily**: You can [transfer](/articles/integrated-domain-provider-transfer-domain) your domain to DNSimple easily.
 - **Domain expiration notices**: Get email notifications when your integrated domains are near expiry.
 
 ## Supported Integrated Domain Providers

--- a/content/articles/registering-domain.markdown
+++ b/content/articles/registering-domain.markdown
@@ -17,6 +17,7 @@ When applicable, we recommend opting for our "auto-renew" feature to avoid your 
 1. Log in to DNSimple with your user credentials.
 1. Click Add Domain from your Dashboard and select the appropriate account if you have more than one.
 1. Fill out the domain name.
+1. If you have linked an [integrated domain provider](/articles/integrated-domain-providers), you can choose to register your domain through them or through DNSimple.
 1. Choose whether you'd like Whois Privacy Protection or auto-renewal on the domain (if applicable).
 1. Click Register Domain.
 1. Provide contact details for the registrant of the domain, or choose a contact from those you've already created.


### PR DESCRIPTION
This PR adds the external domains documentation based on our [internal wiki page](https://dnsimple.atlassian.net/wiki/spaces/SUPPORT/pages/2591096859/Integrated+Domain+Providers).

To be more specific, this adds the following:
* Update supported features section to add registration, renewal, whois privacy, and auto renewal.
* Update domain registration docs to add a note about Integrated Domain Providers
* Add billing section to GoDaddy integrated domain provider to let customers know whether to reach out to us or GoDaddy
* Add documentation on how to transfer an Integrated Provider Domain to DNSimple.