### PR TITLE
Removes Google Universal Analytics and Google Optimize configuration

### DIFF
--- a/layouts/analytics.html
+++ b/layouts/analytics.html
@@ -1,12 +1,11 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=<%= @config[:google_universal_analytics_id] %>"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= @config[:google_analytics_4_id] %>"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '<%= @config[:google_universal_analytics_id] %>', { 'optimize_id': '<%= @config[:google_optimize_id] %>'});
-  gtag('config', '<%= @config[:google_analytics_4_id] %>', { 'optimize_id': '<%= @config[:google_optimize_id] %>'});
+  gtag('config', '<%= @config[:google_analytics_4_id] %>');
 </script>
 
 <% if @config[:posthog_id] != "" %>

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -84,8 +84,6 @@ watcher:
   notify_on_compilation_failure: true
 
 base_url: https://support.dnsimple.com
-google_universal_analytics_id: "UA-17301867-5"
-google_optimize_id: "GTM-WRX44LG"
 google_analytics_4_id: "G-91JJ84XVXY"
 
 environments:


### PR DESCRIPTION
This PR removes Google Universal Analytics and Google Optimize configuration in favor of Google Analytics 4.

I've verified that we're using the latest `gtag.js` code and that we can pass the GA4 variable to it.