### PR TITLE
remove meta field from frontmatter where it is not being used

### DIFF
--- a/content/articles/a-record.md
+++ b/content/articles/a-record.md
@@ -1,5 +1,4 @@
 ---
-meta: An A record maps a domain name to the IP address (IPv4) of the computer hosting the domain.
 title: What's an A Record?
 excerpt: An A record maps a domain name to the IP address (IPv4) of the computer hosting the domain.
 categories:

--- a/content/articles/aaaa-record.md
+++ b/content/articles/aaaa-record.md
@@ -1,5 +1,4 @@
 ---
-meta: An AAAA record maps a domain name to the IP address (IPv6) of the computer hosting the domain.
 title: What's an AAAA record?
 excerpt: An AAAA record maps a domain name to the IP address (IPv6) of the computer hosting the domain.
 categories:

--- a/content/articles/account-activation.md
+++ b/content/articles/account-activation.md
@@ -1,5 +1,4 @@
 ---
-meta: How to activate your DNSimple account.
 title: Account Activation
 excerpt: How to activate your DNSimple account.
 categories:

--- a/content/articles/account-collaborator.md
+++ b/content/articles/account-collaborator.md
@@ -1,5 +1,4 @@
 ---
-meta: The differences between an Account Collaborator and Multi-User Accounts.
 title: Differences between Account Collaborator and Multi-User Accounts
 excerpt: The differences between an Account Collaborator and Multi-User Accounts.
 categories:

--- a/content/articles/account-creation.md
+++ b/content/articles/account-creation.md
@@ -1,5 +1,4 @@
 ---
-meta: How to sign up for a DNSimple account or create a new account for an existing DNSimple user.
 title: Account Creation
 excerpt: How to sign up for a DNSimple account or create a new account for an existing DNSimple user.
 categories:

--- a/content/articles/account-invoice-history.md
+++ b/content/articles/account-invoice-history.md
@@ -1,5 +1,4 @@
 ---
-meta: Using the payment history on your account and understanding the states of the listed invoices.
 title: Account Invoice History
 excerpt: Using the payment history on your account and understanding the states of the listed invoices.
 categories:

--- a/content/articles/account-multi.md
+++ b/content/articles/account-multi.md
@@ -1,5 +1,4 @@
 ---
-meta: How to manage multiple accounts per DNSimple user and switch active accounts. 
 title: Multiple Accounts Per User
 excerpt: How to manage multiple accounts per DNSimple user and switch active accounts. 
 categories:

--- a/content/articles/account-securing.md
+++ b/content/articles/account-securing.md
@@ -1,5 +1,4 @@
 ---
-meta: Some simple ways to make your DNSimple account more secure.
 title: Account Security
 excerpt: Some simple ways to make your DNSimple account more secure.
 categories:

--- a/content/articles/account-subscription-balance.md
+++ b/content/articles/account-subscription-balance.md
@@ -1,5 +1,4 @@
 ---
-meta: Checking your account's subscription balance, credit, and next payment due.
 title: Account Balance
 excerpt: Checking your account's subscription balance, credit, and next payment due.
 categories:

--- a/content/articles/account-suspended.md
+++ b/content/articles/account-suspended.md
@@ -1,5 +1,4 @@
 ---
-meta: Reasons why your DNSimple account may be suspended.
 title: Suspended Account
 excerpt: Reasons why your DNSimple account may be suspended.
 categories:

--- a/content/articles/account-users.md
+++ b/content/articles/account-users.md
@@ -1,5 +1,4 @@
 ---
-meta: How to manage the members on a multi-user DNSimple account.
 title: Managing Multiple Members on One Account
 excerpt: How to manage the members on a multi-user DNSimple account.
 categories:

--- a/content/articles/activity-tracking.md
+++ b/content/articles/activity-tracking.md
@@ -1,5 +1,4 @@
 ---
-meta: How to review the list of events for an account or domain using our audit log feature.
 title: Activity Tracking
 excerpt: How to review the list of events for an account or domain using our audit log feature.
 categories:

--- a/content/articles/add-ns-records-for-subdomain.md
+++ b/content/articles/add-ns-records-for-subdomain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to delegate a subdomain from a domain registered to custom name servers.
 title: Adding NS Records for a Subdomain
 excerpt: How to delegate a subdomain from a domain registered to custom name servers.
 categories:

--- a/content/articles/adding-domain.md
+++ b/content/articles/adding-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to add a domain to a DNSimple account.
 title: Adding a Domain
 excerpt: How to add a domain to a DNSimple account.
 categories:

--- a/content/articles/adding-subdomain.md
+++ b/content/articles/adding-subdomain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to add a subdomain to a DNSimple account.
 title: Adding a Subdomain
 excerpt: How to add a subdomain to a DNSimple account.
 categories:

--- a/content/articles/aldryn-service.md
+++ b/content/articles/aldryn-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Divio Aldryn DNS using DNSimple's one-click service.
 title: Divio Aldryn Service
 excerpt: How to set up Divio Aldryn DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/alias-record.md
+++ b/content/articles/alias-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What an ALIAS record is, and how to add an ALIAS record in DNSimple.
 title: What's an ALIAS record?
 excerpt: What an ALIAS record is, and how to add an ALIAS record in DNSimple.
 categories:

--- a/content/articles/amazon-elasticbeanstalk-service.md
+++ b/content/articles/amazon-elasticbeanstalk-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up AWS Elastic Beanstalk DNS using DNSimple's one-click service.
 title: AWS Elastic Beanstalk Service
 excerpt: How to set up AWS Elastic Beanstalk DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/amazon-lightsail-service.md
+++ b/content/articles/amazon-lightsail-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up AWS Lightsail DNS using DNSimple's one-click service.
 title: AWS Lightsail Service
 excerpt: How to set up AWS Lightsail DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/amazon-route-53-integration-demo.md
+++ b/content/articles/amazon-route-53-integration-demo.md
@@ -1,5 +1,4 @@
 ---
-meta: An introductory demo to integrating Amazon Route 53 with DNSimple.
 title: Amazon Route 53 Integration Demo
 excerpt: An introductory demo to integrating Amazon Route 53 with DNSimple.
 categories:

--- a/content/articles/amazon-s3-service.md
+++ b/content/articles/amazon-s3-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up AWS S3 DNS using DNSimple's one-click service.
 title: AWS S3 Service
 excerpt: How to set up AWS S3 DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/anycast.md
+++ b/content/articles/anycast.md
@@ -1,5 +1,4 @@
 ---
-meta: DNS zones at DNSimple are served through Anycast from 5 points of presence.
 title: Anycast DNS
 excerpt: DNS zones at DNSimple are served through Anycast from 5 points of presence.
 categories:

--- a/content/articles/api-access-token.md
+++ b/content/articles/api-access-token.md
@@ -1,5 +1,4 @@
 ---
-meta: Explains how to create a new API access token for access to the API version 2, including how to create a scoped access token with granular permissions.
 title: API Access Token
 excerpt: Explains how to create a new API access token for access to the API version 2, including how to create a scoped access token with granular permissions.
 categories:

--- a/content/articles/api-documentation.md
+++ b/content/articles/api-documentation.md
@@ -1,5 +1,4 @@
 ---
-meta: You can find our API documentation at the developer site.
 title: API Documentation
 excerpt: You can find our API documentation at the developer site.
 categories:

--- a/content/articles/api-errors.md
+++ b/content/articles/api-errors.md
@@ -1,5 +1,4 @@
 ---
-meta: You can find more information about API errors in our developer site.
 title: API Errors
 excerpt: You can find more information about API errors in our developer site.
 categories:

--- a/content/articles/api-rate-limit.md
+++ b/content/articles/api-rate-limit.md
@@ -1,5 +1,4 @@
 ---
-meta: You can find our API rate limit at the developer site.
 title: API Rate Limit
 excerpt: You can find our API rate limit at the developer site.
 categories:

--- a/content/articles/atmail-service.md
+++ b/content/articles/atmail-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Atmail DNS using DNSimple's one-click service.
 title: Atmail Service
 excerpt: How to set up Atmail DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/auto-import-dns.md
+++ b/content/articles/auto-import-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: Auto-import your DNS records to avoid downtime when transferring or hosting your domain with us. 
 title: Auto-Importing DNS Records
 excerpt: Auto-import your DNS records to avoid downtime when transferring or hosting your domain with us. 
 categories:

--- a/content/articles/auto-renew-only-domains.md
+++ b/content/articles/auto-renew-only-domains.md
@@ -1,5 +1,4 @@
 ---
-meta: Certain domain names are auto-renew only and cannot be manually renewed.
 title: '"Auto-Renew Only" Domains'
 excerpt: Certain domain names are auto-renew only and cannot be manually renewed.
 categories:

--- a/content/articles/before-transferring-domain.md
+++ b/content/articles/before-transferring-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to prepare your DNS in DNSimple to avoid downtime before transferring your domain registration.
 title: Preparing a Domain Transfer to Avoid Downtime
 excerpt: How to prepare your DNS in DNSimple to avoid downtime before transferring your domain registration.
 categories:

--- a/content/articles/billing-settings.md
+++ b/content/articles/billing-settings.md
@@ -1,5 +1,4 @@
 ---
-meta: What you need to know about the billing information displayed on every invoice.
 title: Billing Settings
 excerpt: What you need to know about the billing information displayed on every invoice.
 categories:

--- a/content/articles/blackbell-service.md
+++ b/content/articles/blackbell-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Blackbell DNS using DNSimple's one-click service.
 title: Blackbell Service
 excerpt: How to set up Blackbell DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/blogger-service.md
+++ b/content/articles/blogger-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Blogger DNS using DNSimple's one-click service.
 title: Blogger Service
 excerpt: How to set up Blogger DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/caa-record.md
+++ b/content/articles/caa-record.md
@@ -1,5 +1,4 @@
 ---
-meta: A Certification Authority Authorization (CAA) record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain.
 title: What's a CAA record?
 excerpt: A Certification Authority Authorization (CAA) record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain.
 categories:

--- a/content/articles/can-elliptic-curve-key-ssl-certificates.md
+++ b/content/articles/can-elliptic-curve-key-ssl-certificates.md
@@ -1,5 +1,4 @@
 ---
-meta: Information about Elliptic Curve Cryptography (ECC) SSL certificate support at DNSimple.
 title: Do you support Elliptic Curve Cryptography (ECC) SSL certificates?
 excerpt: Information about Elliptic Curve Cryptography (ECC) SSL certificate support at DNSimple.
 categories:

--- a/content/articles/can-ev-ssl-certificates.md
+++ b/content/articles/can-ev-ssl-certificates.md
@@ -1,5 +1,4 @@
 ---
-meta: Information about Extended Validation (EV) SSL certificate support at DNSimple.
 title: Do you support Extended Validation (EV) SSL certificates?
 excerpt: Information about Extended Validation (EV) SSL certificate support at DNSimple.
 categories:

--- a/content/articles/can-multi-year-ssl-certificates.md
+++ b/content/articles/can-multi-year-ssl-certificates.md
@@ -1,5 +1,4 @@
 ---
-meta: Information about purchasing a multi-year SSL certificate with DNSimple.
 title: Do you support multi-year SSL certificates?
 excerpt: Information about purchasing a multi-year SSL certificate with DNSimple.
 categories:

--- a/content/articles/can-upgrade-single-hostname-ssl-certificate-to-wildcard.md
+++ b/content/articles/can-upgrade-single-hostname-ssl-certificate-to-wildcard.md
@@ -1,5 +1,4 @@
 ---
-meta: Information about upgrading a single-hostname SSL certificate to a wildcard SSL certificate.
 title: Can I upgrade a single-hostname SSL certificate to a wildcard SSL certificate?
 excerpt: Information about upgrading a single-hostname SSL certificate to a wildcard SSL certificate.
 categories:

--- a/content/articles/cancel-subscription.md
+++ b/content/articles/cancel-subscription.md
@@ -1,5 +1,4 @@
 ---
-meta: How to cancel the recurring subscription for a DNSimple account.
 title: Unsubscribe from your DNSimple plan
 excerpt: How to cancel the recurring subscription for a DNSimple account.
 categories:

--- a/content/articles/changing-account-information.md
+++ b/content/articles/changing-account-information.md
@@ -1,5 +1,4 @@
 ---
-meta: How to change the information associated with a DNSimple account.
 title: Changing Account Information
 excerpt: How to change the information associated with a DNSimple account.
 categories:

--- a/content/articles/changing-domain-contact.md
+++ b/content/articles/changing-domain-contact.md
@@ -1,5 +1,4 @@
 ---
-meta: How to change or update the contact assigned to a domain or part of its data.
 title: Changing domain contacts
 excerpt: How to change or update the contact assigned to a domain or part of its data.
 categories:

--- a/content/articles/changing-email.md
+++ b/content/articles/changing-email.md
@@ -1,5 +1,4 @@
 ---
-meta: How to change the email associated with a DNSimple account or user.
 title: Changing Email
 excerpt: How to change the email associated with a DNSimple account or user.
 categories:

--- a/content/articles/changing-payment-details.md
+++ b/content/articles/changing-payment-details.md
@@ -1,5 +1,4 @@
 ---
-meta: How to change a DNSimple account's payment details.
 title: Changing Payment Details
 excerpt: How to change a DNSimple account's payment details.
 categories:

--- a/content/articles/changing-plans.md
+++ b/content/articles/changing-plans.md
@@ -1,5 +1,4 @@
 ---
-meta: How to change the subscribed plan for a DNSimple account.
 title: Changing Subscription Plan
 excerpt: How to change the subscribed plan for a DNSimple account.
 categories:

--- a/content/articles/changing-whois-contact.md
+++ b/content/articles/changing-whois-contact.md
@@ -1,5 +1,4 @@
 ---
-meta: How to change the contact information displayed in the WHOIS for a domain.
 title: Changing WHOIS information
 excerpt: How to change the contact information displayed in the WHOIS for a domain.
 categories:

--- a/content/articles/close-account.md
+++ b/content/articles/close-account.md
@@ -1,5 +1,4 @@
 ---
-meta: How to permanently delete yourself as a DNSimple user.
 title: Deleting yourself as a user
 excerpt: How to permanently delete yourself as a DNSimple user.
 categories:

--- a/content/articles/cloudflare-ds-record.md
+++ b/content/articles/cloudflare-ds-record.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set a DS record on registered domains for Cloudflare DNSSEC.
 title: Using Cloudflare DNSSEC with DNSimple
 excerpt: How to set a DS record on registered domains for Cloudflare DNSSEC.
 categories:

--- a/content/articles/cloudflare-service.md
+++ b/content/articles/cloudflare-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to setup Cloudflare DNS using DNSimple one-click service.
 title: Cloudflare Service
 excerpt: How to setup Cloudflare DNS using DNSimple one-click service.
 categories:

--- a/content/articles/cname-record.md
+++ b/content/articles/cname-record.md
@@ -1,5 +1,4 @@
 ---
-meta: CNAME records can be used to alias one name to another.
 title: What's a CNAME record?
 excerpt: CNAME records can be used to alias one name to another.
 categories:

--- a/content/articles/common-dns-records.md
+++ b/content/articles/common-dns-records.md
@@ -1,5 +1,4 @@
 ---
-meta: Examples of the most common DNS records to configure for your domain.
 title: Common DNS Records
 excerpt: Examples of the most common DNS records to configure for your domain.
 categories:

--- a/content/articles/consul-integration.md
+++ b/content/articles/consul-integration.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use DNSimple's Consul NIA Integration to automate DNS management via Network Infrastructure Automation (NIA)
 title: Consul Integration
 excerpt: How to use DNSimple's Consul NIA Integration to automate DNS management via Network Infrastructure Automation (NIA)
 categories:

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains how to manage your contacts for your domains and SSL certificates.
 title: Managing your contacts
 excerpt: This article explains how to manage your contacts for your domains and SSL certificates.
 categories:

--- a/content/articles/dashboard.md
+++ b/content/articles/dashboard.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use the DNSimple Dashboard to manage your domains.
 title: Getting to Know Your DNSimple Dashboard
 excerpt: How to use the DNSimple Dashboard to manage your domains.
 categories:

--- a/content/articles/delegating-dnsimple-hosted.md
+++ b/content/articles/delegating-dnsimple-hosted.md
@@ -1,5 +1,4 @@
 ---
-meta: How to delegate a domain registered with a different registrar to DNSimple's name servers.
 title: Delegating a Domain registered with another Registrar to DNSimple
 excerpt: How to delegate a domain registered with a different registrar to DNSimple's name servers.
 categories:

--- a/content/articles/delegating-dnsimple-registered.md
+++ b/content/articles/delegating-dnsimple-registered.md
@@ -1,5 +1,4 @@
 ---
-meta: How to delegate a domain registered with DNSimple to DNSimple's name servers.
 title: Delegating a Domain registered with DNSimple to DNSimple
 excerpt: How to delegate a domain registered with DNSimple to DNSimple's name servers.
 categories:

--- a/content/articles/deleting-domain.md
+++ b/content/articles/deleting-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to delete a domain from a DNSimple account.
 title: Deleting a Domain
 excerpt: How to delete a domain from a DNSimple account.
 categories:

--- a/content/articles/differences-a-cname-records.md
+++ b/content/articles/differences-a-cname-records.md
@@ -1,5 +1,4 @@
 ---
-meta: A and CNAME records are the two common ways to map a host name to an address. This article explains the differences between these two records.
 title: Differences Between A and CNAME records
 excerpt: A and CNAME records are the two common ways to map a host name to an address. This article explains the differences between these two records.
 categories:

--- a/content/articles/differences-between-a-cname-alias-url.md
+++ b/content/articles/differences-between-a-cname-alias-url.md
@@ -1,5 +1,4 @@
 ---
-meta: Understanding the differences among the A, CNAME, ALIAS, and URL records.
 title: Differences Among A, CNAME, ALIAS, and URL records
 excerpt: Understanding the differences among the A, CNAME, ALIAS, and URL records.
 categories:

--- a/content/articles/disabling-expiration-notifications.md
+++ b/content/articles/disabling-expiration-notifications.md
@@ -1,5 +1,4 @@
 ---
-meta: How to disable expiration notifications on a domain from your DNSimple account.
 title: Disabling Expiration Notifications
 excerpt: How to disable expiration notifications on a domain from your DNSimple account.
 categories:

--- a/content/articles/dkim-record.md
+++ b/content/articles/dkim-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What a DKIM record is, and how DKIM records work.
 title: What's a DKIM Record?
 excerpt: What a DKIM record is, and how DKIM records work.
 categories:

--- a/content/articles/dmarc-record.md
+++ b/content/articles/dmarc-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What a DMARC record is, and how DMARC records work.
 title: What's a DMARC record?
 excerpt: What a DMARC record is, and how DMARC records work.
 categories:

--- a/content/articles/dns-hosting.md
+++ b/content/articles/dns-hosting.md
@@ -1,5 +1,4 @@
 ---
-meta: DNSimple provides robust DNS hosting using a global Anycast network.
 title: DNS Hosting
 excerpt: DNSimple provides robust DNS hosting using a global Anycast network.
 categories:

--- a/content/articles/dns-query-limits.md
+++ b/content/articles/dns-query-limits.md
@@ -1,5 +1,4 @@
 ---
-meta: We charge $0.10 per million queries per zone.
 title: DNS Query Volume Fees
 excerpt: We charge $0.10 per million queries per zone.
 categories:

--- a/content/articles/dnsimple-and-handshake.md
+++ b/content/articles/dnsimple-and-handshake.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use Handshake (HNS) domains with your DNSimple account.
 title: DNSimple and Handshake (HNS)
 excerpt: How to use Handshake (HNS) domains with your DNSimple account.
 categories:

--- a/content/articles/dnsimple-nameservers.md
+++ b/content/articles/dnsimple-nameservers.md
@@ -1,5 +1,4 @@
 ---
-meta: How to change your domain's name servers to DNSimple's name servers.
 title: DNSimple Name Servers
 excerpt: How to change your domain's name servers to DNSimple's name servers.
 categories:

--- a/content/articles/dnsimple-plans.md
+++ b/content/articles/dnsimple-plans.md
@@ -1,5 +1,4 @@
 ---
-meta: Understand which plan fits you best
 title: DNSimple plans
 excerpt: Understand which plan fits you best
 categories:

--- a/content/articles/dnsimple-services.md
+++ b/content/articles/dnsimple-services.md
@@ -1,5 +1,4 @@
 ---
-meta: "DNSimple provides essential services for every Internet-connected system: hosted DNS, domain registration, a powerful automation API, One Click DNS Services, and SSL certificates."
 title: DNSimple Services
 excerpt: "DNSimple provides essential services for every Internet-connected system: hosted DNS, domain registration, a powerful automation API, One Click DNS Services, and SSL certificates."
 categories:

--- a/content/articles/dnsimple-status.md
+++ b/content/articles/dnsimple-status.md
@@ -1,5 +1,4 @@
 ---
-meta: We make our current system status, as well as our uptime history, available at dnsimplestatus.com.
 title: DNSimple Status Page
 excerpt: We make our current system status, as well as our uptime history, available at dnsimplestatus.com.
 categories:

--- a/content/articles/dnsimple-support.md
+++ b/content/articles/dnsimple-support.md
@@ -1,5 +1,4 @@
 ---
-meta: How to contact DNSimple for questions, issues, or feedback.
 title: Contacting DNSimple Support
 excerpt: How to contact DNSimple for questions, issues, or feedback.
 categories:

--- a/content/articles/dnssec-and-secondary-dns.md
+++ b/content/articles/dnssec-and-secondary-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: A detailed explanation as to why DNSSEC and Secondary DNS may not be compatible together.
 title: Why DNSSEC and Secondary DNS may not work together
 excerpt: A detailed explanation as to why DNSSEC and Secondary DNS may not be compatible together.
 categories:

--- a/content/articles/dnssec.md
+++ b/content/articles/dnssec.md
@@ -1,5 +1,4 @@
 ---
-meta: DNSimple provides full support for DNSSEC in our authoritative name servers, including signing of zones registered outside DNSimple.
 title: DNSSEC
 excerpt: DNSimple provides full support for DNSSEC in our authoritative name servers, including signing of zones registered outside DNSimple.
 categories:

--- a/content/articles/domain-access-control.md
+++ b/content/articles/domain-access-control.md
@@ -1,5 +1,4 @@
 ---
-meta: Control what each account member can access on a per-domain or per-zone basis.
 title: Domain Access Control
 excerpt: Control what each account member can access on a per-domain or per-zone basis.
 categories:

--- a/content/articles/domain-apex-heroku.md
+++ b/content/articles/domain-apex-heroku.md
@@ -1,5 +1,4 @@
 ---
-meta: How to point your domain to your Heroku application using DNSimple.
 title: Pointing the Domain Apex to Heroku
 excerpt: How to point your domain to your Heroku application using DNSimple.
 categories:

--- a/content/articles/domain-auto-renewal.md
+++ b/content/articles/domain-auto-renewal.md
@@ -1,5 +1,4 @@
 ---
-meta: The auto-renewal service reduces the risk of a domain expiring by renewing the domain automatically within 30 days of expiration.
 title: Domain Auto-Renewal
 excerpt: The auto-renewal service reduces the risk of a domain expiring by renewing the domain automatically within 30 days of expiration.
 categories:

--- a/content/articles/domain-list.md
+++ b/content/articles/domain-list.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use the DNSimple Domain List to manage your domains.
 title: Getting to Know Your DNSimple Domain List
 excerpt: How to use the DNSimple Domain List to manage your domains.
 categories:

--- a/content/articles/domain-masking.md
+++ b/content/articles/domain-masking.md
@@ -1,5 +1,4 @@
 ---
-meta: Information on Domain Masking and URL Masking.
 title: Domain Masking
 excerpt: Information on Domain Masking and URL Masking.
 categories:

--- a/content/articles/domain-privacy-after-gdpr.md
+++ b/content/articles/domain-privacy-after-gdpr.md
@@ -1,5 +1,4 @@
 ---
-meta: GDPR impacts available WHOIS information. Learn about the consequences of this law that came into effect on May 25th 2018.
 title: Domain privacy after GDPR
 excerpt: GDPR impacts available WHOIS information. Learn about the consequences of this law that came into effect on May 25th 2018.
 categories:

--- a/content/articles/domain-resolution-issues.md
+++ b/content/articles/domain-resolution-issues.md
@@ -1,5 +1,4 @@
 ---
-meta: This article contains instructions to check and debug domain resolution issues.
 title: Troubleshooting Domain Resolution Issues
 excerpt: This article contains instructions to check and debug domain resolution issues.
 categories:

--- a/content/articles/domain-transfer-pricing.md
+++ b/content/articles/domain-transfer-pricing.md
@@ -1,5 +1,4 @@
 ---
-meta: Domain transfer price varies depenending on the TLD you want to transfer, and generally it includes 1 year of extension.
 title: Domain Transfer Pricing
 excerpt: Domain transfer price varies depenending on the TLD you want to transfer, and generally it includes 1 year of extension.
 categories:

--- a/content/articles/domain-transfer.md
+++ b/content/articles/domain-transfer.md
@@ -1,5 +1,4 @@
 ---
-meta: How to transfer your registered domain to DNSimple.
 title: Transfer a Domain to DNSimple
 excerpt: How to transfer your registered domain to DNSimple.
 categories:

--- a/content/articles/domains-au.md
+++ b/content/articles/domains-au.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .AU domain names.
 title: .AU Domains
 excerpt: This article explains the requirements and special procedures for .AU domain names.
 categories:

--- a/content/articles/domains-bank.md
+++ b/content/articles/domains-bank.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .BANK domain names.
 title: .BANK Domains
 excerpt: This article explains the requirements and special procedures for .BANK domain names.
 categories:

--- a/content/articles/domains-be.md
+++ b/content/articles/domains-be.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .BE names.
 title: .BE Domains
 excerpt: This article explains the requirements and special procedures for .BE names.
 categories:

--- a/content/articles/domains-ch.md
+++ b/content/articles/domains-ch.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .CH domain names.
 title: .CH Domains
 excerpt: This article explains the requirements and special procedures for .CH domain names.
 categories:

--- a/content/articles/domains-day.md
+++ b/content/articles/domains-day.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .DAY domain names.
 title: .DAY Domains
 excerpt: This article explains the requirements and special procedures for .DAY domain names.
 categories:

--- a/content/articles/domains-de.md
+++ b/content/articles/domains-de.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .DE domain names.
 title: .DE Domains
 excerpt: This article explains the requirements and special procedures for .DE domain names.
 categories:

--- a/content/articles/domains-es.md
+++ b/content/articles/domains-es.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .ES domain names.
 title: .ES Domains
 excerpt: This article explains the requirements and special procedures for .ES domain names.
 categories:

--- a/content/articles/domains-eu.md
+++ b/content/articles/domains-eu.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .EU domain names.
 title: .EU Domains
 excerpt: This article explains the requirements and special procedures for .EU domain names.
 categories:

--- a/content/articles/domains-gay.md
+++ b/content/articles/domains-gay.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .GAY domain names.
 title: .GAY Domains
 excerpt: This article explains the requirements and special procedures for .GAY domain names.
 categories:

--- a/content/articles/domains-it.md
+++ b/content/articles/domains-it.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .it domain names.
 title: .IT Domains
 excerpt: This article explains the requirements and special procedures for .it domain names.
 categories:

--- a/content/articles/domains-li.md
+++ b/content/articles/domains-li.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .LI domain names.
 title: .LI Domains
 excerpt: This article explains the requirements and special procedures for .LI domain names.
 categories:

--- a/content/articles/domains-uk.md
+++ b/content/articles/domains-uk.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .UK domain names.
 title: .UK Domains
 excerpt: This article explains the requirements and special procedures for .UK domain names.
 categories:

--- a/content/articles/domains-xxx.md
+++ b/content/articles/domains-xxx.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the requirements and special procedures for .XXX domain names.
 title: .XXX Domains
 excerpt: This article explains the requirements and special procedures for .XXX domain names.
 categories:

--- a/content/articles/drop-catching.md
+++ b/content/articles/drop-catching.md
@@ -1,5 +1,4 @@
 ---
-meta: DNSimple's drop catching policy.
 title: Can I use DNSimple for drop catching?
 excerpt: DNSimple's drop catching policy.
 categories:

--- a/content/articles/ds-records-changing-dns.md
+++ b/content/articles/ds-records-changing-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains what to do if you use DNSSEC and change DNS services.
 title: Managing DS Records When Changing DNS
 excerpt: This article explains what to do if you use DNSSEC and change DNS services.
 categories:

--- a/content/articles/dynamic-dns.md
+++ b/content/articles/dynamic-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: Setting up simple Dynamic DNS with DNSimple.
 title: Dynamic DNS
 excerpt: Setting up simple Dynamic DNS with DNSimple.
 categories:

--- a/content/articles/edns-client-subnet.md
+++ b/content/articles/edns-client-subnet.md
@@ -1,5 +1,4 @@
 ---
-meta: What ECS is and how it works.
 title: EDNS Client Subnet support for ALIAS records
 excerpt: What ECS is and how it works.
 categories:

--- a/content/articles/email-forwarding.md
+++ b/content/articles/email-forwarding.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains the email forwarding service provided by DNSimple.
 title: Email Forwarding
 excerpt: This article explains the email forwarding service provided by DNSimple.
 categories:

--- a/content/articles/email-hosting.md
+++ b/content/articles/email-hosting.md
@@ -1,5 +1,4 @@
 ---
-meta: We focus primarily on domain management services, so we don't provide email hosting.
 title: Email Hosting Support
 excerpt: We focus primarily on domain management services, so we don't provide email hosting.
 categories:

--- a/content/articles/expiring-domain-email-notifications.md
+++ b/content/articles/expiring-domain-email-notifications.md
@@ -1,5 +1,4 @@
 ---
-meta: This page describes the email notifications you will receive about expiring domains purchased through DNSimple.
 title: Expiring Domain Email Notifications
 excerpt: This page describes the email notifications you will receive about expiring domains purchased through DNSimple.
 categories:

--- a/content/articles/expiring-product-email-notifications.md
+++ b/content/articles/expiring-product-email-notifications.md
@@ -1,5 +1,4 @@
 ---
-meta: This page describes the types of email notifications you may receive about expring items purchased through DNSimple.
 title: Expiring Product Email Notifications
 excerpt: This page describes the types of email notifications you may receive about expring items purchased through DNSimple.
 categories:

--- a/content/articles/fanout-service.md
+++ b/content/articles/fanout-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Fanout DNS using DNSimple's one-click service.
 title: Fanout Service
 excerpt: How to set up Fanout DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/faq-ssl-certificates.md
+++ b/content/articles/faq-ssl-certificates.md
@@ -1,5 +1,4 @@
 ---
-meta: A collection of frequently asked questions about the SSL certificates offered by DNSimple.
 title: SSL Certificates Frequently Asked Questions
 excerpt: A collection of frequently asked questions about the SSL certificates offered by DNSimple.
 categories:

--- a/content/articles/fastly-service.md
+++ b/content/articles/fastly-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Fastly DNS using DNSimple's one-click service.
 title: Fastly Service
 excerpt: How to set up Fastly DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/fastmail-service.md
+++ b/content/articles/fastmail-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Fastmail DNS using DNSimple's one-click service.
 title: Fastmail Service
 excerpt: How to set up Fastmail DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/forgot-password.md
+++ b/content/articles/forgot-password.md
@@ -1,5 +1,4 @@
 ---
-meta: Forgot your password? Use this guide to help reset your password so you can log in.
 title: Get Help if You Forgot Your Password
 excerpt: Forgot your password? Use this guide to help reset your password so you can log in.
 catagories:

--- a/content/articles/format-service.md
+++ b/content/articles/format-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Format DNS using DNSimple's one-click service.
 title: Format Service
 excerpt: How to set up Format DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/geniuslink-service.md
+++ b/content/articles/geniuslink-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Geniuslink DNS using DNSimple's one-click service.
 title: Geniuslink Service
 excerpt: How to set up Geniuslink DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/getting-started-clickfunnels.md
+++ b/content/articles/getting-started-clickfunnels.md
@@ -1,5 +1,4 @@
 ---
-meta: Get started with your new DNSimple account quickly.
 title: DNSimple and ClickFunnels
 excerpt: Get started with your new DNSimple account quickly.
 categories:

--- a/content/articles/getting-started-ssl-certificates.md
+++ b/content/articles/getting-started-ssl-certificates.md
@@ -1,5 +1,4 @@
 ---
-meta: How to get started with a new SSL Certificate, from order to installation.
 title: Getting Started with SSL Certificates
 excerpt: How to get started with a new SSL Certificate, from order to installation.
 categories:

--- a/content/articles/getting-started.md
+++ b/content/articles/getting-started.md
@@ -1,5 +1,4 @@
 ---
-meta: A collection of articles to help you get started with DNSimple quickly.
 title: Getting Started
 excerpt: A collection of articles to help you get started with DNSimple quickly.
 categories:

--- a/content/articles/gigalixir-service.md
+++ b/content/articles/gigalixir-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Gigalixir DNS using DNSimple's one-click service.
 title: Gigalixir Service
 excerpt: How to set up Gigalixir DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/github-pages.md
+++ b/content/articles/github-pages.md
@@ -1,5 +1,4 @@
 ---
-meta: How to point your root or apex domain to host your site with GitHub Pages using DNSimple.
 title: GitHub Pages
 excerpt: How to point your root or apex domain to host your site with GitHub Pages using DNSimple.
 categories:

--- a/content/articles/google-domain-transfer-chrome-extension.md
+++ b/content/articles/google-domain-transfer-chrome-extension.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use DNSimple's Chrome Extension to transfer your domain to DNSimple from Google Domains
 title: Google Domain Transfer Chrome Extension
 excerpt: How to use DNSimple's Chrome Extension to transfer your domain to DNSimple from Google Domains
 categories:

--- a/content/articles/google-identity-provider.md
+++ b/content/articles/google-identity-provider.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use Google to create and log in to accounts.
 title: Google as an Identity Provider
 excerpt: How to use Google to create and log in to accounts.
 categories:

--- a/content/articles/google-workspace-service.md
+++ b/content/articles/google-workspace-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Google Workspace DNS using DNSimple one-click service.
 title: Google Workspace (formerly G Suite) Service
 excerpt: How to set up Google Workspace DNS using DNSimple one-click service.
 categories:

--- a/content/articles/guide-dashboard.md
+++ b/content/articles/guide-dashboard.md
@@ -1,5 +1,4 @@
 ---
-meta: A Quick Tour of Your Dashboard and Domain List
 title: First Steps With Your DNSimple Account
 excerpt: A Quick Tour of Your Dashboard and Domain List
 categories:

--- a/content/articles/heroku-connector.md
+++ b/content/articles/heroku-connector.md
@@ -1,5 +1,4 @@
 ---
-meta: How to connect a Heroku app to your domain using DNSimple's Heroku Connector
 title: Heroku Connector
 excerpt: How to connect a Heroku app to your domain using DNSimple's Heroku Connector
 categories:

--- a/content/articles/heroku-error-differentapp.md
+++ b/content/articles/heroku-error-differentapp.md
@@ -1,5 +1,4 @@
 ---
-meta: You pointed your domain to Heroku, but when you access your domain you see a different application than the one you expected.
 title: Troubleshooting Heroku shows different app error
 excerpt: You pointed your domain to Heroku, but when you access your domain you see a different application than the one you expected.
 categories:

--- a/content/articles/heroku-error-nosuchapp.md
+++ b/content/articles/heroku-error-nosuchapp.md
@@ -1,5 +1,4 @@
 ---
-meta: You pointed your domain to Heroku, but when you access your domain you see the error page No such app.
 title: Troubleshooting Heroku "No such app" error
 excerpt: You pointed your domain to Heroku, but when you access your domain you see the error page No such app.
 categories:

--- a/content/articles/heroku-error-ssl.md
+++ b/content/articles/heroku-error-ssl.md
@@ -1,5 +1,4 @@
 ---
-meta: You installed an SSL certificate on Heroku but it is not working properly.
 title: Troubleshooting Heroku SSL errors
 excerpt: You installed an SSL certificate on Heroku but it is not working properly.
 categories:

--- a/content/articles/heroku-service.md
+++ b/content/articles/heroku-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Heroku DNS using DNSimple's one-click service.
 title: Heroku Service
 excerpt: How to set up Heroku DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/how-certificate-renewal-works.md
+++ b/content/articles/how-certificate-renewal-works.md
@@ -1,5 +1,4 @@
 ---
-meta: DNSimple provides a certificate renewal interface that will drastically reduce the amount of time required to purchase a new certificate.
 title: How does an SSL Certificate Renewal work?
 excerpt: DNSimple provides a certificate renewal interface that will drastically reduce the amount of time required to purchase a new certificate.
 categories:

--- a/content/articles/how-dig.md
+++ b/content/articles/how-dig.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to determine the Certificate Authority that signed an SSL certificate.
 title: How to Use dig
 excerpt: Instructions to determine the Certificate Authority that signed an SSL certificate.
 categories:

--- a/content/articles/how-is-dnsimple-pronounced.md
+++ b/content/articles/how-is-dnsimple-pronounced.md
@@ -1,5 +1,4 @@
 ---
-meta: "It's not always obvious how to pronounce DNSimple. Here's a guide."
 title: How to pronounce DNSimple
 excerpt: "It's not always obvious how to pronounce DNSimple. Here's a guide."
 categories:

--- a/content/articles/how-long-does-it-take-for-a-new-record-to-resolve-for-my-domain.md
+++ b/content/articles/how-long-does-it-take-for-a-new-record-to-resolve-for-my-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: If your account is active, records you add to a domain will be available within seconds.
 title: How Long Does It Take for a New Record to Resolve for My Domain?
 excerpt: If your account is active, records you add to a domain will be available within seconds.
 categories:

--- a/content/articles/how-long-to-issue-ssl-certificate.md
+++ b/content/articles/how-long-to-issue-ssl-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: The time frame required to issue a new SSL certificate depends on many factors.
 title: How long does it take to issue an SSL certificate?
 excerpt: The time frame required to issue a new SSL certificate depends on many factors.
 categories:

--- a/content/articles/how-to-determine-certificate-authority.md
+++ b/content/articles/how-to-determine-certificate-authority.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to determine the Certificate Authority that signed an SSL certificate.
 title: How do I determine the Certificate Authority that signed my SSL certificate?
 excerpt: Instructions to determine the Certificate Authority that signed an SSL certificate.
 categories:

--- a/content/articles/how-to-different-ssl-domain-validation-email.md
+++ b/content/articles/how-to-different-ssl-domain-validation-email.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains how to use a different email for validating the SSL certificate.
 title: How can I select a different SSL certificate domain validation email?
 excerpt: This article explains how to use a different email for validating the SSL certificate.
 categories:

--- a/content/articles/how-to-issue-new-transfer-when-transfer-denied.md
+++ b/content/articles/how-to-issue-new-transfer-when-transfer-denied.md
@@ -1,5 +1,4 @@
 ---
-meta: How to proceed in case a domain transfer was denied.
 title: How can I issue a new transfer order when a transfer is denied?
 excerpt: How to proceed in case a domain transfer was denied.
 categories:

--- a/content/articles/i-got-an-ecc-certificate-but-i-want-a-rsa-one.md
+++ b/content/articles/i-got-an-ecc-certificate-but-i-want-a-rsa-one.md
@@ -1,5 +1,4 @@
 ---
-meta: What to do when you need your SSL Certificate to be signed with an RSA key.
 title: I got an ECC-signed certificate but want RSA
 excerpt: What to do when you need your SSL Certificate to be signed with an RSA key.
 categories:

--- a/content/articles/icann-60-day-lock-registrant-change.md
+++ b/content/articles/icann-60-day-lock-registrant-change.md
@@ -1,5 +1,4 @@
 ---
-meta: After changing your registration info, you cannot transfer your domain for 60 days.
 title: ICANN 60-Day Lock After Change of Registrant
 excerpt: After changing your registration info, you cannot transfer your domain for 60 days.
 categories:

--- a/content/articles/icann-domain-validation.md
+++ b/content/articles/icann-domain-validation.md
@@ -1,5 +1,4 @@
 ---
-meta: This support article explains what ICANN domain validation is and how to ensure that your domain name is not suspended by ICANN due to non-validation.
 title: ICANN domain validation requirements
 excerpt: This support article explains what ICANN domain validation is and how to ensure that your domain name is not suspended by ICANN due to non-validation.
 categories:

--- a/content/articles/installing-ssl-certificate.md
+++ b/content/articles/installing-ssl-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains how to use the DNSimple SSL certificate installation wizard to install an SSL certificate in a few clicks on the most common web services and platforms.
 title: Installing an SSL Certificate
 excerpt: This article explains how to use the DNSimple SSL certificate installation wizard to install an SSL certificate in a few clicks on the most common web services and platforms.
 categories:

--- a/content/articles/integrated-dns-provider-amazon-route53.md
+++ b/content/articles/integrated-dns-provider-amazon-route53.md
@@ -1,5 +1,4 @@
 ---
-meta: Link your Amazon Route 53 account to manage zones at DNSimple.
 title: Amazon Route 53
 excerpt: Link your Amazon Route 53 account to manage zones at DNSimple.
 categories:

--- a/content/articles/integrated-dns-provider-coredns.md
+++ b/content/articles/integrated-dns-provider-coredns.md
@@ -1,5 +1,4 @@
 ---
-meta: Sync your zones managed at DNSimple to one or more CoreDNS instances.
 title: CoreDNS
 excerpt: Sync your zones managed at DNSimple to one or more CoreDNS instances.
 categories:

--- a/content/articles/integrated-dns-providers.md
+++ b/content/articles/integrated-dns-providers.md
@@ -1,5 +1,4 @@
 ---
-meta: Link an Integrated DNS Provider to your DNSimple account to synchronize, manage, and view zones at other authoritative DNS providers within DNSimple.
 title: Integrated DNS Providers at DNSimple
 excerpt: Link an Integrated DNS Provider to your DNSimple account to synchronize, manage, and view zones at other authoritative DNS providers within DNSimple.
 categories:

--- a/content/articles/integrated-domain-provider-godaddy.md
+++ b/content/articles/integrated-domain-provider-godaddy.md
@@ -1,5 +1,4 @@
 ---
-meta: Link your GoDaddy account to manage domains at DNSimple.
 title: Integrated Domain Provider - GoDaddy
 excerpt: Link your GoDaddy account to manage domains at DNSimple.
 categories:

--- a/content/articles/integrated-domain-provider-transfer-domain.md
+++ b/content/articles/integrated-domain-provider-transfer-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to transfer your integrated provider domain to DNSimple.
 title: Transfer an Integrated Provider Domain to DNSimple
 excerpt: How to transfer your integrated provider domain to DNSimple.
 categories:

--- a/content/articles/integrated-domain-providers.md
+++ b/content/articles/integrated-domain-providers.md
@@ -1,5 +1,4 @@
 ---
-meta: Link an Integrated Domain Provider to your DNSimple account to manage domains at other domain providers, from within DNSimple.
 title: Integrated Domain Providers at DNSimple
 excerpt: Link an Integrated Domain Provider to your DNSimple account to manage domains at other domain providers, from within DNSimple.
 categories:

--- a/content/articles/ipv6-support.md
+++ b/content/articles/ipv6-support.md
@@ -1,5 +1,4 @@
 ---
-meta: All DNSimple name servers have IPv6 addresses and respond to queries over IPv6.
 title: IPv6 Domain Resolution
 excerpt: All DNSimple name servers have IPv6 addresses and respond to queries over IPv6.
 categories:

--- a/content/articles/jimdo-service.md
+++ b/content/articles/jimdo-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Jimdo DNS using DNSimple's one-click service.
 title: Jimdo Service
 excerpt: How to set up Jimdo DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/kickofflabs-service.md
+++ b/content/articles/kickofflabs-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up KickOffLabs DNS using DNSimple's one-click service.
 title: KickOffLabs Service
 excerpt: How to set up KickOffLabs DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/labeling-domains.md
+++ b/content/articles/labeling-domains.md
@@ -1,5 +1,4 @@
 ---
-meta: When your domain names list grows and becomes hard to maintain, labels can help you organize your inventory.
 title: Organizing and Labeling Domains
 excerpt: When your domain names list grows and becomes hard to maintain, labels can help you organize your inventory.
 categories:

--- a/content/articles/launchrock-service.md
+++ b/content/articles/launchrock-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up LaunchRock DNS using DNSimple's one-click service.
 title: LaunchRock Service
 excerpt: How to set up LaunchRock DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/leave-a-review.md
+++ b/content/articles/leave-a-review.md
@@ -1,5 +1,4 @@
 ---
-meta: At DNSimple, we love hearing what our customers have to say!
 title: Leave a Review
 excerpt: At DNSimple, we love hearing what our customers have to say!
 categories:

--- a/content/articles/letsencrypt.md
+++ b/content/articles/letsencrypt.md
@@ -1,5 +1,4 @@
 ---
-meta: The DNSimple Let's Encrypt integration allows you to request an SSL certificate for free using the Let's Encrypt certification authority.
 title: Let's Encrypt and DNSimple
 excerpt: The DNSimple Let's Encrypt integration allows you to request an SSL certificate for free using the Let's Encrypt certification authority.
 categories:

--- a/content/articles/mailgun-service.md
+++ b/content/articles/mailgun-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Mailgun DNS using DNSimple's one-click service.
 title: Mailgun Service
 excerpt: How to set up Mailgun DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/manage-a-record.md
+++ b/content/articles/manage-a-record.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to add, update, and remove an A record in DNSimple.
 title: Managing A Records
 excerpt: Instructions to add, update, and remove an A record in DNSimple.
 categories:

--- a/content/articles/manage-aaaa-record.md
+++ b/content/articles/manage-aaaa-record.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to add, update, and remove an AAAA record in DNSimple.
 title: Managing AAAA Records
 excerpt: Instructions to add, update, and remove an AAAA record in DNSimple.
 categories:

--- a/content/articles/manage-caa-record.md
+++ b/content/articles/manage-caa-record.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to add, update, and remove a CAA record in DNSimple.
 title: Managing CAA Records
 excerpt: Instructions to add, update, and remove a CAA record in DNSimple.
 categories:

--- a/content/articles/manage-cname-record.md
+++ b/content/articles/manage-cname-record.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to add, update, and remove an CNAME record in DNSimple.
 title: Managing CNAME Records
 excerpt: Instructions to add, update, and remove an CNAME record in DNSimple.
 categories:

--- a/content/articles/manage-ds-record.md
+++ b/content/articles/manage-ds-record.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to add and remove an DS record in DNSimple.
 title: Managing DS Records
 excerpt: Instructions to add and remove an DS record in DNSimple.
 categories:

--- a/content/articles/manage-url-record.md
+++ b/content/articles/manage-url-record.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to add, update, and remove a URL record in DNSimple.
 title: Managing URL Records
 excerpt: Instructions to add, update, and remove a URL record in DNSimple.
 categories:

--- a/content/articles/managing-integrated-domains.md
+++ b/content/articles/managing-integrated-domains.md
@@ -1,5 +1,4 @@
 ---
-meta: We support managing domains at other domain providers.
 title: Managing Integrated Domains
 excerpt: We support managing domains at other domain providers.
 categories:

--- a/content/articles/managing-integrated-zones.md
+++ b/content/articles/managing-integrated-zones.md
@@ -1,5 +1,4 @@
 ---
-meta: We support managing zones at other authoritative DNS providers.
 title: Managing Integrated Zones
 excerpt: We support managing zones at other authoritative DNS providers.
 categories:

--- a/content/articles/managing-seats.md
+++ b/content/articles/managing-seats.md
@@ -1,5 +1,4 @@
 ---
-meta: Managing Seats and Members in Your Team Account.
 title: Managing seats
 excerpt: Managing Seats and Members in Your Team Account.
 categories:

--- a/content/articles/multi-factor-authentication-enforcement.md
+++ b/content/articles/multi-factor-authentication-enforcement.md
@@ -1,5 +1,4 @@
 ---
-meta: How to ensure an account is secured by requiring all members of an account to use Multi-Factor Authentication.
 title: Enforce Multi-Factor Authentication for All Members of an Account
 excerpt: How to ensure an account is secured by requiring all members of an account to use Multi-Factor Authentication.
 categories:

--- a/content/articles/multi-factor-authentication.md
+++ b/content/articles/multi-factor-authentication.md
@@ -1,5 +1,4 @@
 ---
-meta: How to protect your DNSimple account using multi-factor authentication
 title: Multi-Factor Authentication
 excerpt: How to protect your DNSimple account using multi-factor authentication
 categories:

--- a/content/articles/mx-record.md
+++ b/content/articles/mx-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What an MX record is, and how to create MX records with DNSimple.
 title: What's an MX Record?
 excerpt: What an MX record is, and how to create MX records with DNSimple.
 categories:

--- a/content/articles/name-server-sets.md
+++ b/content/articles/name-server-sets.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use name server sets to facilitate the configuration of domain name servers and zone NS records.
 title: Name Server Sets
 excerpt: How to use name server sets to facilitate the configuration of domain name servers and zone NS records.
 categories:

--- a/content/articles/netlify-connector.md
+++ b/content/articles/netlify-connector.md
@@ -1,5 +1,4 @@
 ---
-meta: How to connect a Netlify app to your domain using DNSimple's Netlify Connector
 title: Netlify Connector
 excerpt: How to connect a Netlify app to your domain using DNSimple's Netlify Connector
 categories:

--- a/content/articles/netlify-service.md
+++ b/content/articles/netlify-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Netlify DNS using DNSimple's one-click service.
 title: Netlify Service
 excerpt: How to set up Netlify DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/ns-record.md
+++ b/content/articles/ns-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What an NS record is, and how to create NS records with DNSimple.
 title: What's an NS Record?
 excerpt: What an NS record is, and how to create NS records with DNSimple.
 categories:

--- a/content/articles/oauth-applications.md
+++ b/content/articles/oauth-applications.md
@@ -1,5 +1,4 @@
 ---
-meta: Explains how to create a new OAuth application for access to the API version 2.
 title: OAuth Applications
 excerpt: Explains how to create a new OAuth application for access to the API version 2.
 categories:

--- a/content/articles/office-365-service.md
+++ b/content/articles/office-365-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Office 365 DNS using DNSimple's one-click service.
 title: Office 365 Service
 excerpt: How to set up Office 365 DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/okta-identity-provider.md
+++ b/content/articles/okta-identity-provider.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use Okta to create and log in to accounts.
 title: Okta as an Identity Provider
 excerpt: How to use Okta to create and log in to accounts.
 categories:

--- a/content/articles/ordering-lets-encrypt-certificate.md
+++ b/content/articles/ordering-lets-encrypt-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: How to order a Let's Encrypt certificate with DNSimple.
 title: Ordering a Let's Encrypt Certificate
 excerpt: How to order a Let's Encrypt certificate with DNSimple.
 categories:

--- a/content/articles/ordering-standard-certificate.md
+++ b/content/articles/ordering-standard-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: How to order a standard SSL certificate with DNSimple.
 title: Ordering a Standard SSL Certificate
 excerpt: How to order a standard SSL certificate with DNSimple.
 categories:

--- a/content/articles/ordering-wildcard-certificate.md
+++ b/content/articles/ordering-wildcard-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: How to order a wildcard SSL certificate with DNSimple.
 title: Ordering a Wildcard SSL Certificate
 excerpt: How to order a wildcard SSL certificate with DNSimple.
 categories:

--- a/content/articles/payment-methods.md
+++ b/content/articles/payment-methods.md
@@ -1,5 +1,4 @@
 ---
-meta: Payment methods supported by DNSimple.
 title: Payment methods
 excerpt: Payment methods supported by DNSimple.
 categories:

--- a/content/articles/platformsh-service.md
+++ b/content/articles/platformsh-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Platform.sh DNS using DNSimple's one-click service.
 title: Platform.sh Service
 excerpt: How to set up Platform.sh DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/pobox-service.md
+++ b/content/articles/pobox-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Pobox DNS using DNSimple's one-click service.
 title: Pobox Service
 excerpt: How to set up Pobox DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/pointing-domain-to-dnsimple.md
+++ b/content/articles/pointing-domain-to-dnsimple.md
@@ -1,5 +1,4 @@
 ---
-meta: How to point a domain to DNSimple's name servers.
 title: Pointing a Domain to DNSimple
 excerpt: How to point a domain to DNSimple's name servers.
 categories:

--- a/content/articles/pool-record.md
+++ b/content/articles/pool-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What a POOL record is, and how to create POOL records with DNSimple.
 title: What's a POOL Record?
 excerpt: What a POOL record is, and how to create POOL records with DNSimple.
 categories:

--- a/content/articles/postmark-dmarc-service.md
+++ b/content/articles/postmark-dmarc-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up DMARC Reports by Postmark DNS using DNSimple's one-click service.
 title: DMARC Reports by Postmark Service
 excerpt: How to set up DMARC Reports by Postmark DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/postmark-service.md
+++ b/content/articles/postmark-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Postmark DNS using DNSimple's one-click service.
 title: Postmark Service
 excerpt: How to set up Postmark DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/premium-domains.md
+++ b/content/articles/premium-domains.md
@@ -1,5 +1,4 @@
 ---
-meta: In the new gTLDs domain space, a premium domain is considered of special value by a registrar.
 title: Premium Domains
 excerpt: In the new gTLDs domain space, a premium domain is considered of special value by a registrar.
 categories:

--- a/content/articles/product-expiration-notification.md
+++ b/content/articles/product-expiration-notification.md
@@ -1,5 +1,4 @@
 ---
-meta: The Product Expiration email contains a list of products expiring within two months, grouped by expiration range.
 title: Product Expiration Notification
 excerpt: The Product Expiration email contains a list of products expiring within two months, grouped by expiration range.
 categories:

--- a/content/articles/product-expiring-tomorrow-notification.md
+++ b/content/articles/product-expiring-tomorrow-notification.md
@@ -1,5 +1,4 @@
 ---
-meta: The Product Expiring Tomorrow email contains a list of domains expiring within 24 hours.
 title: Product Expiring Tomorrow Notification
 excerpt: The Product Expiring Tomorrow email contains a list of domains expiring within 24 hours.
 categories:

--- a/content/articles/protection-ddos.md
+++ b/content/articles/protection-ddos.md
@@ -1,5 +1,4 @@
 ---
-meta: DNSimple offers multi-layered DDoS defense.
 title: Protection Against DDoS Attacks
 excerpt: DNSimple offers multi-layered DDoS defense.
 categories:

--- a/content/articles/rackspace-email-service.md
+++ b/content/articles/rackspace-email-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Rackspace Email DNS using DNSimple's one-click service.
 title: Rackspace Email Service
 excerpt: How to set up Rackspace Email DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/reactivate-subscription.md
+++ b/content/articles/reactivate-subscription.md
@@ -1,5 +1,4 @@
 ---
-meta: How to reactivate the subscription for a DNSimple account.
 title: Reactivate your subscription
 excerpt: How to reactivate the subscription for a DNSimple account.
 categories:

--- a/content/articles/reasons-hosting-dns.md
+++ b/content/articles/reasons-hosting-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: You should consider DNSimple for easy DNS management and expert support.
 title: Why should I host my DNS with DNSimple?
 excerpt: You should consider DNSimple for easy DNS management and expert support.
 categories:

--- a/content/articles/reasons-registering-domain.md
+++ b/content/articles/reasons-registering-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: We won't try to sell you a bunch of other services when you register your domain.
 title: Why should I register my domain name with DNSimple?
 excerpt: We won't try to sell you a bunch of other services when you register your domain.
 categories:

--- a/content/articles/record-editor-integrated-zones.md
+++ b/content/articles/record-editor-integrated-zones.md
@@ -1,5 +1,4 @@
 ---
-meta: Manage and sync the DNS records of a zone at DNSimple and/or Integrated DNS Providers.
 title: Record Editor for Integrated Zones
 excerpt: Manage and sync the DNS records of a zone at DNSimple and/or Integrated DNS Providers.
 categories:

--- a/content/articles/record-editor.md
+++ b/content/articles/record-editor.md
@@ -1,5 +1,4 @@
 ---
-meta: The Record Editor gives you the ability to view, create, and manage the DNS records for a domain.
 title: Record Editor
 excerpt: The Record Editor gives you the ability to view, create, and manage the DNS records for a domain.
 categories:

--- a/content/articles/record-notes.md
+++ b/content/articles/record-notes.md
@@ -1,5 +1,4 @@
 ---
-meta: Make notes on your records to remember the purpose of the change.
 title: Record Notes
 excerpt: Make notes on your records to remember the purpose of the change.
 categories:

--- a/content/articles/record-resolution-issues.md
+++ b/content/articles/record-resolution-issues.md
@@ -1,5 +1,4 @@
 ---
-meta: This article contains instructions to check and debug record resolution issues.
 title: Troubleshooting Record Resolution Issues
 excerpt: This article contains instructions to check and debug record resolution issues.
 categories:

--- a/content/articles/recovering-deleted-domain.md
+++ b/content/articles/recovering-deleted-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to recover a domain deleted from your DNSimple account.
 title: Recovering a Deleted Domain
 excerpt: How to recover a domain deleted from your DNSimple account.
 categories:

--- a/content/articles/redirect-heroku.md
+++ b/content/articles/redirect-heroku.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains how to use DNSimple to redirect to an app hosted on Heroku with/without HTTPS.
 title: Redirecting www to Non-www Domain at Heroku
 excerpt: This article explains how to use DNSimple to redirect to an app hosted on Heroku with/without HTTPS.
 categories:

--- a/content/articles/redirector.md
+++ b/content/articles/redirector.md
@@ -1,5 +1,4 @@
 ---
-meta: The redirector is a special feature provided by DNSimple that you can use to redirect HTTP/HTTPS requests sent to a host name to a different URL.
 title: DNSimple Redirector
 excerpt: The redirector is a special feature provided by DNSimple that you can use to redirect HTTP/HTTPS requests sent to a host name to a different URL.
 categories:

--- a/content/articles/regional-records.md
+++ b/content/articles/regional-records.md
@@ -1,5 +1,4 @@
 ---
-meta: Select geographical regions where you want a record to appear.
 title: Regional Records
 excerpt: Select geographical regions where you want a record to appear.
 categories:

--- a/content/articles/registering-domain.md
+++ b/content/articles/registering-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to register a domain with a DNSimple account.
 title: Registering a Domain
 excerpt: How to register a domain with a DNSimple account.
 categories:

--- a/content/articles/reissuing-ssl-certificate.md
+++ b/content/articles/reissuing-ssl-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: How to reissue a previously issued SSL certificate with a new CSR and/or private key.
 title: Re-issuing an SSL Certificate
 excerpt: How to reissue a previously issued SSL certificate with a new CSR and/or private key.
 categories:

--- a/content/articles/renewing-domain.md
+++ b/content/articles/renewing-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to renew a domain using your DNSimple account.
 title: Renewing a Domain
 excerpt: How to renew a domain using your DNSimple account.
 categories:

--- a/content/articles/renewing-lets-encrypt-ssl-certificate.md
+++ b/content/articles/renewing-lets-encrypt-ssl-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to renew a Let's Encrypt SSL certificate for a domain with DNSimple.
 title: Renewing a Let's Encrypt SSL Certificate
 excerpt: Instructions to renew a Let's Encrypt SSL certificate for a domain with DNSimple.
 categories:

--- a/content/articles/renewing-ssl-certificate.md
+++ b/content/articles/renewing-ssl-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to renew an SSL certificate for a domain with DNSimple.
 title: Renewing an SSL Certificate
 excerpt: Instructions to renew an SSL certificate for a domain with DNSimple.
 categories:

--- a/content/articles/renewing-standard-ssl-certificate.md
+++ b/content/articles/renewing-standard-ssl-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: Instructions to renew a standard SSL certificate for a domain with DNSimple.
 title: Renewing a standard SSL Certificate
 excerpt: Instructions to renew a standard SSL certificate for a domain with DNSimple.
 categories:

--- a/content/articles/resolution-status.md
+++ b/content/articles/resolution-status.md
@@ -1,5 +1,4 @@
 ---
-meta: The resolution status component in the domain page shows if the domain is currently resolving with DNSimple.
 title: Resolution Status
 excerpt: The resolution status component in the domain page shows if the domain is currently resolving with DNSimple.
 categories:

--- a/content/articles/restoring-domain.md
+++ b/content/articles/restoring-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: How to restore a domain with a DNSimple account.
 title: Restoring a Domain
 excerpt: How to restore a domain with a DNSimple account.
 categories:

--- a/content/articles/reverse-dns.md
+++ b/content/articles/reverse-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: We support reverse DNS zones.
 title: Reverse DNS Zones
 excerpt: We support reverse DNS zones.
 categories:

--- a/content/articles/sandbox.md
+++ b/content/articles/sandbox.md
@@ -1,5 +1,4 @@
 ---
-meta: Information about the sandbox enviroment available to test integration with DNSimple API.
 title: API Sandbox
 excerpt: Information about the sandbox enviroment available to test integration with DNSimple API.
 categories:

--- a/content/articles/secondary-dns-dnsimple-as-secondary.md
+++ b/content/articles/secondary-dns-dnsimple-as-secondary.md
@@ -1,5 +1,4 @@
 ---
-meta: Learn how to configure DNSimple as a secondary DNS provider.
 title: Add DNSimple as a secondary DNS server
 excerpt: Learn how to configure DNSimple as a secondary DNS provider.
 categories:

--- a/content/articles/secondary-dns-provider-dns-made-easy.md
+++ b/content/articles/secondary-dns-provider-dns-made-easy.md
@@ -1,5 +1,4 @@
 ---
-meta: Secondary DNS can be complicated to set up. We simplify it with provider specific settings for DNSMadeEasy.
 title: Add DNSMadeEasy as a secondary DNS server
 excerpt: Secondary DNS can be complicated to set up. We simplify it with provider specific settings for DNSMadeEasy.
 categories:

--- a/content/articles/secondary-dns-provider-dyn.md
+++ b/content/articles/secondary-dns-provider-dyn.md
@@ -1,5 +1,4 @@
 ---
-meta: Secondary DNS can be complicated to set up. We simplify it with provider specific settings for Dyn.
 title: Add Dyn as a secondary DNS server
 excerpt: Secondary DNS can be complicated to set up. We simplify it with provider specific settings for Dyn.
 categories:

--- a/content/articles/secondary-dns-provider-easy-dns.md
+++ b/content/articles/secondary-dns-provider-easy-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: Secondary DNS can be complicated to set up. We simplify it with provider-specific settings for EasyDNS.
 title: Add EasyDNS as a secondary DNS server
 excerpt: Secondary DNS can be complicated to set up. We simplify it with provider-specific settings for EasyDNS.
 categories:

--- a/content/articles/secondary-dns.md
+++ b/content/articles/secondary-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: This page provides information about secondary DNS configuration with DNSimple.
 title: Add a secondary DNS server to DNSimple
 excerpt: This page provides information about secondary DNS configuration with DNSimple.
 categories:

--- a/content/articles/secondary-dnsimple.md
+++ b/content/articles/secondary-dnsimple.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use DNSimple along with other DNS providers.
 title: Using DNSimple alongside other DNS providers
 excerpt: How to use DNSimple along with other DNS providers.
 categories:

--- a/content/articles/services.md
+++ b/content/articles/services.md
@@ -1,5 +1,4 @@
 ---
-meta: Services are DNS snippets ready for you to use in one click.
 title: One-click Services
 excerpt: Services are DNS snippets ready for you to use in one click.
 categories:

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -1,5 +1,4 @@
 ---
-meta: To set the name servers, your domain must be registered with DNSimple. If that's not the case, use the control panel of your current domain registrar to update the name servers.
 title: Setting the Name Servers for a Domain
 excerpt: To set the name servers, your domain must be registered with DNSimple. If that's not the case, use the control panel of your current domain registrar to update the name servers.
 categories:

--- a/content/articles/setting-up-accounts-for-clients.md
+++ b/content/articles/setting-up-accounts-for-clients.md
@@ -1,5 +1,4 @@
 ---
-meta: How to create and manage multiple accounts for clients.
 title: Creating accounts for clients
 excerpt: How to create and manage multiple accounts for clients.
 categories:

--- a/content/articles/sha-2-ssl-certificates.md
+++ b/content/articles/sha-2-ssl-certificates.md
@@ -1,5 +1,4 @@
 ---
-meta: All certificates purchased with DNSimple are currently signed with the SHA-2 hash algorithm.
 title: SHA-2 SSL Certificates
 excerpt: All certificates purchased with DNSimple are currently signed with the SHA-2 hash algorithm.
 categories:

--- a/content/articles/sharing-domain.md
+++ b/content/articles/sharing-domain.md
@@ -1,5 +1,4 @@
 ---
-meta: With DNSimple, you can share a domain with other users to share management.
 title: Sharing Domain Management with Other Users
 excerpt: With DNSimple, you can share a domain with other users to share management.
 categories:

--- a/content/articles/shopify-service.md
+++ b/content/articles/shopify-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Shopify DNS using DNSimple's one-click service.
 title: Shopify Service
 excerpt: How to set up Shopify DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/slack-integration.md
+++ b/content/articles/slack-integration.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up the DNSimple Slack app.
 title: Slack App
 excerpt: How to set up the DNSimple Slack app.
 categories:

--- a/content/articles/soa-record.md
+++ b/content/articles/soa-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What an SOA record is and how to add SOA records in DNSimple.
 title: What's an SOA Record?
 excerpt: What an SOA record is and how to add SOA records in DNSimple.
 categories:

--- a/content/articles/spf-record.md
+++ b/content/articles/spf-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What an SPF record is, and how the SPF record works.
 title: What's an SPF Record?
 excerpt: What an SPF record is, and how the SPF record works.
 categories:

--- a/content/articles/squarespace-service.md
+++ b/content/articles/squarespace-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Squarespace DNS using DNSimple's one-click service.
 title: Squarespace Service
 excerpt: How to set up Squarespace DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/srv-record.md
+++ b/content/articles/srv-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What an SRV record is, and how to add an SRV record in DNSimple.
 title: What's an SRV Record?
 excerpt: What an SRV record is, and how to add an SRV record in DNSimple.
 categories:

--- a/content/articles/ssl-certificate-authorities.md
+++ b/content/articles/ssl-certificate-authorities.md
@@ -1,5 +1,4 @@
 ---
-meta: The list of Certificate Authorities used by DNSimple to sign SSL certificates.
 title: SSL Certificate Authorities used by DNSimple
 excerpt: The list of Certificate Authorities used by DNSimple to sign SSL certificates.
 categories:

--- a/content/articles/ssl-certificate-names.md
+++ b/content/articles/ssl-certificate-names.md
@@ -1,5 +1,4 @@
 ---
-meta: Guidelines and information for selecting the SSL certificate host names.
 title: Choosing the SSL Certificate Names
 excerpt: Guidelines and information for selecting the SSL certificate host names.
 categories:

--- a/content/articles/ssl-certificate-with-apache.md
+++ b/content/articles/ssl-certificate-with-apache.md
@@ -1,5 +1,4 @@
 ---
-meta: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple, install it on Apache, and configure the Apache host.
 title: SSL Certificates with Apache
 excerpt: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple, install it on Apache, and configure the Apache host.
 categories:

--- a/content/articles/ssl-certificate-with-azure.md
+++ b/content/articles/ssl-certificate-with-azure.md
@@ -1,5 +1,4 @@
 ---
-meta: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple, install it on Azure, and configure your Azure application.
 title: SSL Certificates with Microsoft Azure
 excerpt: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple, install it on Azure, and configure your Azure application.
 categories:

--- a/content/articles/ssl-certificate-with-heroku.md
+++ b/content/articles/ssl-certificate-with-heroku.md
@@ -1,5 +1,4 @@
 ---
-meta: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple, install it on Heroku, and configure your Heroku application.
 title: SSL Certificates with Heroku
 excerpt: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple, install it on Heroku, and configure your Heroku application.
 categories:

--- a/content/articles/ssl-certificate-with-microsoft-iis.md
+++ b/content/articles/ssl-certificate-with-microsoft-iis.md
@@ -1,5 +1,4 @@
 ---
-meta: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple and install it on Microsoft Windows IIS.
 title: SSL Certificates with Microsoft Windows IIS
 excerpt: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple and install it on Microsoft Windows IIS.
 categories:

--- a/content/articles/ssl-certificate-with-nginx.md
+++ b/content/articles/ssl-certificate-with-nginx.md
@@ -1,5 +1,4 @@
 ---
-meta: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple, install it on NGINX, and configure the NGINX host.
 title: SSL Certificates with NGINX
 excerpt: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple, install it on NGINX, and configure the NGINX host.
 categories:

--- a/content/articles/ssl-certificate-with-windows.md
+++ b/content/articles/ssl-certificate-with-windows.md
@@ -1,5 +1,4 @@
 ---
-meta: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple and install it on Windows.
 title: SSL Certificates with Windows
 excerpt: This article provides step-by-step instructions to obtain a new SSL certificate via DNSimple and install it on Windows.
 categories:

--- a/content/articles/ssl-certificates-email-validation.md
+++ b/content/articles/ssl-certificates-email-validation.md
@@ -1,5 +1,4 @@
 ---
-meta: The email-based domain validation is the most common domain ownership validation method for a certificate and it is required for domain-validated certificates.
 title: SSL Certificate email-based Domain Validation
 excerpt: The email-based domain validation is the most common domain ownership validation method for a certificate and it is required for domain-validated certificates.
 categories:

--- a/content/articles/ssl-certificates-types.md
+++ b/content/articles/ssl-certificates-types.md
@@ -1,5 +1,4 @@
 ---
-meta: This article quickly explains the differences between the various types you may want to use to secure a website.
 title: SSL Certificate Types
 excerpt: This article quickly explains the differences between the various types you may want to use to secure a website.
 categories:

--- a/content/articles/ssl-certificates.md
+++ b/content/articles/ssl-certificates.md
@@ -1,5 +1,4 @@
 ---
-meta: Information about purchasing and managing an SSL/TLS certificate with DNSimple.
 title: SSL/TLS Certificates
 excerpt: Information about purchasing and managing an SSL/TLS certificate with DNSimple.
 categories:

--- a/content/articles/standard-vs-letsencrypt.md
+++ b/content/articles/standard-vs-letsencrypt.md
@@ -1,5 +1,4 @@
 ---
-meta: This article summarizes the most important DNSimple offering differences between Let's Encrypt and Standard SSL certificates.
 title: Standard vs Let's Encrypt SSL Certificates
 excerpt: This article summarizes the most important DNSimple offering differences between Let's Encrypt and Standard SSL certificates.
 categories:

--- a/content/articles/subscription-renewals.md
+++ b/content/articles/subscription-renewals.md
@@ -1,5 +1,4 @@
 ---
-meta: How to find all the relevant information about subscription renewals, and how to handle failed subscription renewal payments.
 title: Subscription Renewals
 excerpt: How to find all the relevant information about subscription renewals, and how to handle failed subscription renewal payments.
 categories:

--- a/content/articles/supadupa-service.md
+++ b/content/articles/supadupa-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up SupaDupa DNS using DNSimple's one-click service.
 title: SupaDupa Service
 excerpt: How to set up SupaDupa DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/superlock.md
+++ b/content/articles/superlock.md
@@ -1,5 +1,4 @@
 ---
-meta: Protect your domain from accidental transfers with DNSimple SuperLock.
 title: DNSimple SuperLock
 excerpt: Protect your domain from accidental transfers with DNSimple SuperLock.
 categories:

--- a/content/articles/supported-dns-records.md
+++ b/content/articles/supported-dns-records.md
@@ -1,5 +1,4 @@
 ---
-meta: The list of DNS record types (RR) supported by DNSimple.
 title: Supported DNS Record Types
 excerpt: The list of DNS record types (RR) supported by DNSimple.
 categories:

--- a/content/articles/surge-service.md
+++ b/content/articles/surge-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Surge DNS using DNSimple's one-click service.
 title: Surge Service
 excerpt: How to set up Surge DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/templates-with-srv-records.md
+++ b/content/articles/templates-with-srv-records.md
@@ -1,5 +1,4 @@
 ---
-meta: How to configure templates with SRV records
 title: SRV records in templates
 excerpt: How to configure templates with SRV records
 categories:

--- a/content/articles/templates.md
+++ b/content/articles/templates.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use templates to facilitate the entry of DNS records.
 title: How to use templates
 excerpt: How to use templates to facilitate the entry of DNS records.
 categories:

--- a/content/articles/tender-service.md
+++ b/content/articles/tender-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Tender DNS using DNSimple's one-click service.
 title: Tender Service
 excerpt: How to set up Tender DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/terraform-provider.md
+++ b/content/articles/terraform-provider.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use DNSimple's Terraform provider to manage your DNS
 title: Terraform Provider
 excerpt: How to use DNSimple's Terraform provider to manage your DNS
 categories:

--- a/content/articles/tlds-regulated.md
+++ b/content/articles/tlds-regulated.md
@@ -1,5 +1,4 @@
 ---
-meta: Information about regulated and highly-regulated TLDs.
 title: Regulated Top-Level Domains
 excerpt: Information about regulated and highly-regulated TLDs.
 categories:

--- a/content/articles/transfer-account-ownership.md
+++ b/content/articles/transfer-account-ownership.md
@@ -1,5 +1,4 @@
 ---
-meta: How to transfer ownership of the account to another DNSimple user.
 title: Transfer Account Ownership
 excerpt: How to transfer ownership of the account to another DNSimple user.
 categories:

--- a/content/articles/transferring-domain-away.md
+++ b/content/articles/transferring-domain-away.md
@@ -1,5 +1,4 @@
 ---
-meta: How to request a transfer code and transfer a domain from DNSimple to a different registrar.
 title: Transferring a domain away from DNSimple
 excerpt: How to request a transfer code and transfer a domain from DNSimple to a different registrar.
 categories:

--- a/content/articles/transferring-domain-between-accounts.md
+++ b/content/articles/transferring-domain-between-accounts.md
@@ -1,5 +1,4 @@
 ---
-meta: How to move a domain from one DNSimple account to another.
 title: Transferring a Domain to Another DNSimple Account
 excerpt: How to move a domain from one DNSimple account to another.
 categories:

--- a/content/articles/troubleshooting-email-forwarding-gmail.md
+++ b/content/articles/troubleshooting-email-forwarding-gmail.md
@@ -1,5 +1,4 @@
 ---
-meta: How to check and debug email forwarding issues.
 title: Troubleshooting Email Forwarding with Gmail
 excerpt: How to check and debug email forwarding issues.
 categories:

--- a/content/articles/troubleshooting-redirects.md
+++ b/content/articles/troubleshooting-redirects.md
@@ -1,5 +1,4 @@
 ---
-meta: How to check and debug URL redirect issues.
 title: Troubleshooting URL Redirects
 excerpt: How to check and debug URL redirect issues.
 categories:

--- a/content/articles/tumblr-service.md
+++ b/content/articles/tumblr-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Tumblr DNS using DNSimple's one-click service.
 title: Tumblr Service
 excerpt: How to set up Tumblr DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/txt-record.md
+++ b/content/articles/txt-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What a TXT record is, how to create TXT records with DNSimple, and other details about how we manage them.
 title: What's a TXT Record?
 excerpt: What a TXT record is, how to create TXT records with DNSimple, and other details about how we manage them.
 categories:

--- a/content/articles/understanding-invoice.md
+++ b/content/articles/understanding-invoice.md
@@ -1,5 +1,4 @@
 ---
-meta: A detailed explanation of DNSimple invoices.
 title: Understanding Your DNSimple Invoice
 excerpt: A detailed explanation of DNSimple invoices.
 categories:

--- a/content/articles/url-record.md
+++ b/content/articles/url-record.md
@@ -1,5 +1,4 @@
 ---
-meta: What a URL record is, and how to add a URL record in DNSimple.
 title: What's a URL Record?
 excerpt: What a URL record is, and how to add a URL record in DNSimple.
 categories:

--- a/content/articles/urlforward-service.md
+++ b/content/articles/urlforward-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up URL Forwarding DNS using DNSimple's one-click service.
 title: URL Forwarding Service
 excerpt: How to set up URL Forwarding DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/vanity-nameservers.md
+++ b/content/articles/vanity-nameservers.md
@@ -1,5 +1,4 @@
 ---
-meta: How to enable and disable Vanity Name Servers in DNSimple.
 title: Vanity Name Servers
 excerpt: How to enable and disable Vanity Name Servers in DNSimple.
 categories:

--- a/content/articles/web-hosting.md
+++ b/content/articles/web-hosting.md
@@ -1,5 +1,4 @@
 ---
-meta: We focus primarily on domain management services. We don't provide web hosting.
 title: Web Hosting Support
 excerpt: We focus primarily on domain management services. We don't provide web hosting.
 categories:

--- a/content/articles/webflow-service.md
+++ b/content/articles/webflow-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Webflow DNS using DNSimple's one-click service.
 title: Webflow Service
 excerpt: How to set up Webflow DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/webhooks.md
+++ b/content/articles/webhooks.md
@@ -1,5 +1,4 @@
 ---
-meta: This article describes the DNSimple API webhook service delivery and management.
 title: Webhooks and API events
 excerpt: This article describes the DNSimple API webhook service delivery and management.
 categories:

--- a/content/articles/weebly-service.md
+++ b/content/articles/weebly-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Weebly DNS using DNSimple's one-click service.
 title: Weebly Service
 excerpt: How to set up Weebly DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/what-happens-if-i-stop-paying.md
+++ b/content/articles/what-happens-if-i-stop-paying.md
@@ -1,5 +1,4 @@
 ---
-meta: Description of what happens if an account is unsubscribed.
 title: What happens if I stop paying for my DNSimple subscription?
 excerpt: Description of what happens if an account is unsubscribed.
 categories:

--- a/content/articles/what-happens-when-domain-expires.md
+++ b/content/articles/what-happens-when-domain-expires.md
@@ -1,5 +1,4 @@
 ---
-meta: What happens when a domain expires, how to recover it, and understanding the associated fees.
 title: What Happens When a Domain Expires?
 excerpt: What happens when a domain expires, how to recover it, and understanding the associated fees.
 categories:

--- a/content/articles/what-is-a-nameserver.md
+++ b/content/articles/what-is-a-nameserver.md
@@ -1,5 +1,4 @@
 ---
-meta: An explanation of what name servers are, why they're important, and how to set them up.
 title: What is a name server?
 excerpt: An explanation of what name servers are, why they're important, and how to set them up.
 categories:

--- a/content/articles/what-is-certificate-authority.md
+++ b/content/articles/what-is-certificate-authority.md
@@ -1,5 +1,4 @@
 ---
-meta: A certificate authority is a trusted entity that issues digital certificates.
 title: What is a Certificate Authority?
 excerpt: A certificate authority is a trusted entity that issues digital certificates.
 categories:

--- a/content/articles/what-is-common-name.md
+++ b/content/articles/what-is-common-name.md
@@ -1,5 +1,4 @@
 ---
-meta: The SSL certificate Common Name identifies the hostname associated with the certificate.
 title: What is the SSL Certificate Common Name?
 excerpt: The SSL certificate Common Name identifies the hostname associated with the certificate.
 categories:

--- a/content/articles/what-is-csr.md
+++ b/content/articles/what-is-csr.md
@@ -1,5 +1,4 @@
 ---
-meta: The Certificate Signing Request is a block of encrypted text that is sent to the Certificate Authority in order to apply for a certificate.
 title: What is the CSR?
 excerpt: The Certificate Signing Request is a block of encrypted text that is sent to the Certificate Authority in order to apply for a certificate.
 categories:

--- a/content/articles/what-is-ssl-certificate-chain.md
+++ b/content/articles/what-is-ssl-certificate-chain.md
@@ -1,5 +1,4 @@
 ---
-meta: The difference between the root certificate, intermediate certificates, and server certificate.
 title: What is the SSL Certificate Chain?
 excerpt: The difference between the root certificate, intermediate certificates, and server certificate.
 categories:

--- a/content/articles/what-is-ssl-root-certificate.md
+++ b/content/articles/what-is-ssl-root-certificate.md
@@ -1,5 +1,4 @@
 ---
-meta: A Root SSL certificate is a certificate issued by a trusted certificate authority.
 title: What is a Root Certificate?
 excerpt: A Root SSL certificate is a certificate issued by a trusted certificate authority.
 categories:

--- a/content/articles/what-is-ssl-san.md
+++ b/content/articles/what-is-ssl-san.md
@@ -1,5 +1,4 @@
 ---
-meta: The Subject Alternative Name (SAN) is an extension to the X.509 specification that allows to specify additional host names for a single SSL certificate.
 title: What is the Subject Alternative Name (SAN)?
 excerpt: The Subject Alternative Name (SAN) is an extension to the X.509 specification that allows to specify additional host names for a single SSL certificate.
 categories:

--- a/content/articles/what-is-tld.md
+++ b/content/articles/what-is-tld.md
@@ -1,5 +1,4 @@
 ---
-meta: The term top-level domain, or TLD, refers to the first part of every domain name.
 title: What is a TLD?
 excerpt: The term top-level domain, or TLD, refers to the first part of every domain name.
 categories:

--- a/content/articles/what-is-whois-privacy.md
+++ b/content/articles/what-is-whois-privacy.md
@@ -1,5 +1,4 @@
 ---
-meta: If you would like to keep your contact information private for a domain then you may sign up for the WHOIS privacy service.
 title: What is WHOIS Privacy Service?
 excerpt: If you would like to keep your contact information private for a domain then you may sign up for the WHOIS privacy service.
 categories:

--- a/content/articles/what-minimum-time-to-live.md
+++ b/content/articles/what-minimum-time-to-live.md
@@ -1,5 +1,4 @@
 ---
-meta: The standard time-to-live (TTL) for records added to DNSimple is 1 hour, but you can set different values.
 title: What's the Minimum Time-To-Live Provided by DNSimple?
 excerpt: The standard time-to-live (TTL) for records added to DNSimple is 1 hour, but you can set different values.
 categories:

--- a/content/articles/where-are-your-servers-located.md
+++ b/content/articles/where-are-your-servers-located.md
@@ -1,5 +1,4 @@
 ---
-meta: Our Anycast network consists of <%= POPS.count %> points-of-presence around the world.
 title: Where are your servers located?
 excerpt: Our Anycast network consists of <%= POPS.count %> points-of-presence around the world.
 categories:

--- a/content/articles/whois-privacy-blocks-transfer-email.md
+++ b/content/articles/whois-privacy-blocks-transfer-email.md
@@ -1,5 +1,4 @@
 ---
-meta: Whois Privacy services often do not properly deliver transfer approval emails, and thus should be disabled before requesting a transfer.
 title: Whois Privacy may cause transfer approval emails to not be delivered
 excerpt: Whois Privacy services often do not properly deliver transfer approval emails, and thus should be disabled before requesting a transfer.
 categories:

--- a/content/articles/whois-privacy.md
+++ b/content/articles/whois-privacy.md
@@ -1,5 +1,4 @@
 ---
-meta: How to enable and disable WHOIS Privacy for a domain.
 title: WHOIS Privacy Protection
 excerpt: How to enable and disable WHOIS Privacy for a domain.
 categories:

--- a/content/articles/why-anycast-dns.md
+++ b/content/articles/why-anycast-dns.md
@@ -1,5 +1,4 @@
 ---
-meta: Anycast offers several advantages over Unicast, resulting in lower latency and better traffic distribution.
 title: Why Anycast DNS?
 excerpt: Anycast offers several advantages over Unicast, resulting in lower latency and better traffic distribution.
 categories:

--- a/content/articles/why-not-web-hosting.md
+++ b/content/articles/why-not-web-hosting.md
@@ -1,5 +1,4 @@
 ---
-meta: Some reasons DNSimple doesn't offer web hosting services.
 title: Why we don't offer web hosting services
 excerpt: Some reasons DNSimple doesn't offer web hosting services.
 categories:

--- a/content/articles/windows-azure-service.md
+++ b/content/articles/windows-azure-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up Windows Azure DNS using DNSimple's one-click service.
 title: Windows Azure Service
 excerpt: How to set up Windows Azure DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/wordpress-service.md
+++ b/content/articles/wordpress-service.md
@@ -1,5 +1,4 @@
 ---
-meta: How to set up WordPress DNS using DNSimple's one-click service.
 title: WordPress Service
 excerpt: How to set up WordPress DNS using DNSimple's one-click service.
 categories:

--- a/content/articles/wordpress.md
+++ b/content/articles/wordpress.md
@@ -1,5 +1,4 @@
 ---
-meta: How to use a WordPress blog with DNSimple.
 title: WordPress and DNSimple
 excerpt: How to use a WordPress blog with DNSimple.
 categories:

--- a/content/articles/writing-guide.md
+++ b/content/articles/writing-guide.md
@@ -1,5 +1,4 @@
 ---
-meta: Guidelines & best practices for writing support docs.
 title: Writing Guidelines
 excerpt: Guidelines & best practices for writing support docs.
 categories:

--- a/content/articles/zone-files.md
+++ b/content/articles/zone-files.md
@@ -1,5 +1,4 @@
 ---
-meta: This article explains what a DNS zone file is, and how to import and export zone text files in DNSimple.
 title: Domain Zone Files
 excerpt: This article explains what a DNS zone file is, and how to import and export zone text files in DNSimple.
 categories:

--- a/content/articles/zone-ns-records.md
+++ b/content/articles/zone-ns-records.md
@@ -1,5 +1,4 @@
 ---
-meta: How to update zone NS records for a hosted domain
 title: Zone NS Records
 excerpt: How to update zone NS records for a hosted domain
 categories:


### PR DESCRIPTION
As a result of[ this conversation](https://dnsimple.slack.com/archives/C04RG803Z17/p1716551705115449)  this PR removes the meta field from all articles where the meta is the same as the excerpt _(meaning it is not being used)_

I have updated [the wiki page](https://dnsimple.atlassian.net/wiki/spaces/BIZOPS/pages/2615115803/Support+Article+Creation+and+Update+Procedure#SEO---Done-by-Marketing) on  indicating that a meta field can be added to override the excerpt as the meta for the page. 