### PR TITLE
Remove mention of GoDaddy domain registration

### DIFF
--- a/content/articles/integrated-domain-provider-godaddy.md
+++ b/content/articles/integrated-domain-provider-godaddy.md
@@ -28,7 +28,6 @@ DNSimple supports the ability to manage domains that are registered through [GoD
 
 - **Import integrated domains**: When you link an Integrated Domain Provider to your DNSimple account, domains registered via that Integrated Domain Provider will be imported into DNSimple and listed on the Domains page.
 - **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, and name servers from the DNSimple dashboard.
-- **Register domains via DNSimple**: Learn how to [register](/articles/registering-domain) a domain on GoDaddy via DNSimple.
 - **Transfer your domain to DNSimple easily**: Read more about [transferring](/articles/integrated-domain-provider-transfer-domain) domains.
 - **Domain expiration notices**: Get email notifications when your integrated domains are near expiry.
 
@@ -38,13 +37,11 @@ To link [GoDaddy](https://www.godaddy.com) as an Integrated Domain Provider, you
 
 - An [API key and API secret](https://developer.godaddy.com/keys) for the Production GoDaddy environment
 - The [customer number](https://godaddy.com/help/what-is-my-customer-number-20038) of your GoDaddy account
-- If you want to register domains, you will need a [Good as Gold account](https://godaddy.com/help/what-is-good-as-gold-3359) set up with GoDaddy
 
 ## Invoice and billing
 
 For operations concerning the registration of your domain, like:
 
-- Registering the domain
 - Renewing the domain
 - Turning auto renewal on and off
 - Turning whois privacy on and off

--- a/content/articles/integrated-domain-providers.md
+++ b/content/articles/integrated-domain-providers.md
@@ -22,7 +22,6 @@ DNSimple supports the ability to manage domains that are registered with other d
 
 - **Import integrated domains**: When you link an Integrated Domain Provider to your DNSimple account, domains registered via that Integrated Domain Provider will be imported into DNSimple and listed on the Domain Names page.
 - **View and manage integrated domains**: View the expiry date, delegation name servers, domain registration contact, and DNSSEC information of your integrated domains from DNSimple. You can also manage your domain's WHOIS Privacy, renewal, name servers from the DNSimple dashboard.
-- **Register domains via DNSimple**: Learn how to [register](/articles/registering-domain) a domain on your Integrated Provider via DNSimple.
 - **Transfer your domain to DNSimple easily**: Read more about [transferring](/articles/integrated-domain-provider-transfer-domain) your domains.
 - **Domain expiration notices**: Get email notifications when your integrated domains are near expiry.
 


### PR DESCRIPTION
We will be disabling GoDaddy domain registrations in the DNSimple app. This update removes any mention of GoDaddy domain registrations in the support site.

Belongs to https://github.com/dnsimple/dnsimple-app/issues/26047