### PR TITLE
Fixes searching for 'Record Editor'

### DIFF
--- a/templates/search.js.erb
+++ b/templates/search.js.erb
@@ -14,6 +14,9 @@ var articleScore = function articleScore (article, q) {
   if (article.searchTitle.indexOf(q) !== -1)
     score += 75;
 
+  if (article.searchTitle === q)
+    score += 50;
+
   if (article.searchBody.indexOf(q) !== -1)
     score += 50;
 

--- a/templates/search.js.erb
+++ b/templates/search.js.erb
@@ -93,13 +93,13 @@ var findByScore = function findByScore (q, articles) {
       article.score = articleScore(article, q);
       return article.score > MIN_SCORE;
     })
-    .filter(function (article, index) {
-      return index <= MAX_RESULTS;
-    })
     .sort(function (a, b) {
       if (a.score > b.score) return -1;
       if (a.score < b.score) return 1;
       return 0;
+    })
+    .filter(function (article, index) {
+      return index <= MAX_RESULTS;
     });
 };
 


### PR DESCRIPTION
This PR fixes an issue where searches for terms that exceed the maximum result limit (30 items) would miss relevant articles. For example, when searching for 'Record Editor,' the article wouldn't appear in the search results because results were being trimmed (30 items) before all articles were sorted by relevance.

I've also implemented logic to boost the ranking of articles whose titles exactly match the search term. I hope that this helps showing more accurate results.

