### PR TITLE
Fix webapp configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,5 @@ group :development do
 end
 
 group :nanoc do
-  gem 'guard-nanoc'
+  gem 'nanoc-live'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,12 @@ GEM
     adsf (1.4.7)
       rack (>= 1.0.0, < 4.0.0)
       rackup (~> 2.1)
+    adsf-live (1.4.8)
+      adsf (~> 1.3)
+      em-websocket (~> 0.5)
+      eventmachine (~> 1.2)
+      listen (~> 3.0)
+      rack-livereload (~> 0.3)
     ansi (1.5.0)
     builder (3.2.4)
     coderay (1.1.3)
@@ -18,23 +24,12 @@ GEM
     ddmetrics (1.0.1)
     ddplugin (1.0.3)
     diff-lcs (1.5.0)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
     ffi (1.15.4)
-    formatador (0.2.5)
-    guard (2.16.1)
-      formatador (>= 0.2.4)
-      listen (>= 2.7, < 4.0)
-      lumberjack (>= 1.0.12, < 2.0)
-      nenv (~> 0.1)
-      notiffany (~> 0.0)
-      pry (>= 0.9.12)
-      shellany (~> 0.0)
-      thor (>= 0.18.1)
-    guard-compat (1.2.1)
-    guard-nanoc (2.1.9)
-      guard (~> 2.8)
-      guard-compat (~> 1.0)
-      nanoc-cli (~> 4.11, >= 4.11.14)
-      nanoc-core (~> 4.11, >= 4.11.14)
+    http_parser.rb (0.8.0)
     immutable-ruby (0.1.0)
       concurrent-ruby (~> 1.1)
       sorted_set (~> 1.0)
@@ -43,10 +38,9 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    listen (3.7.0)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lumberjack (1.2.4)
     memo_wise (1.7.0)
     method_source (1.0.0)
     mime-types (3.5.1)
@@ -92,14 +86,15 @@ GEM
       nanoc-checking (~> 1.0)
       nanoc-cli (~> 4.11, >= 4.11.15)
       nanoc-core (~> 4.11, >= 4.11.15)
-    nenv (0.3.0)
+    nanoc-live (1.0.0)
+      adsf-live (~> 1.4)
+      listen (~> 3.0)
+      nanoc-cli (~> 4.11, >= 4.11.14)
+      nanoc-core (~> 4.11, >= 4.11.14)
     nio4r (2.5.9)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    notiffany (0.1.3)
-      nenv (~> 0.1)
-      shellany (~> 0.0)
     parallel (1.23.0)
     pastel (0.8.0)
       tty-color (~> 0.5)
@@ -113,6 +108,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (3.0.7)
+    rack-livereload (0.5.1)
+      rack
     rackup (2.1.0)
       rack (>= 3)
       webrick (~> 1.8)
@@ -131,14 +128,12 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     set (1.0.3)
-    shellany (0.0.1)
     slow_enumerator_tools (1.1.0)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
     stringio (3.0.7)
     systemu (2.6.5)
-    thor (1.0.1)
     tty-color (0.6.0)
     tty-command (0.10.1)
       pastel (~> 0.8)
@@ -154,13 +149,13 @@ DEPENDENCIES
   adsf
   builder
   ddmemoize
-  guard-nanoc
   kramdown
   kramdown-parser-gfm
   mime-types
   minitest
   minitest-reporters
   nanoc (~> 4.12)
+  nanoc-live
   nokogiri
   pry (~> 0.14.2)
   puma
@@ -170,4 +165,4 @@ DEPENDENCIES
   systemu
 
 BUNDLED WITH
-   2.3.7
+   2.4.22


### PR DESCRIPTION
This PR removes the now deprecated `guard-nanoc` in favor of `nanoc-live` as otherwise, you can't run the app in development.

**Other changes:**
* bump bundler version