### PR TITLE
Article style consistency edits

### DIFF
--- a/content/articles/deployment-editor.markdown
+++ b/content/articles/deployment-editor.markdown
@@ -1,29 +1,29 @@
 ---
 title: Deployment Editor
-excerpt: Manage and sync the DNS records of a zone at DNSimple and/or integrated DNS providers.
+excerpt: Manage and sync the DNS records of a zone at DNSimple and/or Integrated DNS Providers.
 categories:
 - DNS
 ---
 
 # Deployment Editor
 
-From the Deployment editor page, you can view the records and sync state for zones at DNSimple and any configured [integrated DNS providers](/articles/integrated-dns-providers). The Deployment editor page groups records together so you can easily see which records are at which DNS provider(s).
+From the Deployment Editor page, you can view the records and sync state for zones at DNSimple and any configured [Integrated DNS Providers](/articles/integrated-dns-providers). The Deployment Editor page groups records together so you can easily see which records are at which DNS provider(s).
 
 <div class="section-steps" markdown="1">
-##### Accessing the Deployment Editor from the Record editor page
+##### Accessing the Deployment Editor from the Record Editor page
 
 1.  From the [Record Editor](/articles/record-editor) page, click the menu icon next to the <label>Record editor<label> heading.
 
     ![Deployment Editor Link](/files/deployment-editor-from-record-editor.png)
 
-1.  In the popup menu, click the <label>View as Deployment editor</label> link to navigate to the <label>Deployment Editor</label> page.
+1.  In the popup menu, click the <label>View as Deployment Editor</label> link to navigate to the <label>Deployment Editor</label> page.
 
     ![Deployment Editor](/files/deployment-editor-link-menu.png)
 </div>
 
 ## Managing zone records in the Deployment Editor
 
-On the Deployment editor page, you can see which records are present at which DNS provider(s).
+On the Deployment Editor page, you can see which records are present at which DNS provider(s).
 
 ![Managing zone records in the deployment editor](/files/deployment-editor-manage-records.png)
 
@@ -34,11 +34,11 @@ In the deployment editor, you can add a zone record to one or more DNS providers
 <div class="section-steps" markdown="1">
 ##### Adding a record
 
-1.  From the Deployment Editor page, click the <label>Add record</label> button and choose the type of record you're adding.
+1.  From the Deployment Editor page, click the <label>Add Record</label> button and choose the type of record you're adding.
 
     ![Deployment Editor Add Record button](/files/deployment-editor-add-record-button.png)
 
-1.  Enter the required infomation and press <label>Add Record</label> to create the record. For each DNS provider the record should be added to, ensure the corresponding checkbox is checked. Note the record note will only be saved if DNSimple is one of the selected providers.
+1.  Enter the required infomation, and press <label>Add Record</label> to create the record. For each DNS provider the record should be added to, ensure the corresponding checkbox is checked. Note the record note will only be saved if DNSimple is one of the selected providers.
 
     ![Deployment Editor Add Record](/files/deployment-editor-add-record.png)
 </div>
@@ -62,7 +62,7 @@ You can update a zone record at one or more DNS providers from the Deployment Ed
 
     ![Deployment Editor Update Record button](/files/deployment-editor-edit-record-button.png)
 
-1.  Enter the required infomation and press <label>Update Record</label> to update the record. For each DNS provider the record should be updated at, ensure the corresponding checkbox is checked. For any selected DNS provider, if the record didn't already exist there, it will be added to the provider.  Note the record note will only be saved if DNSimple is one of the selected providers.
+1.  Enter the required infomation, and press <label>Update Record</label> to update the record. For each DNS provider the record should be updated at, ensure the corresponding checkbox is checked. For any selected DNS provider, if the record didn't already exist there, it will be added to the provider.  Note the record note will only be saved if DNSimple is one of the selected providers.
 
     ![Deployment Editor Update Record](/files/deployment-editor-edit-record.png)
 </div>

--- a/content/articles/integrated-dns-provider-amazon-route53.markdown
+++ b/content/articles/integrated-dns-provider-amazon-route53.markdown
@@ -17,13 +17,13 @@ categories:
 
 DNSimple supports the ability to view and manage zones that are deployed at [Amazon Route 53](https://aws.amazon.com/route53/).
 
-## Video Walk-through
+## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
   <iframe src="https://www.youtube.com/embed/4LsTT0pgBaQ" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
-## Supported Features
+## Supported features
 
 - **Import integrated zones**: When you link Route 53 to your DNSimple account, all the zones hosted on Route 53 will be imported into DNSimple and listed on the [Domain Names](/articles/managing-integrated-zones) page.
 - **Management of integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Deployment Editor](/articles/deployment-editor). (See: The list of supported record types for Route 53)
@@ -31,7 +31,7 @@ DNSimple supports the ability to view and manage zones that are deployed at [Ama
 
 ## Prerequisites
 
-To link [Amazon Route 53](https://aws.amazon.com/route53/) as an integrated DNS provider, you need:
+To link [Amazon Route 53](https://aws.amazon.com/route53/) as an Integrated DNS Provider, you need:
 
 - An [AWS access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for an AWS user with permission to manage public hosted zones at Route 53, including these permissions:
   - route53:ListHostedZones
@@ -43,7 +43,7 @@ To link [Amazon Route 53](https://aws.amazon.com/route53/) as an integrated DNS 
   - route53:DeleteHostedZone
 - Administrator access to a DNSimple account
 
-## Supported Record Types
+## Supported record types
 
 The following Route 53 record types are supported for syncing and management at DNSimple:
 

--- a/content/articles/integrated-dns-provider-coredns.markdown
+++ b/content/articles/integrated-dns-provider-coredns.markdown
@@ -15,9 +15,9 @@ categories:
 
 ---
 
-DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns.io/). The CoreDNS integrated provider is configured per zone and returns the current sync state for all zone records to the [Deployment Editor](/articles/deployment-editor#record-syncing).
+DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns.io/). The CoreDNS Integrated Provider is configured per zone and returns the current sync state for all zone records to the [Deployment Editor](/articles/deployment-editor#record-syncing).
 
-## Video Walk-through
+## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
   <iframe src="https://www.youtube.com/embed/9yO2Oo_N1ms" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
@@ -30,14 +30,14 @@ DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns
   - [DNSimple CoreDNS Docker Container](https://hub.docker.com/r/dnsimple/coredns-dnsimple/tags)
 - Administrator access to a DNSimple account
 
-## Supported Features
+## Supported features
 
 - **Management of integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Deployment Editor](/articles/deployment-editor).
 - **Sync integrated zone records**: Sync your zone records from DNSimple to multiple CoreDNS instances, and verify the sync state with the [Deployment Editor](/articles/deployment-editor#record-syncing).
 
-The CoreDNS integrated provider supports one-way syncing of zone records configured at DNSimple. All records configured for the zone at DNSimple will be synced to CoreDNS on startup and again during each refresh interval. Zone records for any other integrated DNS provider must first be synced to DNSimple before they will be available to CoreDNS instances.
+The CoreDNS Integrated Provider supports one-way syncing of zone records configured at DNSimple. All records configured for the zone at DNSimple will be synced to CoreDNS on startup and again during each refresh interval. Zone records for any other Integrated DNS Provider must first be synced to DNSimple before they will be available to CoreDNS instances.
 
-#### Supported Record Types
+#### Supported record types
 
 All DNSimple record types can be synced to CoreDNS:
 

--- a/content/articles/integrated-dns-providers.markdown
+++ b/content/articles/integrated-dns-providers.markdown
@@ -1,6 +1,6 @@
 ---
 title: Integrated DNS Providers at DNSimple
-excerpt: Link an integrated DNS provider to your DNSimple account to synchronize, manage, and view zones at other authoritative DNS providers within DNSimple.
+excerpt: Link an Integrated DNS Provider to your DNSimple account to synchronize, manage, and view zones at other authoritative DNS providers within DNSimple.
 categories:
 - DNS
 - Integrations
@@ -15,45 +15,45 @@ categories:
 
 ---
 
-DNSimple supports the ability to synchronize, manage, and view zones that are deployed in other DNS providers external to DNSimple. DNSimple calls such providers "integrated DNS providers" and zones ["integrated zones"](/articles/managing-integrated-zones).
+DNSimple supports the ability to synchronize, manage, and view zones that are deployed in other DNS providers external to DNSimple. DNSimple calls these providers "Integrated DNS Providers" and zones ["integrated zones"](/articles/managing-integrated-zones).
 
-## Supported Features
+## Supported features
 
-- **Import integrated zones**: When you link an integrated DNS provider to your DNSimple account, zones hosted on that integrated DNS provider will be imported into DNSimple and listed on the [Domain Names](/articles/managing-integrated-zones) page.
+- **Import integrated zones**: When you link an Integrated DNS Provider to your DNSimple account, zones hosted on that Integrated DNS Provider will be imported into DNSimple and listed on the [Domain Names](/articles/managing-integrated-zones) page.
 - **Manage integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Deployment Editor](/articles/deployment-editor).
 - **Sync integrated zone records**: Sync your zone records from the integrated zone to DNSimple, or from DNSimple to the integrated zone, with the [Deployment Editor](/articles/deployment-editor#record-syncing).
 
 <info>
-The list of supported features and record types differs for each integrated provider. See the provider page for more information.
+The list of supported features and record types differs for each Integrated Provider. See the provider page for more information.
 </info>
 
 ## Supported Integrated DNS Providers
 
-To manage [integrated zones](/articles/managing-integrated-zones) from DNSimple, you first have to link an integrated DNS provider to your DNSimple account.
+To manage [integrated zones](/articles/managing-integrated-zones) from DNSimple, you first have to link an Integrated DNS Provider to your DNSimple account.
 
 DNSimple supports zone integration with the providers listed below.
 
 - [Amazon Route 53](/articles/integrated-dns-provider-amazon-route53)
 - [CoreDNS](/articles/integrated-dns-provider-coredns)
 
-## Supported Record Types {#supported-record-types}
+## Supported record types {#supported-record-types}
 
-Supported record types can be [synced](/articles/deployment-editor#record-syncing) from/to DNSimple to/from an integrated DNS provider.
-However, record fields not supported by DNSimple or the destination provider may be ignored. For example, record fields, like [record notes](/articles/record-notes) and [regional records](/articles/regional-records) information, may not be supported depending on the integrated DNS provider.
+Supported record types can be [synced](/articles/deployment-editor#record-syncing) from/to DNSimple to/from an Integrated DNS Provider.
+However, record fields not supported by DNSimple or the destination provider may be ignored. For example, record fields, like [record notes](/articles/record-notes) and [regional records](/articles/regional-records) information, may not be supported depending on the Integrated DNS Provider.
 
 ## Linking an Integrated DNS Provider to your account
 
 1. At DNSimple, go to the <label>Account</label> page, and click the <label>Integrated Providers</label> tab.
-1. Under <label>Add an integrated provider<label>, click the link button for the integrated DNS provider you want to link to your DNSimple account.
-![Link an integrated DNS provider](/files/account-integrated-provider-link.png)
-1. Fill in any required paramaters for the integrated DNS provider configuration.
-1. Fill in any necessary credentials for your account at the integrated DNS provider.
-![Enter integrated DNS provider credentials](/files/account-external-provider-link-credentials.png)
-1. After successfully linking the integrated DNS provider, you will arrive back on the DNSimple Integrated Providers page with the integrated DNS provider newly linked to your account, listed under "Linked providers". You can view the imported integrated zones from the [Domain Names](/articles/managing-integrated-zones) page, and manage and sync integrated zone records from the [Deployment Editor](/articles/deployment-editor).
+1. Under <label>Add an Integrated Provider<label>, click the link button for the Integrated DNS Provider you want to link to your DNSimple account.
+![Link an Integrated DNS Provider](/files/account-integrated-provider-link.png)
+1. Fill in any required paramaters for the Integrated DNS Provider configuration.
+1. Fill in any necessary credentials for your account at the Integrated DNS Provider.
+![Enter Integrated DNS Provider credentials](/files/account-external-provider-link-credentials.png)
+1. After successfully linking the Integrated DNS Provider, you will arrive back on the DNSimple Integrated Providers page with the Integrated DNS Provider newly linked to your account, listed under "Linked providers". You can view the imported integrated zones from the [Domain Names](/articles/managing-integrated-zones) page, and manage and sync integrated zone records from the [Deployment Editor](/articles/deployment-editor).
 ![Account integrated providers list](/files/account-integrated-providers.png)
 
 ## Unlinking an Integrated DNS Provider from your account
 
 1. At DNSimple, go to the <label>Account</label> page, and click the <label>Integrated Providers</label> tab.
-1. Under <label>Linked providers<label>, click the <label>Remove</label> button for the integrated DNS provider you want to unlink from your DNSimple account. This will remove the ability to view and manage zones and their DNS records at the linked provider via DNSimple.
-![Unlink an integrated DNS provider](/files/account-integrated-provider-unlink.png)
+1. Under <label>Linked providers<label>, click the <label>Remove</label> button for the Integrated DNS Provider you want to unlink from your DNSimple account. This will remove the ability to view and manage zones and their DNS records at the linked provider via DNSimple.
+![Unlink an Integrated DNS Provider](/files/account-integrated-provider-unlink.png)

--- a/content/articles/integrated-domain-providers.markdown
+++ b/content/articles/integrated-domain-providers.markdown
@@ -17,7 +17,7 @@ categories:
 
 DNSimple supports the ability to manage domains that are registered with other domain providers external to DNSimple. DNSimple calls such providers "Integrated Domain Providers".
 
-## Supported Features
+## Supported features
 
 - **Import integrated domains**: When you link an Integrated Domain Provider to your DNSimple account, domains registered via that Integrated Domain Provider will be imported into DNSimple and listed on the Domain Names page.
 - **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, name servers from the DNSimple dashboard.

--- a/content/articles/integrated-domain-providers.markdown
+++ b/content/articles/integrated-domain-providers.markdown
@@ -1,6 +1,6 @@
 ---
 title: Integrated Domain Providers at DNSimple
-excerpt: Link an integrated domain provider to your DNSimple account to manage domains at other domain providers, from within DNSimple.
+excerpt: Link an Integrated Domain Provider to your DNSimple account to manage domains at other domain providers, from within DNSimple.
 categories:
 - Domains
 - Integrations
@@ -15,19 +15,19 @@ categories:
 
 ---
 
-DNSimple supports the ability to manage domains that are registered with other domain providers external to DNSimple. DNSimple calls such providers "integrated domain providers".
+DNSimple supports the ability to manage domains that are registered with other domain providers external to DNSimple. DNSimple calls such providers "Integrated Domain Providers".
 
 ## Supported Features
 
-- **Import integrated domains**: When you link an integrated domain provider to your DNSimple account, domains registered via that integrated domain provider will be imported into DNSimple and listed on the Domain Names page.
+- **Import integrated domains**: When you link an Integrated Domain Provider to your DNSimple account, domains registered via that Integrated Domain Provider will be imported into DNSimple and listed on the Domain Names page.
 - **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, name servers from the DNSimple dashboard.
-- **Register domains via DNSimple**: Learn how to [register](/articles/registering-domain) a domain on your integrated provider via DNSimple.
+- **Register domains via DNSimple**: Learn how to [register](/articles/registering-domain) a domain on your Integrated Provider via DNSimple.
 - **Transfer your domain to DNSimple easily**: Read more about [transferring](/articles/integrated-domain-provider-transfer-domain) your domains.
 - **Domain expiration notices**: Get email notifications when your integrated domains are near expiry.
 
 ## Supported Integrated Domain Providers
 
-To manage integrated domains from DNSimple, you first have to link an integrated domain provider to your DNSimple account.
+To manage integrated domains from DNSimple, you first have to link an Integrated Domain Provider to your DNSimple account.
 
 DNSimple supports domain integration with the providers listed below.
 
@@ -36,15 +36,15 @@ DNSimple supports domain integration with the providers listed below.
 ## Linking an Integrated Domain Provider to your account {#linking-integrated-domain-provider}
 
 1. At DNSimple, go to the <label>Account</label> page, and click the <label>Integrated Providers</label> tab.
-1. Under <label>Add an integrated provider<label>, click the link button for the integrated domain provider you want to link to your DNSimple account.
-![Link an integrated domain provider](/files/account-integrated-domain-provider-link.png)
-1. Fill in any necessary information and credentials for your account at the integrated domain provider.
-![Enter integrated domain provider credentials](/files/account-integrated-domain-provider-link-credentials.png)
-1. After successfully linking the integrated domain provider, you will be redirected to the Domain Names page, where you can [manage your integrated domains](/articles/managing-integrated-domains).
+1. Under <label>Add an Integrated Provider<label>, click the link button for the Integrated Domain Provider you want to link to your DNSimple account.
+![Link an Integrated Domain Provider](/files/account-integrated-domain-provider-link.png)
+1. Fill in any necessary information and credentials for your account at the Integrated Domain Provider.
+![Enter Integrated Domain Provider credentials](/files/account-integrated-domain-provider-link-credentials.png)
+1. After successfully linking the Integrated Domain Provider, you will be redirected to the Domain Names page, where you can [manage your integrated domains](/articles/managing-integrated-domains).
 ![Domain Names page](/files/domain-names.png)
 
 ## Unlinking an Integrated Domain Provider from your account
 
 1. At DNSimple, go to the <label>Account</label> page, and click the <label>Integrated Providers</label> tab.
-1. Under <label>Linked providers<label>, click the <label>Remove</label> button for the integrated domain provider you want to unlink from your DNSimple account. This will disable the ability to refresh the state of the imported domains from the linked provider via DNSimple.
-![Unlink an integrated domain provider](/files/account-integrated-domain-provider-unlink.png)
+1. Under <label>Linked providers<label>, click the <label>Remove</label> button for the Integrated Domain Provider you want to unlink from your DNSimple account. This will disable the ability to refresh the state of the imported domains from the linked provider via DNSimple.
+![Unlink an Integrated Domain Provider](/files/account-integrated-domain-provider-unlink.png)

--- a/content/articles/managing-integrated-domains.markdown
+++ b/content/articles/managing-integrated-domains.markdown
@@ -8,7 +8,7 @@ categories:
 
 # Managing Integrated Domains
 
-From the Domains page, you can view the refreshed state of your DNSimple domains alongside domains from [integrated domain providers](/articles/integrated-domain-providers).
+From the Domains page, you can view the refreshed state of your DNSimple domains alongside domains from [Integrated Domain Providers](/articles/integrated-domain-providers).
 
 <div class="section-steps" markdown="1">
 ##### Viewing integrated domains from the Domains page
@@ -23,7 +23,7 @@ From the Domains page, you can view the refreshed state of your DNSimple domains
 
 ## Refreshing integrated domains {#refreshing-integrated-domains}
 
-Loading the Domain Names page automatically refreshes the current state of integrated domains and imports any new domains from linked integrated domain providers.
+Loading the Domain Names page automatically refreshes the current state of integrated domains and imports any new domains from linked Integrated Domain Providers.
 
 
 ## Managing an integrated domain {#managing-an-integrated-domain}

--- a/content/articles/managing-integrated-zones.markdown
+++ b/content/articles/managing-integrated-zones.markdown
@@ -7,7 +7,7 @@ categories:
 
 # Managing Integrated Zones
 
-From the Domain Names page, you can view the refreshed state of your DNSimple zones alongside zones from [integrated DNS providers](/articles/integrated-dns-providers).
+From the Domain Names page, you can view the refreshed state of your DNSimple zones alongside zones from [Integrated DNS Providers](/articles/integrated-dns-providers).
 
 <div class="section-steps" markdown="1">
 ##### Accessing the Domain Names page
@@ -16,11 +16,11 @@ From the Domain Names page, you can view the refreshed state of your DNSimple zo
 
     ![Domain Names Tab](/files/domain-names-tab.png)
 
-1.  On the <label>Domain Names</label> page, the zones in your DNSimple account and zones from [integrated DNS providers](/articles/integrated-dns-providers) will be listed. Click any linked zone to enter the [Deployment Editor](/articles/deployment-editor) and manage the zone's records. The labels under the DNS Zones column indicate which DNS provider(s) the zone can be managed at.
+1.  On the <label>Domain Names</label> page, the zones in your DNSimple account and zones from [Integrated DNS Providers](/articles/integrated-dns-providers) will be listed. Click any linked zone to enter the [Deployment Editor](/articles/deployment-editor) and manage the zone's records. The labels under the DNS Zones column indicate which DNS provider(s) the zone can be managed at.
 
     ![Domain Names Integrated Zones Table](/files/domain-names-integrated-zones.png)
 </div>
 
 ## Refreshing and importing integrated zones {#refreshing-and-importing-integrated-zones}
 
-Loading the Domain Names page automatically [refreshes](/articles/deployment-editor#refreshing-integrated-zone-records) the current state of integrated zones and imports any new zones and their records from linked integrated DNS providers that support import. The new zones and zone records will be fetched in the background upon page load, and the Domain Names page will automatically update to reflect them once ready.
+Loading the Domain Names page automatically [refreshes](/articles/deployment-editor#refreshing-integrated-zone-records) the current state of integrated zones and imports any new zones and their records from linked Integrated DNS Providers that support import. The new zones and zone records will be fetched in the background upon page load, and the Domain Names page will automatically update to reflect them once ready.

--- a/content/articles/registering-domain.markdown
+++ b/content/articles/registering-domain.markdown
@@ -18,7 +18,7 @@ When applicable, we recommend opting for our "auto-renew" feature to avoid your 
 1. Click Add from your Dashboard in the appropriate account's card if you have more than one.
 1. Click Register domain
 1. Fill out the domain name.
-1. If you have linked an [integrated domain provider](/articles/integrated-domain-providers), you can choose to register your domain through them or through DNSimple.
+1. If you have linked an [Integrated Domain Provider](/articles/integrated-domain-providers), you can choose to register your domain through them or through DNSimple.
 1. Choose whether you'd like Whois Privacy Protection or auto-renewal on the domain (if applicable).
 1. Click Register Domain.
 1. Provide contact details for the registrant of the domain, or choose a contact from those you've already created.


### PR DESCRIPTION
Updates existing support articles to have the correct capitalization for Integrated Providers, Integrated DNS Providers, and Integrated Domain Providers. 

Updates style to capitalize H1 & lowercase H2 as per https://support.dnsimple.com/articles/writing-guide/ (will be conducting an audit for this and other issues across all support articles in the near future) 