### PR TITLE
Add first Version of Cache edge text

### DIFF
--- a/content/articles/delegating-dnsimple-hosted.markdown
+++ b/content/articles/delegating-dnsimple-hosted.markdown
@@ -17,7 +17,7 @@ Pointing the name servers to DNSimple will cause the domain to resolve using the
 1.  Enter the [DNSimple name servers](/articles/dnsimple-nameservers):
 
     - ns1.dnsimple.com
-    - ns2.dnsimple.com
+    - ns2.dnsimple-edge.net
     - ns3.dnsimple.com
     - ns4.dnsimple-edge.org
 </div>

--- a/content/articles/delegating-dnsimple-registered.markdown
+++ b/content/articles/delegating-dnsimple-registered.markdown
@@ -25,9 +25,9 @@ Switching the name servers to DNSimple will cause the domain to resolve using th
 
 1.  Enter the [DNSimple name servers](/articles/dnsimple-nameservers)
   - ns1.dnsimple.com
-  - ns2.dnsimple.com
+  - ns2.dnsimple-edge.net
   - ns3.dnsimple.com
-  - ns4.dnsimple.com or ns4.dnsimple-edge.org
+  - ns4.dnsimple-edge.org
 
     ![Enter name servers](/files/complete-name-server-change.png)
 

--- a/content/articles/dnsimple-nameservers.markdown
+++ b/content/articles/dnsimple-nameservers.markdown
@@ -12,13 +12,13 @@ For DNSimple to provide DNS for one of your domain names, you must change the na
 The DNSimple name servers are:
 
 - ns1.dnsimple.com
-- ns2.dnsimple.com
+- ns2.dnsimple-edge.net
 - ns3.dnsimple.com
-- ns4.dnsimple.com or ns4.dnsimple-edge.org
+- ns4.dnsimple-edge.org
 
 If you registered your domain with DNSimple, your name servers will already be set to the DNSimple name servers. There's nothing else you need to do.
 
-If you transferred your domain into DNSimple from another registrar, and you're ready for us to start providing your DNS, you need to [change your name severs to DNSimple](/articles/delegating-dnsimple-registered/). 
+If you transferred your domain into DNSimple from another registrar, and you're ready for us to start providing your DNS, you need to [change your name severs to DNSimple](/articles/delegating-dnsimple-registered/).
 
 <note>
 We do not automatically change your name servers to ours during the transfer process.
@@ -48,12 +48,29 @@ If you need to provide the IP addresses to your current registrar, use the follo
 <td>2400:cb00:2049:1::a29f:1a04</td>
 </tr>
 <tr>
-<td>ns4.dnsimple.com</td>
+<td>ns4.dnsimple-edge.org</td>
 <td>199.247.155.53</td>
 <td>2620:111:8007::53</td>
 </tr>
+</table>
+
+## Legacy Name Servers
+
+We have some older name servers that we consider legacy. You can use them but it is recommended you use the more diverse names and TLDs.
+
+<table>
 <tr>
-<td>ns4.dnsimple-edge.org</td>
+<th>Name</th>
+<th>IPv4 Address</th>
+<th>IPv6 Address</th>
+</tr>
+<tr>
+<td>ns2.dnsimple.com</td>
+<td>162.159.25.4</td>
+<td>2400:cb00:2049:1::a29f:1904</td>
+</tr>
+<tr>
+<td>ns4.dnsimple.com</td>
 <td>199.247.155.53</td>
 <td>2620:111:8007::53</td>
 </tr>

--- a/content/articles/dnsimple-nameservers.markdown
+++ b/content/articles/dnsimple-nameservers.markdown
@@ -38,9 +38,9 @@ If you need to provide the IP addresses to your current registrar, use the follo
 <td>2400:cb00:2049:1::a29f:1804</td>
 </tr>
 <tr>
-<td>ns2.dnsimple.com</td>
-<td>162.159.25.4</td>
-<td>2400:cb00:2049:1::a29f:1904</td>
+<td>ns2.dnsimple-edge.net</td>
+<td>199.247.153.53</td>
+<td>2620:111:8005::53</td>
 </tr>
 <tr>
 <td>ns3.dnsimple.com</td>

--- a/content/articles/dnsimple-nameservers.markdown
+++ b/content/articles/dnsimple-nameservers.markdown
@@ -56,7 +56,7 @@ If you need to provide the IP addresses to your current registrar, use the follo
 
 ## Legacy Name Servers
 
-We have some older name servers that we consider legacy. You can use them but it is recommended you use the more diverse names and TLDs.
+We have some older name servers that we consider legacy. You can use them, but we recommend you use the more diverse names and TLDs.
 
 <table>
 <tr>

--- a/content/articles/domain-resolution-issues.markdown
+++ b/content/articles/domain-resolution-issues.markdown
@@ -11,7 +11,7 @@ To use our [DNS hosting service](/articles/dns-hosting), the domain should resol
 
 You can check the domain resolution status using [Is It DNSimple?](http://isitdnsimple.com/). The resolution status is also displayed on the domain page in your DNSimple account.
 
-The following is a checklist of common issues to help you if a domain isn't resolving correctly. 
+The following is a checklist of common issues to help you if a domain isn't resolving correctly.
 
 
 ## Name server propagation delay
@@ -36,9 +36,9 @@ You can use `dig` or any other DNS tool to get the name servers for the domain.
 ~~~
 $ dig NS example.com +short
 ns1.dnsimple.com.
-ns2.dnsimple.com.
+ns2.dnsimple-edge.net.
 ns3.dnsimple.com.
-ns4.dnsimple.com.
+ns4.dnsimple-edge.org.
 ~~~
 
 The order of the name servers is irrelevant.
@@ -61,7 +61,7 @@ If not, update the name servers to [point to DNSimple](/articles/pointing-domain
 
 ## Check that the domain is using *all* DNSimple name servers
 
-DNSimple provides four name servers. You should include all the name servers to make sure DNS will resolve if one name server is temporarily unavailable due to maintenance, etc. 
+DNSimple provides four name servers. You should include all the name servers to make sure DNS will resolve if one name server is temporarily unavailable due to maintenance, etc.
 
 
 ## Check that the domain is using *only* DNSimple name servers
@@ -71,9 +71,9 @@ In some cases, a misconfiguration may result in DNSimple name servers listed alo
 ~~~
 $ dig NS example.com +short
 ns1.dnsimple.com.
-ns2.dnsimple.com.
+ns2.dnsimple-edge.net.
 ns3.dnsimple.com.
-ns4.dnsimple.com.
+ns4.dnsimple-edge.org.
 ns1.thirdparty.com.
 ns2.thirdparty.com.
 ~~~
@@ -97,9 +97,9 @@ Registrar: ENOM, INC.
 Whois Server: whois.enom.com
 Referral URL: http://www.enom.com
 Name Server: NS1.DNSIMPLE.COM
-Name Server: NS2.DNSIMPLE.COM
+Name Server: NS2.DNSIMPLE-EDGE.NET
 Name Server: NS3.DNSIMPLE.COM
-Name Server: NS4.DNSIMPLE.COM
+Name Server: NS4.DNSIMPLE-EDGE.ORG
 Status: clientTransferProhibited
 Updated Date: 13-jun-2013
 Creation Date: 07-apr-2010

--- a/content/articles/how-dig.markdown
+++ b/content/articles/how-dig.markdown
@@ -40,7 +40,7 @@ The output above shows lots of interesting details. Line one contains the versio
 
 The question section displays the DNS question that was sent: "I want A records for dnsimple.com". The Answer section shows what the name server responded with: "dnsimple.com has one A record with the content 50.31.213.210 and a time-to-live (TTL) of 59 seconds.
 
-It also gives details about how long the query took, what server was used, when the query was sent, and the size of the DNS packet. 
+It also gives details about how long the query took, what server was used, when the query was sent, and the size of the DNS packet.
 
 
 ## Dig at a name server
@@ -110,9 +110,9 @@ com.			172800	IN	NS	g.gtld-servers.net.
 ;; Received 490 bytes from 192.112.36.4#53(192.112.36.4) in 1849 ms
 
 dnsimple.com.		172800	IN	NS	ns1.dnsimple.com.
-dnsimple.com.		172800	IN	NS	ns2.dnsimple.com.
+dnsimple.com.		172800	IN	NS	ns2.dnsimple-edge.net.
 dnsimple.com.		172800	IN	NS	ns3.dnsimple.com.
-dnsimple.com.		172800	IN	NS	ns4.dnsimple.com.
+dnsimple.com.		172800	IN	NS	ns4.dnsimple-edge.org.
 ;; Received 278 bytes from 192.55.83.30#53(192.55.83.30) in 306 ms
 
 dnsimple.com.		60	IN	A	50.31.213.210

--- a/content/articles/manage-caa-record.markdown
+++ b/content/articles/manage-caa-record.markdown
@@ -19,7 +19,7 @@ You can manage [CAA records](/articles/caa-record) in DNSimple using the [DNS re
 The instructions in this article assume you're familiar with the [CAA record format](/articles/caa-record#record-format) and usage.
 
 <note>
-CAA records are only supported on the DNSimple primary name servers (ns1.dnsimple.com through ns4.dnsimple.com and ns4.dnsimple-edge.org). We don't support transferring CAA records to secondary name servers.
+CAA records are only supported on the [DNSimple name servers](/articles/dnsimple-nameservers). We don't support transferring CAA records to secondary name servers.
 </note>
 
 

--- a/content/articles/ns-record.markdown
+++ b/content/articles/ns-record.markdown
@@ -11,9 +11,9 @@ An NS record delegates a subdomain to a set of name servers. Whenever you delega
 
 ~~~
 dnsimple.com. 172800 IN NS ns1.dnsimple.com.
-dnsimple.com. 172800 IN NS ns2.dnsimple.com.
+dnsimple.com. 172800 IN NS ns2.dnsimple-edge.net.
 dnsimple.com. 172800 IN NS ns3.dnsimple.com.
-dnsimple.com. 172800 IN NS ns4.dnsimple.com.
+dnsimple.com. 172800 IN NS ns4.dnsimple-edge.org.
 ~~~
 
 We automatically publish NS records in our authoritative [name servers](/articles/dnsimple-nameservers/) for each domain we're authoritative for. These NS records will appear in the System Records section of each domain's Manage page, and will either be our default name servers (ns1.dnsimple.com through ns4.dnsimple.com and ns4.dnsimple-edge.org), or your vanity name servers if you have vanity name servers.

--- a/content/articles/ns-record.markdown
+++ b/content/articles/ns-record.markdown
@@ -16,6 +16,6 @@ dnsimple.com. 172800 IN NS ns3.dnsimple.com.
 dnsimple.com. 172800 IN NS ns4.dnsimple-edge.org.
 ~~~
 
-We automatically publish NS records in our authoritative [name servers](/articles/dnsimple-nameservers/) for each domain we're authoritative for. These NS records will appear in the System Records section of each domain's Manage page, and will either be our default name servers (ns1.dnsimple.com through ns4.dnsimple.com and ns4.dnsimple-edge.org), or your vanity name servers if you have vanity name servers.
+We automatically publish NS records in our authoritative [name servers](/articles/dnsimple-nameservers/) for each domain we're authoritative for. These NS records will appear in the System Records section of each domain's Manage page, and will either be our default name servers, or your vanity name servers if you have vanity name servers.
 
 If you want to delegate a registered domain name to a different DNS provider, you can do that through the domain's Manage page. You can't remove or change the NS records for your domain in the Advanced Editor page. Click [here](/articles/zone-ns-records) to read about how to update NS records for the zone of a hosted domain.

--- a/content/articles/record-resolution-issues.markdown
+++ b/content/articles/record-resolution-issues.markdown
@@ -82,9 +82,9 @@ com.            172800  IN  NS  g.gtld-servers.net.
 ;; Received 1176 bytes from 199.9.14.201#53(b.root-servers.net) in 86 ms
 
 dnsimple.com.       172800  IN  NS  ns1.dnsimple.com.
-dnsimple.com.       172800  IN  NS  ns2.dnsimple.com.
+dnsimple.com.       172800  IN  NS  ns2.dnsimple-edge.net.
 dnsimple.com.       172800  IN  NS  ns3.dnsimple.com.
-dnsimple.com.       172800  IN  NS  ns4.dnsimple.com.
+dnsimple.com.       172800  IN  NS  ns4.dnsimple-edge.org.
 ...
 ;; Received 842 bytes from 192.33.14.30#53(b.gtld-servers.net) in 38 ms
 

--- a/content/articles/secondary-dns-dnsimple-as-secondary.markdown
+++ b/content/articles/secondary-dns-dnsimple-as-secondary.markdown
@@ -72,7 +72,7 @@ These are our AXFR client IPs:
 - Production
   - `3.12.234.2`
   - `2600:1f16:ae2:e900:f05c:9438:865f:64a0`
-- Sandbox 
+- Sandbox
   - `3.142.158.214`
   - `2600:1f16:ae2:e900:413:73dd:ebf2:2902`
 
@@ -88,7 +88,7 @@ Example of what the set of NS records may look like:
 - `NS example.com ns2.primary.com`
 - `NS example.com ns3.primary.com`
 - `NS example.com ns1.dnsimple.com`
-- `NS example.com ns2.dnsimple.com`
+- `NS example.com ns2.dnsimple-edge.net`
 - `NS example.com ns3.dnsimple.com`
 
 ### 2. Delegate the domain through both DNS providers at your domain's registrar
@@ -102,7 +102,7 @@ Example of what the name servers may look like:
 - `ns2.primary.com`
 - `ns3.primary.com`
 - `ns1.dnsimple.com`
-- `ns2.dnsimple.com`
+- `ns2.dnsimple-edge.net`
 - `ns3.dnsimple.com`
 
 

--- a/content/articles/secondary-dns-provider-dns-made-easy.markdown
+++ b/content/articles/secondary-dns-provider-dns-made-easy.markdown
@@ -89,12 +89,12 @@ The query should return all the DNSimple and DNSMadeEasy name servers in the `AU
 example.com.  3600  IN  SOA axfr.dnsimple.com. admin.dnsimple.com. 1425544360 86400 7200 604800 300
 
 ;; AUTHORITY SECTION:
-example.com.  3600  IN  NS  ns2.dnsimple.com.
+example.com.  3600  IN  NS  ns2.dnsimple-edge.net.
 example.com.  3600  IN  NS  ns6.dnsmadeeasy.com.
 example.com.  3600  IN  NS  ns7.dnsmadeeasy.com.
 example.com.  3600  IN  NS  ns3.dnsimple.com.
 example.com.  3600  IN  NS  ns5.dnsmadeeasy.com.
-example.com.  3600  IN  NS  ns4.dnsimple.com.
+example.com.  3600  IN  NS  ns4.dnsimple-edge.org.
 example.com.  3600  IN  NS  ns1.dnsimple.com.
 
 ;; Query time: 55 msec

--- a/content/articles/secondary-dns-provider-easy-dns.markdown
+++ b/content/articles/secondary-dns-provider-easy-dns.markdown
@@ -89,8 +89,8 @@ example.com. 3600  IN  SOA axfr.dnsimple.com. admin.dnsimple.com. 1425558979 864
 
 ;; AUTHORITY SECTION:
 example.com. 3600  IN  NS  xfr0.easydns.com.
-example.com. 3600  IN  NS  ns4.dnsimple.com.
-example.com. 3600  IN  NS  ns2.dnsimple.com.
+example.com. 3600  IN  NS  ns4.dnsimple-edge.org.
+example.com. 3600  IN  NS  ns2.dnsimple-edge.net.
 example.com. 3600  IN  NS  ns1.dnsimple.com.
 example.com. 3600  IN  NS  ns3.dnsimple.com.
 

--- a/content/articles/secondary-dns.markdown
+++ b/content/articles/secondary-dns.markdown
@@ -35,16 +35,16 @@ You can configure Secondary DNS on all domains whether they delegate to us or no
 If you don't have your domain registered with us, update the delegation of your domain at your registrar to use the secondary name servers you have chosen. If you set up the secondary name servers `ns1.secondary.com` and `ns2.secondary.com`, delegation at your registrar will need to change from:
 
 - `ns1.dnsimple.com`
-- `ns2.dnsimple.com`
+- `ns2.dnsimple-edge.net`
 - `ns3.dnsimple.com`
-- `ns4.dnsimple.com`
+- `ns4.dnsimple-edge.org`
 
 to
 
 - `ns1.dnsimple.com`
-- `ns2.dnsimple.com`
+- `ns2.dnsimple-edge.net`
 - `ns3.dnsimple.com`
-- `ns4.dnsimple.com`
+- `ns4.dnsimple-edge.org`
 - `ns1.secondary.com`
 - `ns2.secondary.com`
 

--- a/content/articles/supported-dns-records.markdown
+++ b/content/articles/supported-dns-records.markdown
@@ -50,5 +50,5 @@ We support additional record types used behind the scenes to provide various DNS
 ## Limitations
 
 <note>
-CAA records are only supported on the DNSimple primary name servers (ns1.dnsimple.com through ns4.dnsimple.com and ns4.dnsimple-edge.org). We don't support transferring CAA records to secondary name servers.
+CAA records are only supported on the [DNSimple name servers](/articles/dnsimple-nameservers). We don't support transferring CAA records to secondary name servers.
 </note>


### PR DESCRIPTION
This adds the new NS2 and clarifies that the old NS2 and NS4 are less recommended.
I used the word legacy over deprecated for now.

# **DO NOT MERGE** Until cleared by the SIP team.