### PR TITLE
Adding alt tags to all images with missing alts

### DIFF
--- a/content/articles/dashboard.md
+++ b/content/articles/dashboard.md
@@ -12,46 +12,46 @@ categories:
 
 Your DNSimple Dashboard contains all of the important highlights for each of your DNSimple accounts: important messages, account overviews and account activity.
 
-![](/files/dashboard-account-cards.png)
+![screenshot: Showing multiple account cards](/files/dashboard-account-cards.png)
 
 ## Important messages
 
 If you have important messages, they'll appear at the top of your dashboard, giving you full visibility of domains that have expired or need your attention.
 
-![](/files/dashboard-important-reminder.png)
+![screenshot: Showing notifications for domains](/files/dashboard-important-reminder.png)
 
-Under these messages, you'll find snapshots for every account you have access to as an authorized user. 
+Under these messages, you'll find snapshots for every account you have access to as an authorized user.
 
-![](/files/dashboard-account-card.png)
+![screenshot: Showing counts of domains, zones, certificates, and contacts](/files/dashboard-account-card.png)
 
 If you have more than one account, or if you started to create a new account and haven't completed it yet, it will appear like this:
 
-![](/files/dashboard-multiple-account-card.png)
+![screenshot: Showing incomplete secondary account](/files/dashboard-multiple-account-card.png)
 
 ## Account overview
 
-Each account has its own corresponding square on the dashboard. You'll see the [name of the account](/articles/changing-account-information/#changing-other-account-data) in the upper left corner of the square and the [plan type](/articles/changing-account-information/#changing-other-account-data) this specific account is subscribed to. 
+Each account has its own corresponding square on the dashboard. You'll see the [name of the account](/articles/changing-account-information/#changing-other-account-data) in the upper left corner of the square and the [plan type](/articles/changing-account-information/#changing-other-account-data) this specific account is subscribed to.
 
-![](/files/dashboard-account-name.png)
+![screenshot: Showing dashboard account card](/files/dashboard-account-name.png)
 
 To the right, you'll find an **Add** dropdown. This expands to a list of shortcuts, making it even easier to manage and add new domains quickly. If you select an option that is not available on your [current plan](/articles/dnsimple-plans), you will be directed to a page advising you of this after selecting the option.
 
-![](/files/dashboard-account-card-add-dropdown.png)
+![screenshot: Showing options for adding domains](/files/dashboard-account-card-add-dropdown.png)
 
 Below, you'll see a breakdown of what is currently in each account.
 
-![](/files/dashboard-account-card-category.png)
+![screenshot: Showing counts of domains dns contacts and ssl certificates](/files/dashboard-account-card-category.png)
 
-- **Registered Domains** - the number of domains registered with DNSimple, or with an Integrated Provider. 
-- **DNS Zones** - the number of [currently active](/articles/managing-integrated-zones/) domains. This includes zones resolving with DNSimple or with an Integrated Provider.  
+- **Registered Domains** - the number of domains registered with DNSimple, or with an Integrated Provider.
+- **DNS Zones** - the number of [currently active](/articles/managing-integrated-zones/) domains. This includes zones resolving with DNSimple or with an Integrated Provider.
 - **SSL Certificates** - the number of active certificates that are attached to active zones.
-- **Contacts** - every [contact](/articles/contact-management/) you've created for this account. Contacts are required when you're registering or transferring a domain, or issuing an SSL certificate.  
+- **Contacts** - every [contact](/articles/contact-management/) you've created for this account. Contacts are required when you're registering or transferring a domain, or issuing an SSL certificate.
 
-## Adding a new account 
+## Adding a new account
 
-Below all account cards you'll find **+ Add new account**. Select this to easily set up your [new account](/articles/account-creation/). 
+Below all account cards you'll find **+ Add new account**. Select this to easily set up your [new account](/articles/account-creation/).
 
-## Managing domains across multiple accounts 
+## Managing domains across multiple accounts
 
 As your account lists grow, you'll notice a **Search By Account Name** bar above the list of account cards. Just type in the name of the account you want to work with to easily find it.
 
@@ -61,9 +61,9 @@ The **Latest activity** section provides a view of activity across all accounts 
 
 Similar to the activity view, the information displayed highlights the *Type, Event, Text, User, Date, and Account*. Each is linked to the individual event listed, so you can see information specific to an account without scrolling back up to the account card.
 
-To learn more about the highlighted categories and how the information is organized, read [this guide](/articles/activity-tracking/#activity-tracking-at-the-account-level). From the individual account and domain activity views, you can filter based on events to easily find what you need. 
+To learn more about the highlighted categories and how the information is organized, read [this guide](/articles/activity-tracking/#activity-tracking-at-the-account-level). From the individual account and domain activity views, you can filter based on events to easily find what you need.
 
-## Have more questions? 
+## Have more questions?
 
 The DNSimple Dashboard gives authorized users a comprehensive view of their DNSimple accounts. You can have accounts specific to your clients, customers, departments, or anything that makes sense to you. We value your time and want you to be able to access everything you need - simply.
 

--- a/content/articles/domain-list.md
+++ b/content/articles/domain-list.md
@@ -10,7 +10,7 @@ categories:
 
 <iframe width="791" height="445" src="https://www.youtube.com/embed/PGa3Jk3nnGM" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-The DNSimple Domain List is your home base for all the domains in your account. You'll see domains registered with DNSimple, with our Integrated Providers, and domains registered elsewhere that point to our name servers or those of an Integrated Provider. 
+The DNSimple Domain List is your home base for all the domains in your account. You'll see domains registered with DNSimple, with our Integrated Providers, and domains registered elsewhere that point to our name servers or those of an Integrated Provider.
 
 ## Navigating to the Domain List
 
@@ -18,37 +18,37 @@ There are three ways to access the list of domain names within each account:
 
 Select Registered Domains or DNS Zones from the account you want to view in your DNSimple Dashboard.
 
-![](/files/domain-list-account-card-selection.png)
+![screenshot: Showing count of domains and DNS zones](/files/domain-list-account-card-selection.png)
 
 Select the account from the top navigation bar.
 
 If you're already in the account but on another page, select Domain Names from the account navigation bar.
 
-![](/files/domain-list-domain-name-arrow.png)
+![screenshot: Showing link to domain names in the navigation](/files/domain-list-domain-name-arrow.png)
 
-The account you're viewing is bolded so you can verify you're in the correct account. 
+The account you're viewing is bolded so you can verify you're in the correct account.
 
 ## List view
 
-The page displays the first 50 domains in your account. 
+The page displays the first 50 domains in your account.
 
 If you have more than 50, use the pagination under the domain list to view next and previous pages, or jump to a specific page.
 
 Each domain has an overview with the following information:
 
-![](/files/domain-list-headers.png)
+![screenshot: Showing table headers for the domain list table](/files/domain-list-headers.png)
 
- ### Domain Name 
- A clickable link to the domain-specific home page to view, edit and manage the DNS and Domain Management. 
+ ### Domain Name
+ A clickable link to the domain-specific home page to view, edit and manage the DNS and Domain Management.
 
-### Domain Registration 
+### Domain Registration
 The state of the domain in DNSimple.
  - **Transfer Domain** - indicates the domain is not registered with DNSimple or an Integrated Provider. Click the link attached to begin the transfer process.
  - **Registered** - indicates the domain is registered with DNSimple or an Integrated Provider. Clicking Registered will take you directly to the domain's registration hub.
    - If the domain is registered with DNSimple, it will display the expiration date, and auto-renew (if enabled). If the domain is not set to auto-renew, it will not be included in the quick view, and can be turned on by following [these steps](/articles/domain-auto-renewal/).
    - If the domain is registered with an Integrated Provider, that provider is also displayed.
 
-![](/files/domain-list-godaddy-autorenew.png)
+![screenshot: Showing a domain that is registered with GoDaddy](/files/domain-list-godaddy-autorenew.png)
 
 ### DNS Zones
 
@@ -56,51 +56,51 @@ This indicates whether you have activated the zones and if the domain is resolvi
 
 If it's active and resolving with DNSimple, it will appear like this:
 
-![](/files/domain-list-active-zone.png)
+![screenshot: Showing active domain](/files/domain-list-active-zone.png)
 
 If it's active and resolving with an Integrated Provider, that provider will also be displayed.
 
-![](/files/domain-list-active-zone-route53.png)
+![screenshot: Showing domain which has activated route53 as a zone](/files/domain-list-active-zone-route53.png)
 
 If the domain does not have the zones activated within your DNSimple account, it will show as Inactive.
 
-![](/files/domain-list-inactive-zone.png)
+![screenshot: Showing domain which is inactive](/files/domain-list-inactive-zone.png)
 
 Learn more about Active and Inactive Zones and how to manage them [here](/articles/dns-hosting/).
 
-### Certificates 
+### Certificates
 
 This section displays all certificates currently issued to domains registered with DNSimple or an Integrated Provider.
 
 If the domain has active certificates attached, they will be displayed, along with an identifier for the type of certificate issued. Clicking the link takes you to the domain-specific certificate page:
 
-![](/files/domain-list-one-certificate.png)
+![screenshot: Showing lets encrypt certificate](/files/domain-list-one-certificate.png)
 
 If the domain is registered or resolving with DNSimple but does not have an active certificate, click the link shown below to add one:
 
-![](/files/domain-list-add-certificate.png)
+![screenshot: Showing add certificate link](/files/domain-list-add-certificate.png)
 
 If the field is empty, the domain is registered elsewhere **and** resolving elsewhere. To learn more about certificates, visit [this guide](/articles/getting-started-ssl-certificates/).
 
-### Last Updated  
-Displays the date of the last activity logged for this domain. 
+### Last Updated
+Displays the date of the last activity logged for this domain.
 
-### Add to Favorites 
-While not specified in the header, the stars to the right of each domain let you add them to your favorites for easy access. 
+### Add to Favorites
+While not specified in the header, the stars to the right of each domain let you add them to your favorites for easy access.
 
-### Add new 
+### Add new
 Above the Domain List view, you'll see an "Add new" dropdown.
 
-![](/files/domain-list-add-new.png)
+![screenshot: Showing add new domain dropdown](/files/domain-list-add-new.png)
 
-Click this button, and the menu will provide you with easy access to the many ways to manage your domains in DNSimple. 
+Click this button, and the menu will provide you with easy access to the many ways to manage your domains in DNSimple.
 
-![](/files/domain-list-add-new-dropdown.png)
+![screenshot: Showing menu of actions to take on a domain](/files/domain-list-add-new-dropdown.png)
 
 ### Label domains
-At the bottom of your domain list, you'll see a button to add Labels. 
+At the bottom of your domain list, you'll see a button to add Labels.
 
 This option allows for optimal organization and understanding of the specifics to the domains in your account. Learn more about the available options in [this guide](/articles/labeling-domains/).
 
-## Have more questions? 
+## Have more questions?
 Now you can use the Domain List to organize, view and manage your domains. Efficient domain management is only a click away. Have questions or feedback? [Get in touch](https://dnsimple.com/feedback) - our team is always happy to help.

--- a/content/articles/domain-list.md
+++ b/content/articles/domain-list.md
@@ -10,7 +10,7 @@ categories:
 
 <iframe width="791" height="445" src="https://www.youtube.com/embed/PGa3Jk3nnGM" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-The DNSimple Domain List is your home base for all the domains in your account. You'll see domains registered with DNSimple, with our Integrated Providers, and domains registered elsewhere that point to our name servers or those of an Integrated Provider. 
+The DNSimple Domain List is your home base for all the domains in your account. You'll see domains registered with DNSimple, with our Integrated Providers, and domains registered elsewhere that point to our name servers or those of an Integrated Provider.
 
 ## Navigating to the Domain List
 
@@ -18,37 +18,37 @@ There are three ways to access the list of domain names within each account:
 
 Select Registered Domains or DNS Zones from the account you want to view in your DNSimple Dashboard.
 
-![](/files/domain-list-account-card-selection.png)
+![screenshot: Showing count of domains and DNS zones](/files/domain-list-account-card-selection.png)
 
 Select the account from the top navigation bar.
 
 If you're already in the account but on another page, select Domain Names from the account navigation bar.
 
-![](/files/domain-list-domain-name-arrow.png)
+![screenshot: Showing link to domain names in the navigation](/files/domain-list-domain-name-arrow.png)
 
-The account you're viewing is bolded so you can verify you're in the correct account. 
+The account you're viewing is bolded so you can verify you're in the correct account.
 
 ## List view
 
-The page displays the first 50 domains in your account. 
+The page displays the first 50 domains in your account.
 
 If you have more than 50, use the pagination under the domain list to view next and previous pages, or jump to a specific page.
 
 Each domain has an overview with the following information:
 
-![](/files/domain-list-headers.png)
+![screenshot: Showing table headers for the domain list table](/files/domain-list-headers.png)
 
-### Domain Name
-A clickable link to the domain-specific home page to view, edit and manage the DNS and Domain Management.
+ ### Domain Name
+ A clickable link to the domain-specific home page to view, edit and manage the DNS and Domain Management.
 
-### Domain Registration 
+### Domain Registration
 The state of the domain in DNSimple.
  - **Transfer Domain** - indicates the domain is not registered with DNSimple or an Integrated Provider. Click the link attached to begin the transfer process.
  - **Registered** - indicates the domain is registered with DNSimple or an Integrated Provider. Clicking Registered will take you directly to the domain's registration hub.
    - If the domain is registered with DNSimple, it will display the expiration date, and auto-renew (if enabled). If the domain is not set to auto-renew, it will not be included in the quick view, and can be turned on by following [these steps](/articles/domain-auto-renewal/).
    - If the domain is registered with an Integrated Provider, that provider is also displayed.
 
-![](/files/domain-list-godaddy-autorenew.png)
+![screenshot: Showing a domain that is registered with GoDaddy](/files/domain-list-godaddy-autorenew.png)
 
 ### DNS Zones
 
@@ -56,51 +56,51 @@ This indicates whether you have activated the zones and if the domain is resolvi
 
 If it's active and resolving with DNSimple, it will appear like this:
 
-![](/files/domain-list-active-zone.png)
+![screenshot: Showing active domain](/files/domain-list-active-zone.png)
 
 If it's active and resolving with an Integrated Provider, that provider will also be displayed.
 
-![](/files/domain-list-active-zone-route53.png)
+![screenshot: Showing domain which has activated route53 as a zone](/files/domain-list-active-zone-route53.png)
 
 If the domain does not have the zones activated within your DNSimple account, it will show as Inactive.
 
-![](/files/domain-list-inactive-zone.png)
+![screenshot: Showing domain which is inactive](/files/domain-list-inactive-zone.png)
 
 Learn more about Active and Inactive Zones and how to manage them [here](/articles/dns-hosting/).
 
-### Certificates 
+### Certificates
 
 This section displays all certificates currently issued to domains registered with DNSimple or an Integrated Provider.
 
 If the domain has active certificates attached, they will be displayed, along with an identifier for the type of certificate issued. Clicking the link takes you to the domain-specific certificate page:
 
-![](/files/domain-list-one-certificate.png)
+![screenshot: Showing lets encrypt certificate](/files/domain-list-one-certificate.png)
 
 If the domain is registered or resolving with DNSimple but does not have an active certificate, click the link shown below to add one:
 
-![](/files/domain-list-add-certificate.png)
+![screenshot: Showing add certificate link](/files/domain-list-add-certificate.png)
 
 If the field is empty, the domain is registered elsewhere **and** resolving elsewhere. To learn more about certificates, visit [this guide](/articles/getting-started-ssl-certificates/).
 
-### Last Updated  
-Displays the date of the last activity logged for this domain. 
+### Last Updated
+Displays the date of the last activity logged for this domain.
 
-### Add to Favorites 
-While not specified in the header, the stars to the right of each domain let you add them to your favorites for easy access. 
+### Add to Favorites
+While not specified in the header, the stars to the right of each domain let you add them to your favorites for easy access.
 
-### Add new 
+### Add new
 Above the Domain List view, you'll see an "Add new" dropdown.
 
-![](/files/domain-list-add-new.png)
+![screenshot: Showing add new domain dropdown](/files/domain-list-add-new.png)
 
-Click this button, and the menu will provide you with easy access to the many ways to manage your domains in DNSimple. 
+Click this button, and the menu will provide you with easy access to the many ways to manage your domains in DNSimple.
 
-![](/files/domain-list-add-new-dropdown.png)
+![screenshot: Showing menu of actions to take on a domain](/files/domain-list-add-new-dropdown.png)
 
 ### Label domains
-At the bottom of your domain list, you'll see a button to add Labels. 
+At the bottom of your domain list, you'll see a button to add Labels.
 
 This option allows for optimal organization and understanding of the specifics to the domains in your account. Learn more about the available options in [this guide](/articles/labeling-domains/).
 
-## Have more questions? 
+## Have more questions?
 Now you can use the Domain List to organize, view and manage your domains. Efficient domain management is only a click away. Have questions or feedback? [Get in touch](https://dnsimple.com/feedback) - our team is always happy to help.

--- a/content/articles/domains-xxx.md
+++ b/content/articles/domains-xxx.md
@@ -22,7 +22,7 @@ In order for a .XXX domain to be activated by the .XXX registry and be allowed t
 
 You can provide the token during the registration in the UI or as an extended attribute via API:
 
-![](/files/xxx-member-auth-token.png)
+![screenshot: Enter member authorization token](/files/xxx-member-auth-token.png)
 
 <strong>NOTE:</strong> Anyone can register non-resolving .XXX domains. Only individuals, business, entities, and organizations that:
 

--- a/content/articles/heroku-error-ssl.md
+++ b/content/articles/heroku-error-ssl.md
@@ -42,7 +42,7 @@ Here's a few possible variants of the error message, depending on the browser yo
 >
 > This server could not prove that it is **www.alpha.com**; its security certificate is from **www.bravo.com**. This may be caused by a misconfiguration or an attacker intercepting your connection.
 
-![](/files/heroku-ssl-error-commonname-chrome.png)
+![screenshot: Showing SSL certificate error in Chrome](/files/heroku-ssl-error-commonname-chrome.png)
 
 **Google Chrome**
 
@@ -50,8 +50,8 @@ Here's a few possible variants of the error message, depending on the browser yo
 >
 > You attempted to reach example.com, but instead you actually reached a server identifying itself as *.herokuapp.com. This may be caused by a misconfiguration on the server or by something more serious. An attacker on your network could be trying to get you to visit a fake (and potentially harmful) version of example.com.
 
-![](/files/heroku-ssl-error-commonname-chrome2.png)
+![screenshot: Showing SSL certificate error in Chrome](/files/heroku-ssl-error-commonname-chrome2.png)
 
 **Safari**
 
-![](/files/heroku-ssl-error-commonname-safari.png)
+![screenshot: Showing SSL certificate error in Safari](/files/heroku-ssl-error-commonname-safari.png)

--- a/content/articles/how-to-determine-certificate-authority.md
+++ b/content/articles/how-to-determine-certificate-authority.md
@@ -13,11 +13,11 @@ categories:
 
 When you request an SSL certificate with DNSimple, the certificate authority information are clearly visible in your SSL certificate page:
 
-![](/files/ssl-authority-order.png)
+![screenshot: Showing the SSL certificates page](/files/ssl-authority-order.png)
 
 Once the SSL certificate is issued, we also extract the identification of the Issuer (the Certificate Authority) from the certificate, and we display it in the certificate page:
 
-![](/files/ssl-authority-certificate.png)
+![screenshot: Showing a certificate on the certificates page](/files/ssl-authority-certificate.png)
 
 If you can't access your SSL certificate page, or you didn't request the certificate using DNSimple, then use the following generic procedure to determine the certificate authority.
 
@@ -28,7 +28,7 @@ To determine the [Certificate Authority](/articles/what-is-certificate-authority
 
 The steps to view the certificate information depend on the browser. For instance, in Google Chrome, click on the lock icon in the address bar, switch to the the <label>Connection</label> tab and click on <label>Certificate Information</label>.
 
-![](/files/dnsimple-certificate-determine-authority.png)
+![screenshot: Showing SSL Certificate information](/files/dnsimple-certificate-determine-authority.png)
 
 Search for the issuer organization name. Please note that, in some cases, Certificate Authorities may delegate the signing process to subsidiaries or acquired companies.
 

--- a/content/articles/manage-a-record.md
+++ b/content/articles/manage-a-record.md
@@ -27,11 +27,11 @@ The instructions in this article assume you're familiar with the [A record forma
 
 1.  In the record editor, click <label>Add</label> and select <label>A</label> to add a new A record.
 
-    ![](/files/record-a-create-select.png)
+    ![screenshot: Showing select menu for choosing to create a new A record](/files/record-a-create-select.png)
 
 1.  Enter the A record information.
 
-    ![](/files/record-a-create-new.png)
+    ![screenshot: Showing form for creating an A record for a domain](/files/record-a-create-new.png)
 
     - _Name_: the subdomain you want to create the record for, without the domain name. For example, if you want to represent `www.example.com` enter `www`. Leave it blank to represent the root domain `example.com`.
 
@@ -50,7 +50,7 @@ The instructions in this article assume you're familiar with the [A record forma
 
 1.  The record is created and visible in the record list.
 
-    ![](/files/record-a-item.png)
+    ![screenshot: Showing an A record for a domain](/files/record-a-item.png)
 
 </div>
 
@@ -62,7 +62,7 @@ The instructions in this article assume you're familiar with the [A record forma
 
 1.  In the record editor, search for the record and click on the _pencil_ icon to edit it.
 
-    ![](/files/record-a-item-edit.png)
+    ![screenshot: Showing button for editing an A record from a domain](/files/record-a-item-edit.png)
 
 1.  Update the information and click <label>Update Record</label> to save the record.
 </div>
@@ -75,7 +75,7 @@ The instructions in this article assume you're familiar with the [A record forma
 
 1.  In the record editor, search for the record and click on the _trash_ icon to delete it.
 
-    ![](/files/record-a-item-delete.png)
+    ![screenshot: Showing button for deleting an A record from a domain](/files/record-a-item-delete.png)
 
 1.  Confirm the dialog to delete the record.
 </div>

--- a/content/articles/manage-aaaa-record.md
+++ b/content/articles/manage-aaaa-record.md
@@ -27,11 +27,11 @@ The instructions in this article assume you're familiar with the [AAAA record fo
 
 1.  In the record editor, click <label>Add</label> and select <label>AAAA</label> to add a new AAAA record.
 
-    ![](/files/record-aaaa-create-select.png)
+    ![screenshot: Showing selection of AAAA for a new record for domain](/files/record-aaaa-create-select.png)
 
 1.  Enter the AAAA record information.
 
-    ![](/files/record-aaaa-create-new.png)
+    ![screenshot: Showing the form for creating a new AAAA record](/files/record-aaaa-create-new.png)
 
     - _Name_: the subdomain you want to create the record for, without the domain name. For example, if you want to represent `www.example.com` enter `www`. Leave it blank to represent the root domain `example.com`.
     - _IP Address_: the IPv6 address the record will resolve to.
@@ -46,7 +46,7 @@ The instructions in this article assume you're familiar with the [AAAA record fo
 
 1.  The record is created and will be visible in the record list.
 
-    ![](/files/record-aaaa-item.png)
+    ![screenshot: Showing a newly created AAAA record for a domain](/files/record-aaaa-item.png)
 
 </div>
 
@@ -58,7 +58,7 @@ The instructions in this article assume you're familiar with the [AAAA record fo
 
 1.  In the record editor, search for the record and click on the _pencil_ icon to edit it.
 
-    ![](/files/record-aaaa-item-edit.png)
+    ![screenshot: Showing button for editing a AAAA record](/files/record-aaaa-item-edit.png)
 
 1.  Update the information and click <label>Update Record</label> to save the record.
 </div>
@@ -71,7 +71,7 @@ The instructions in this article assume you're familiar with the [AAAA record fo
 
 1.  In the record editor, search for the record and click on the _trash_ icon to delete it.
 
-    ![](/files/record-aaaa-item-delete.png)
+    ![screenshot: Highlighting delete button for a AAAA record](/files/record-aaaa-item-delete.png)
 
 1.  Confirm the dialog to delete the record.
 </div>

--- a/content/articles/manage-caa-record.md
+++ b/content/articles/manage-caa-record.md
@@ -45,13 +45,13 @@ We don't support the ability to specify via interface the destructured CAA recor
 
 1.  In the record editor, click <label>Add</label> and select <label>CAA</label> to add a new CAA record.
 
-    ![](/files/record-caa-create-select.png)
+    ![screenshot: Showing selecting CAA from record type to add](/files/record-caa-create-select.png)
 
 1.  Select the <label>Provider</label> tab.
 
 1.  Enter the CAA record information.
 
-    ![](/files/record-caa-create-new.png)
+    ![screenshot: Showing create new CAA record form](/files/record-caa-create-new.png)
 
     - _Name_: the subdomain you want to create the record for, without the domain name. For example, if you want to represent `www.example.com` enter `www`. Leave it blank to represent the root domain `example.com`.
     - _Provider_: the Certificate Authority you want to allow.
@@ -67,7 +67,7 @@ We don't support the ability to specify via interface the destructured CAA recor
 
 1.  The record is created and visible in the record list.
 
-    ![](/files/record-caa-item.png)
+    ![screenshot: Showing a CAA record](/files/record-caa-item.png)
 
 </div>
 
@@ -79,7 +79,7 @@ We don't support the ability to specify via interface the destructured CAA recor
 
 1.  In the record editor, search for the record and click on the _pencil_ icon to edit it.
 
-    ![](/files/record-caa-item-edit.png)
+    ![screenshot: Showing button for edit CAA record](/files/record-caa-item-edit.png)
 
 1.  Update the information and click <label>Update Record</label> to save the record.
 </div>
@@ -92,7 +92,7 @@ We don't support the ability to specify via interface the destructured CAA recor
 
 1.  In the record editor, search for the record and click on the _trash_ icon to delete it.
 
-    ![](/files/record-caa-item-delete.png)
+    ![screenshot: showing delete button for CAA record](/files/record-caa-item-delete.png)
 
 1.  Confirm the dialog to delete the record.
 </div>

--- a/content/articles/manage-cname-record.md
+++ b/content/articles/manage-cname-record.md
@@ -27,11 +27,11 @@ The instructions in this article assume you're familiar with the [CNAME record f
 
 1.  In the record editor, click <label>Add</label> and select <label>CNAME</label> to add a new CNAME record.
 
-    ![](/files/record-cname-create-select.png)
+    ![screenshot: select add CNAME record](/files/record-cname-create-select.png)
 
 1.  Enter the CNAME record information.
 
-    ![](/files/record-cname-create-new.png)
+    ![screenshot: create new CNAME record form](/files/record-cname-create-new.png)
 
     - _Name_: the subdomain you want to create the record for, without the domain name. For example, if you want to represent `www.example.com` enter `www`. Leave it blank to represent the root domain `example.com`.
     - _Content_: the target host name this host will point to. It must be a host name (e.g. foo.bar.com) and not a URL (e.g. http://foo.bar.com or http://foo.bar.com/foo are invalid).
@@ -46,7 +46,7 @@ The instructions in this article assume you're familiar with the [CNAME record f
 
 1.  The record is created and visible in the record list.
 
-    ![](/files/record-cname-item.png)
+    ![screenshot: Showing a CNAME record](/files/record-cname-item.png)
 
 </div>
 
@@ -58,7 +58,7 @@ The instructions in this article assume you're familiar with the [CNAME record f
 
 1.  In the record editor, search for the record and click on the _pencil_ icon to edit it.
 
-    ![](/files/record-cname-item-edit.png)
+    ![screenshot: Showing button to edit a CNAME record](/files/record-cname-item-edit.png)
 
 1.  Update the information and click <label>Update Record</label> to save the record.
 </div>
@@ -71,7 +71,7 @@ The instructions in this article assume you're familiar with the [CNAME record f
 
 1.  In the record editor, search for the record and click on the _trash_ icon to delete it.
 
-    ![](/files/record-cname-item-delete.png)
+    ![screenshot: Showing button to delete a CNAME record](/files/record-cname-item-delete.png)
 
 1.  Confirm the dialog to delete the record.
 </div>

--- a/content/articles/manage-ds-record.md
+++ b/content/articles/manage-ds-record.md
@@ -83,11 +83,11 @@ The Add DS Record page will load. The form fields shown on the Add DS record pag
 
 1.  In the DS records page, search for the record and click on the _trash_ icon to delete it.
 
-    ![Delete DS Record](/files/ds-records-delete.png)
+    ![screenshot: Delete DS Record](/files/ds-records-delete.png)
 
 2.  Confirm the dialog to delete the record.
 
-    ![](/files/ds-records-delete-confirmation.png)
+    ![screenshot: Showing confirmation prior to deleting DS record](/files/ds-records-delete-confirmation.png)
 
 3.  The record is deleted and no longer visible in the record list.
 </div>

--- a/content/articles/manage-url-record.md
+++ b/content/articles/manage-url-record.md
@@ -27,11 +27,11 @@ The instructions in this article assume you're familiar with the [URL record for
 
 1.  In the record editor, click <label>Add</label> and select <label>URL</label> to add a new URL record.
 
-    ![](/files/record-url-create-select.png)
+    ![screenshot: Selecting URL record from list of record types](/files/record-url-create-select.png)
 
 1.  Enter the URL record information.
 
-    ![](/files/record-url-create-new.png)
+    ![screenshot: Create new URL record form](/files/record-url-create-new.png)
 
     - _Name_: the subdomain you want to redirect, without the domain name. For example, if you want to redirect `www.example.com` enter `www`. Leave it blank to redirect the root domain `example.com`.
     - _Content_: the redirect target URL. It must be a URL (e.g. `https://foo.bar.com`). It can also contain a path, query and any other standard URL components (e.g. `http://foo.bar.com/path/to/site?redir=1`).
@@ -46,7 +46,7 @@ The instructions in this article assume you're familiar with the [URL record for
 
 1.  The record is created and visible in the record list.
 
-    ![](/files/record-url-item.png)
+    ![screenshot: Showing new URL record form](/files/record-url-item.png)
 
 </div>
 
@@ -58,7 +58,7 @@ The instructions in this article assume you're familiar with the [URL record for
 
 1.  In the record editor, search for the record and click on the _pencil_ icon to edit it.
 
-    ![](/files/record-url-item-edit.png)
+    ![screenshot: Showing button to edit an existing URL record](/files/record-url-item-edit.png)
 
 1.  Update the information and click <label>Update Record</label> to save the record.
 </div>
@@ -71,7 +71,7 @@ The instructions in this article assume you're familiar with the [URL record for
 
 1.  In the record editor, search for the record and click on the _trash_ icon to delete it.
 
-    ![](/files/record-url-item-delete.png)
+    ![Screenshot: Showing button for deleting a URL record](/files/record-url-item-delete.png)
 
 1.  Confirm the dialog to delete the record.
 </div>

--- a/content/articles/multi-factor-authentication.md
+++ b/content/articles/multi-factor-authentication.md
@@ -51,7 +51,7 @@ When you enable MFA for your user profile, you'll be logged out of all currently
 
 1.  The setup process ends here if you have an alternative MFA method already set up; however, if this is the only multi-factor authentication method you have set up, a [recovery code](#recovery-code) will be generated, and you'll need to confirm the recovery code. Copy and store the [recovery code](#recovery-code) in a safe place.
 
-    ![Multi-factor recovery code](/files/user-mfa-authenticator-recovery-code.png)      
+    ![Multi-factor recovery code](/files/user-mfa-authenticator-recovery-code.png)
 
 1.  Follow the instructions to complete the setup and activate multi-factor authentication via one-time password.
 
@@ -134,7 +134,7 @@ You can remove a one-time password authenticator application or any security key
 </div>
 
 ## Logging in with multi-factor authentication {#login}
-When multi-factor protection is enabled, you must perform a second verification step each time you log in with your username and password. The second verification step can be done with an authentication method you have enabled, like one-time passwords or security keys. 
+When multi-factor protection is enabled, you must perform a second verification step each time you log in with your username and password. The second verification step can be done with an authentication method you have enabled, like one-time passwords or security keys.
 
 <div class="section-steps" markdown="1">
 ##### Using a one-time password
@@ -164,7 +164,7 @@ The verification code automatically expires every 30 seconds. If the expiration 
 
 1.  Log in to DNSimple with your username and password.
 
-1.  If the credentials are correct, you'll see a 2-Step Verification window. 
+1.  If the credentials are correct, you'll see a 2-Step Verification window.
 
     ![Multi-factor authentication](/files/mfa-login-security-key.png)
 
@@ -194,11 +194,11 @@ When you enter a valid recovery code, multi-factor protection will immediately b
 
 1.  On the 2-Step Verification page, click <label>Use recovery code</label>.
 
-    ![](/files/user-mfa-login-recovery-code.png)
+    ![screenshot: Use recovery code for MFA](/files/user-mfa-login-recovery-code.png)
 
 1.  Enter the recovery code, and click <label>Log in and disable all multi-factor authentications</label>.
 
-    ![](/files/user-mfa-disable-with-recovery-code.png)
+    ![screenshot: Use recovery code disables MFA authentication](/files/user-mfa-disable-with-recovery-code.png)
 
 1.  If the recovery code is correct, MFA protection will immediately be disabled for the account.
 </div>
@@ -295,6 +295,6 @@ Sometimes, a one-time password verification code may not be accepted, despite en
 
 The verification code automatically expires every 30 seconds. Most one-time password authenticator apps display a count-down with the remaining time before expiration.
 
-![](/files/2fa-code-expiration.png)
+![screenshot: Display of countdown of 2fa code expiration](/files/2fa-code-expiration.png)
 
 If the expiration is close to five seconds or less, you should wait for the next verification code to limit the possibility of an authentication failure caused by time differences or connection latency.

--- a/content/articles/ssl-certificates-email-validation.md
+++ b/content/articles/ssl-certificates-email-validation.md
@@ -93,7 +93,7 @@ You select the validation email when you purchase the certificate. You can use o
 
 1.  Read the list of all available approver emails.
 
-    ![](/files/dnsimple-ssl-selectapprover.png)
+    ![screenshot: Select email to receive SSL approval message](/files/dnsimple-ssl-selectapprover.png)
 
 2.  Choose the email address you want to use by clicking on it.
 3.  Click *Send Approver Email* to configure and submit the certificate for validation.
@@ -113,11 +113,11 @@ If the approver is not in this list or you need time to configure one of those e
 
 1.  Click <label>complete the setup process now</label>.
 
-    ![](/files/dnsimple-ssl-completesetup.png)
+    ![screenshot: Complete the SSL setup process](/files/dnsimple-ssl-completesetup.png)
 
 1.  Read the list of all available approver emails.
 
-    ![](/files/dnsimple-ssl-selectapprover.png)
+    ![screenshot: Select email address to approve the certificate](/files/dnsimple-ssl-selectapprover.png)
 
 1.  Choose the email address you want to use by clicking on it.
 1.  Click <label>Send Approver Email</label> to configure and submit the certificate for validation.

--- a/content/articles/ssl-certificates-types.md
+++ b/content/articles/ssl-certificates-types.md
@@ -33,7 +33,7 @@ The order normally takes from a few minutes to a few hours.
 
 If the certificate is valid and signed by a trusted authority, the browsers indicate a successfully secured HTTPS connection.
 
-![](/files/dnsimple-ssltypes-https.png)
+![screenshot: Showing an accepted SSL certificate in a browser URL bar](/files/dnsimple-ssltypes-https.png)
 
 <info>
 DNSimple provides both [single-name and wildcard](/articles/ssl-certificates) domain-validated certificates.
@@ -49,7 +49,7 @@ The order can take from a few hours to a few days, due to the company validation
 
 The Organization Validated SSL Certificates display the company information in the certificate details.
 
-![](/files/dnsimple-ssltypes-company.png)
+![screenshot: Viewing information of an SSL company certificate](/files/dnsimple-ssltypes-company.png)
 
 <info>
 DNSimple currently doesn't provide organization-validated certificates.
@@ -65,7 +65,7 @@ The order can take from a few days to a few weeks, due to the extended validatio
 
 The Extended Validation SSL Certificates are generally identified with a green address bar in the browser containing the company name.
 
-![](/files/dnsimple-ssltypes-greenbar.png)
+![screenshot: Showing green url bar when a SSL certificate is present on a site](/files/dnsimple-ssltypes-greenbar.png)
 
 <info>
 DNSimple currently doesn't provide extended validation certificates. However, we provide a recommendation for a CA that does [here](/articles/can-ev-ssl-certificates).

--- a/content/articles/transferring-domain-between-accounts.md
+++ b/content/articles/transferring-domain-between-accounts.md
@@ -32,7 +32,7 @@ When transferring a domain to another DNSimple account, the domain's registrant 
 
 To transfer a domain to another DNSimple account, go to the domain's management page, click on the _Settings_ tab and then follow the <label>Transfer ownership</label> link.
 
-![](/files/transfer-ownership.png)
+![screenshot: Initiate domain transfer](/files/transfer-ownership.png)
 
 Enter the destination email address of another DNSimple account. Make sure the email address you enter matches the correct account. Once the domain has been transferred, you won't be able to control this domain under your current account.
 
@@ -44,11 +44,11 @@ Make sure to use the [account email address](/articles/changing-account-email/),
 
 If another DNSimple account holder (or Reseller) attempts to push a domain into your account, you have to accept it before it will be added. You'll receive a notification on your domain list indicating the pending push.
 
-![](/files/pending-push-notification.png)
+![screenshot: Notification of pending pushes](/files/pending-push-notification.png)
 
 When you review your pending pushes, you'll see a list with the option to accept or reject the domain being pushed to you.
 
-![](/files/pending-pushes.jpg)
+![screenshot: Accept or reject pending push](/files/pending-pushes.jpg)
 
 Click the <label>Accept</label> button. You'll be prompted to assign an existing contact to the domain, or create a new contact. After you've assigned a contact, the domain will be transferred to your account. From there, you can configure it as needed.
 


### PR DESCRIPTION
This adds descriptive alt tags to all images that were missing alt descriptions. this is part of the ongoing efforts to increase SEO.

belongs to: https://github.com/dnsimple/dnsimple-marketing/issues/729