### PR TITLE
Capture search event

### DIFF
--- a/content/search/results.js
+++ b/content/search/results.js
@@ -52,14 +52,10 @@
   };
 
   var debounce = function debounce (func, delay) {
-    var timeout;
-    return function () {
-      var context = this;
-      var args = arguments;
+    let timeout;
+    return function(...args) {
       clearTimeout(timeout);
-      timeout = setTimeout(function () {
-        func.call(context, args[0]);
-      }, delay);
+      timeout = setTimeout(() => func.apply(this, args), delay);
     };
   };
 

--- a/content/search/results.js
+++ b/content/search/results.js
@@ -51,6 +51,18 @@
     return $results;
   };
 
+  var debounce = function debounce (func, delay) {
+    var timeout;
+    return function () {
+      var context = this;
+      var args = arguments;
+      clearTimeout(timeout);
+      timeout = setTimeout(function () {
+        func.call(context, args[0]);
+      }, delay);
+    };
+  };
+
   if (typeof module === 'object' && typeof module.exports === 'object')
     module.exports = {
       parseQueryParams: parseQueryParams,
@@ -65,8 +77,8 @@
     if (q.length)
       showResults($main, $input, q);
 
-    $input.oninput = function (e) {
+    $input.addEventListener('input', debounce(function () {
       showResults($main, $input, $input.value);
-    };
+    }, 300));
   }
 })();

--- a/content/search/results.js
+++ b/content/search/results.js
@@ -63,6 +63,10 @@
     };
   };
 
+  var trackSearch = function trackSearch (query) {
+    window.posthog.capture('support-search', { query: $input.value });
+  };
+
   if (typeof module === 'object' && typeof module.exports === 'object')
     module.exports = {
       parseQueryParams: parseQueryParams,
@@ -74,11 +78,14 @@
     var $input = document.getElementById('input-search');
     var q = parseQueryParams(window.location.search);
 
-    if (q.length)
+    if (q.length) {
       showResults($main, $input, q);
+      trackSearch(q);
+    }
 
     $input.addEventListener('input', debounce(function () {
       showResults($main, $input, $input.value);
+      trackSearch($input.value);
     }, 300));
   }
 })();


### PR DESCRIPTION
To better understand how to enhance the search functionality for an upcoming project, I'd like to track the specific terms and queries that our users are searching for. This will help us identify patterns, prioritize improvements, and ensure the search results are more relevant to their needs.

I've created a `debounce` method so we don't track every single search character. This means that that the search is behaving a bit differently. We wait 300ms after user input to submit the query.

The queries are sent to PostHog.

## QA

There is no PostHog environment configured for local testing, so your browser console will show you an error. If you want to verify the values sent to PostHog, override the `trackSearch` method to only output the query to the console:
```js
  var trackSearch = function trackSearch (query) {
    // window.posthog.capture('support-search', { query: $input.value });
    console.log(query);
  };
``` 