### PR TITLE
bump up the font size of dnsimple.com link in the footer

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -97,7 +97,7 @@
         </div>
         <div class="w-100 w-30-ns tc tl-ns">
           <nav>
-            <a href="https://dnsimple.com/campaign/support?utm_source=support&utm_medium=web&utm_content=link-footer" class="pb2 db link">DNSimple.com</a>
+            <a href="https://dnsimple.com/campaign/support?utm_source=support&utm_medium=web&utm_content=link-footer" class="pb2 f4 db link">DNSimple.com</a>
             <a href="https://blog.dnsimple.com/" class="pb2 db link">Blog</a>
             <a href="https://dnsimple.com/contact" class="pb2 db link">Contact</a>
             <a href="http://dnsimplestatus.com/" class="pb2 db link">Status</a>


### PR DESCRIPTION
Increasing the font size of the dnsimple.com link in the footer of the support site

belongs to: https://github.com/dnsimple/dnsimple-marketing/issues/744

<img width="1140" alt="Screenshot 2024-11-14 at 3 44 38 PM" src="https://github.com/user-attachments/assets/5d09f708-9ae7-4555-bde0-8884103833b6">
