### PR TITLE
Update DNSSEC & SecondaryDNS RFC

### DIFF
--- a/content/articles/dnssec-and-secondary-dns.md
+++ b/content/articles/dnssec-and-secondary-dns.md
@@ -7,8 +7,11 @@ categories:
 
 # Why DNSSEC and Secondary DNS may not work together
 
+> [!NOTE]
+> This pertains to online signing of RR sets. DNSimple does not support offline signing of RR sets at this time.
+
 All authoritative name servers MUST sign all record sets with all private keys that are Zone Signing Key (ZSK) type. This is necessary because a resolver could get the ZSK from one authoritative name server and the RRSIG from another authoritative name server. To include the RRSIG for all ZSK DNSKEYs, the authoritative name servers must have all private key material. We currently do not share private key material, and even if we did, AXFR does not support transferring private key material and thus key rotations would have to be done manually in a coordinated fashion.
 
 Note that in practice, it is possible to run multi-provider DNSSEC without sharing ZSK private key material, however it is not guaranteed to work due to the condition described above with resolvers getting the DNSKEY and the RRset + RRSIG from different authoritative name servers.
 
-You can read more information about multi-provider DNSSEC in this [Draft RFC here](https://tools.ietf.org/html/draft-ietf-dnsop-multi-provider-dnssec-05).
+You can read more information about multi-provider DNSSEC in [RFC 8901 here](https://datatracker.ietf.org/doc/html/rfc8901).

--- a/content/articles/dnssec-and-secondary-dns.md
+++ b/content/articles/dnssec-and-secondary-dns.md
@@ -11,4 +11,4 @@ All authoritative name servers MUST sign all record sets with all private keys t
 
 Note that in practice, it is possible to run multi-provider DNSSEC without sharing ZSK private key material, however it is not guaranteed to work due to the condition described above with resolvers getting the DNSKEY and the RRset + RRSIG from different authoritative name servers.
 
-You can read more information about multi-provider DNSSEC in [RFC 8901 here](https://datatracker.ietf.org/doc/html/rfc8901).
+You can read more about multi-provider DNSSEC in [RFC 8901](https://datatracker.ietf.org/doc/html/rfc8901).

--- a/content/articles/dnssec-and-secondary-dns.md
+++ b/content/articles/dnssec-and-secondary-dns.md
@@ -7,9 +7,6 @@ categories:
 
 # Why DNSSEC and Secondary DNS may not work together
 
-> [!NOTE]
-> This pertains to online signing of RR sets. DNSimple does not support offline signing of RR sets at this time.
-
 All authoritative name servers MUST sign all record sets with all private keys that are Zone Signing Key (ZSK) type. This is necessary because a resolver could get the ZSK from one authoritative name server and the RRSIG from another authoritative name server. To include the RRSIG for all ZSK DNSKEYs, the authoritative name servers must have all private key material. We currently do not share private key material, and even if we did, AXFR does not support transferring private key material and thus key rotations would have to be done manually in a coordinated fashion.
 
 Note that in practice, it is possible to run multi-provider DNSSEC without sharing ZSK private key material, however it is not guaranteed to work due to the condition described above with resolvers getting the DNSKEY and the RRset + RRSIG from different authoritative name servers.

--- a/content/articles/dnssec.md
+++ b/content/articles/dnssec.md
@@ -9,7 +9,7 @@ categories:
 # DNSSEC
 
 <warning>
-  You cannot enable DNSSEC if you have set up [Secondary DNS enabled](/articles/secondary-dns). They will not work in conjunction. Ensure you are not currently using Secondary DNS, or disable Secondary DNS before using DNSSEC. You can read more about why [here](/articles/dnssec-and-secondary-dns).
+  DNSimple does not support [Secondary DNS](/articles/secondary-dns) if you have DNSSEC enabled. They will not work in conjunction. Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS. You can read more about the complexities of multi-signer DNSSEC models in [RFC 8901](https://datatracker.ietf.org/doc/html/rfc8901).
 </warning>
 
 ### Table of Contents {#toc}

--- a/content/articles/secondary-dns-dnsimple-as-secondary.md
+++ b/content/articles/secondary-dns-dnsimple-as-secondary.md
@@ -24,9 +24,9 @@ For an overview of Secondary DNS, have a look at [our introduction article](/art
 ## Requirements
 
 <warning>
-  Don't add DNSimple as a secondary DNS server to domains with DNSSEC. We do not import external RRSIG records, which will produce resolution failures in DNSSEC aware resolutors.
+  Don't add DNSimple as a secondary DNS server to domains with DNSSEC. We do not import external RRSIG records, which will produce resolution failures from DNSSEC aware resolvers.
 
-  Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS. You can read more about why [here](/articles/dnssec-and-secondary-dns).
+  Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS.
 </warning>
 
 
@@ -34,7 +34,7 @@ For an overview of Secondary DNS, have a look at [our introduction article](/art
 
 Create a secondary zone by heading to the account dashboard. Select the <label>Domain Names</label> tab.
 
-![Seconary DNS tab](/files/domain-names-tab.png)
+![Secondary DNS tab](/files/domain-names-tab.png)
 
 Click the <label>Add new</label> button, and choose <label>Secondary DNS zone (with DNSimple as follower)</label> from the provided options.
 

--- a/content/articles/secondary-dns.md
+++ b/content/articles/secondary-dns.md
@@ -15,7 +15,7 @@ categories:
 ---
 
 <warning>
-  You cannot set up Secondary DNS if you have [DNSSEC](/articles/dnssec) enabled. They will not work in conjunction. Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS. You can read more about why [here](/articles/dnssec-and-secondary-dns).
+  DNSimple does not support Secondary DNS if you have [DNSSEC](/articles/dnssec) enabled. They will not work in conjunction. Please ensure that you are not currently using DNSSEC, or disable DNSSEC before using Secondary DNS. You can read more about the complexities of multi-signer DNSSEC models in [RFC 8901](https://datatracker.ietf.org/doc/html/rfc8901).
 </warning>
 
 ## Getting started


### PR DESCRIPTION
A customer wrote in about the technical accuracy of this article. While reviewing it, I noticed the RFC was finalized in 2020. 
The first purpose of this PR is to fix that.

Offline record signing was mentioned as another solution to address this, but we do not support that at this time, and I am not fully able to vouch for whether signed non-existence is fully solved for pre-signed AXFR. We could either note this or look into this as a possibility but before that...

While reviewing this article, should we rephrase or replace it as it applies explicitly to DNSimple? This reasonably technical document explains potential issues around something we don't support. I wonder if explaining "the why" is as valuable to our customers. It could become more about clarifying what we support and what customers can do depending on their use case.
Before I refactored, I wanted to bring up the conversation.


I'm CCing @m0rcq on this as a second pair of high-technical eyes.