### PR TITLE
Remove sandbox inbound axfr addresses from support docs

### DIFF
--- a/content/articles/secondary-dns-dnsimple-as-secondary.md
+++ b/content/articles/secondary-dns-dnsimple-as-secondary.md
@@ -77,9 +77,6 @@ These are our AXFR client IPs:
 - Production
   - `3.12.234.2`
   - `2600:1f16:ae2:e900:f05c:9438:865f:64a0`
-- Sandbox
-  - `3.142.158.214`
-  - `2600:1f16:ae2:e900:413:73dd:ebf2:2902`
 
 ## Ensuring the domain is delegated through both providers for greater redundancy
 


### PR DESCRIPTION
This removes the sandbox Inbound AXFR addresses from our support documentation in preparation for removing the sandbox service.