### PR TITLE
Clarify Secondary DNS and Let's Encrypt incompatibility

### DIFF
--- a/content/articles/letsencrypt.md
+++ b/content/articles/letsencrypt.md
@@ -58,7 +58,7 @@ Some Let's Encrypt features may not be supported by DNSimple. Check the [limitat
 The DNSimple Let's Encrypt integration allows you to request an SSL certificate for free using the Let's Encrypt certification authority.
 
 <note>
-To request an SSL certificate with Let's Encrypt, the domains **must be delegated and resolving only with DNSimple**. The domain doesn't need to be registered with DNSimple. This means it is not compatible with Secondary DNS.
+To request an SSL certificate with Let's Encrypt, the domains **must be delegated to and resolving only with DNSimple**. The domain doesn't need to be registered with DNSimple. This means it is not compatible with Secondary DNS.
 </note>
 
 The certificate validation is completely automated using a DNS challenge. Once issued, you'll receive an email and [webhook notification](https://developer.dnsimple.com/v2/webhooks/). The certificate will then be available to download from your DNSimple account.

--- a/content/articles/letsencrypt.md
+++ b/content/articles/letsencrypt.md
@@ -58,7 +58,7 @@ Some Let's Encrypt features may not be supported by DNSimple. Check the [limitat
 The DNSimple Let's Encrypt integration allows you to request an SSL certificate for free using the Let's Encrypt certification authority.
 
 <note>
-To request an SSL certificate with Let's Encrypt, the domains **must be delegated to and resolving only with DNSimple**. The domain doesn't need to be registered with DNSimple. This means it is not compatible with Secondary DNS.
+To request an SSL certificate with Let's Encrypt, the domains **must be delegated to and exclusively resolving with DNSimple**, it is not compatible with Secondary DNS. The domain doesn't need to be registered with DNSimple.
 </note>
 
 The certificate validation is completely automated using a DNS challenge. Once issued, you'll receive an email and [webhook notification](https://developer.dnsimple.com/v2/webhooks/). The certificate will then be available to download from your DNSimple account.

--- a/content/articles/letsencrypt.md
+++ b/content/articles/letsencrypt.md
@@ -58,7 +58,7 @@ Some Let's Encrypt features may not be supported by DNSimple. Check the [limitat
 The DNSimple Let's Encrypt integration allows you to request an SSL certificate for free using the Let's Encrypt certification authority.
 
 <note>
-To request an SSL certificate with Let's Encrypt, the domains **must be delegated and resolving with DNSimple**. The domain doesn't need to be registered with DNSimple.
+To request an SSL certificate with Let's Encrypt, the domains **must be delegated and resolving only with DNSimple**. The domain doesn't need to be registered with DNSimple. This means it is not compatible with Secondary DNS.
 </note>
 
 The certificate validation is completely automated using a DNS challenge. Once issued, you'll receive an email and [webhook notification](https://developer.dnsimple.com/v2/webhooks/). The certificate will then be available to download from your DNSimple account.

--- a/content/articles/letsencrypt.md
+++ b/content/articles/letsencrypt.md
@@ -58,7 +58,7 @@ Some Let's Encrypt features may not be supported by DNSimple. Check the [limitat
 The DNSimple Let's Encrypt integration allows you to request an SSL certificate for free using the Let's Encrypt certification authority.
 
 <note>
-To request an SSL certificate with Let's Encrypt, the domains **must be delegated to and exclusively resolving with DNSimple**, it is not compatible with Secondary DNS. The domain doesn't need to be registered with DNSimple.
+To request an SSL certificate with Let's Encrypt, the domains **must be delegated to and exclusively resolving with DNSimple**. It is not compatible with Secondary DNS. The domain doesn't need to be registered with DNSimple.
 </note>
 
 The certificate validation is completely automated using a DNS challenge. Once issued, you'll receive an email and [webhook notification](https://developer.dnsimple.com/v2/webhooks/). The certificate will then be available to download from your DNSimple account.

--- a/content/articles/ordering-lets-encrypt-certificate.md
+++ b/content/articles/ordering-lets-encrypt-certificate.md
@@ -21,7 +21,11 @@ SSL certificates issued by Let's Encrypt are valid for 90 days from the issue da
 
 ## Before starting
 
-To order an SSL certificate, you need a DNSimple account. A subscription is necessary to keep the certificate renewed, and the domain must be delegated to use DNSimple's name servers due to the DNS challenge — which is automatically configured and checked in our implementation. **It is not necessary to transfer registration to us, but the domain must be only delegated to our name servers.**
+To order an SSL certificate, you need a DNSimple account. A subscription is necessary to keep the certificate renewed, and the domain must be delegated to use DNSimple's name servers due to the DNS challenge — which is automatically configured and checked in our implementation.
+
+<note>
+It is not necessary to transfer registration to us, but the domain must be only delegated to our name servers.
+</note>
 
 For more details about the configuration, approval, and installation of the certificate, read the [Getting Started with SSL Certificates](/articles/getting-started-ssl-certificates) article, or follow the instructions on the site after you submit the SSL certificate order.
 

--- a/content/articles/standard-vs-letsencrypt.md
+++ b/content/articles/standard-vs-letsencrypt.md
@@ -50,7 +50,8 @@ You want to use a custom private key. | **Standard**
 You want to use a wildcard name. | **Let's Encrypt** or **Standard**
 You want a longer expiration. | **Standard**
 You want to fully automate SSL certificate orders without manual intervention. | **Let's Encrypt**
-Your domain is only resolving with DNSimple. | **Let's Encrypt** or **Standard**
+Your domain is resolving exclusively with DNSimple. | **Let's Encrypt** or **Standard**
+
 Your domain is resolving with both DNSimple and Secondary DNS. | **Standard**
 Your domain is NOT resolving with DNSimple. | **Standard**
 Your domain is NOT registered but resolving with DNSimple. | **Let's Encrypt** or **Standard**

--- a/content/articles/standard-vs-letsencrypt.md
+++ b/content/articles/standard-vs-letsencrypt.md
@@ -51,7 +51,6 @@ You want to use a wildcard name. | **Let's Encrypt** or **Standard**
 You want a longer expiration. | **Standard**
 You want to fully automate SSL certificate orders without manual intervention. | **Let's Encrypt**
 Your domain is resolving exclusively with DNSimple. | **Let's Encrypt** or **Standard**
-
 Your domain is resolving with both DNSimple and Secondary DNS. | **Standard**
 Your domain is NOT resolving with DNSimple. | **Standard**
 Your domain is NOT registered but resolving with DNSimple. | **Let's Encrypt** or **Standard**

--- a/content/articles/standard-vs-letsencrypt.md
+++ b/content/articles/standard-vs-letsencrypt.md
@@ -50,7 +50,8 @@ You want to use a custom private key. | **Standard**
 You want to use a wildcard name. | **Let's Encrypt** or **Standard**
 You want a longer expiration. | **Standard**
 You want to fully automate SSL certificate orders without manual intervention. | **Let's Encrypt**
-Your domain is resolving with DNSimple. | **Let's Encrypt** or **Standard**
+Your domain is only resolving with DNSimple. | **Let's Encrypt** or **Standard**
+Your domain is resolving with both DNSimple and Secondary DNS. | **Standard**
 Your domain is NOT resolving with DNSimple. | **Standard**
 Your domain is NOT registered but resolving with DNSimple. | **Let's Encrypt** or **Standard**
 Your domain is NOT registered ant NOT resolving with DNSimple. | **Standard**


### PR DESCRIPTION
This has bit another customer, and when I went to find the information on support to link them, I found that this needed to be clarified. This tries to;

- using a callout in ordering is easier to see than a bold line
- add clarifying note to the base LE article
- add the use case to the standard vs. le table