### PR TITLE
Improving Search Experience: Use Posthog to track search queries and results

### DIFF
--- a/_widget/src/components/app/analytics.js
+++ b/_widget/src/components/app/analytics.js
@@ -1,0 +1,10 @@
+export const trackSearch = (() => {
+  let timeout;
+  return (query, results) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      if (window.posthog)
+        window.posthog.capture('support-search', { query, results });
+    }, 900);
+  };
+})();

--- a/_widget/src/components/app/search.js
+++ b/_widget/src/components/app/search.js
@@ -1,3 +1,5 @@
+import { trackSearch } from './analytics.js';
+
 // Items are matched in the order
 // Dictionary only works with lowercase with no punctuation
 
@@ -123,6 +125,8 @@ const findByScore = (q, articles) => {
 };
 
 const search = (q, articles, dictionary = DICTIONARY) => {
+  const original_q = q;
+
   q = (q || '').toLowerCase().trim();
 
   if (q[0] === '/')
@@ -133,7 +137,14 @@ const search = (q, articles, dictionary = DICTIONARY) => {
 
   q = applyDictionary(dictionary, q);
 
-  return findByScore(q, articles);
+  const results = findByScore(q, articles);
+
+  if (original_q) {
+    const articleTitles = results.map((r) => r.title);
+    trackSearch(original_q, articleTitles);
+  }
+
+  return results;
 };
 
 export {

--- a/spec/_widget/components/analytics.spec.js
+++ b/spec/_widget/components/analytics.spec.js
@@ -1,0 +1,40 @@
+import { trackSearch } from '../../../_widget/src/components/app/analytics.js';
+
+jest.useFakeTimers();
+
+beforeEach(() => {
+  jest.clearAllTimers();
+  jest.clearAllMocks();
+});
+
+describe('Analytics', () => {
+  describe('trackSearch', () => {
+    beforeEach(() => {
+      global.window.posthog = { capture: jest.fn() };
+    });
+
+    test('debounces the tracking event', () => {
+      trackSearch('query1', ['result1']);
+      trackSearch('query2', ['result2']);
+      trackSearch('query3', ['result3']);
+
+      // Fast-forward time but not enough for debounce to trigger
+      jest.advanceTimersByTime(800);
+      expect(window.posthog.capture).not.toHaveBeenCalled();
+
+      // Advance past debounce threshold
+      jest.advanceTimersByTime(100);
+      expect(window.posthog.capture).toHaveBeenCalledTimes(1);
+      expect(window.posthog.capture).toHaveBeenCalledWith('support-search', { query: 'query3', results: ['result3'] });
+    });
+  });
+
+  test('should not throw an error if posthog is undefined', () => {
+    delete global.window.posthog;
+
+    expect(() => {
+      trackSearch('test query', ['result1']);
+      jest.advanceTimersByTime(900);
+    }).not.toThrow();
+  });
+});

--- a/spec/_widget/components/search.spec.js
+++ b/spec/_widget/components/search.spec.js
@@ -104,6 +104,15 @@ describe('Search', () => {
       expect(results[0].title).toContain('Unsubscribed');
     });
 
+    test('ranks by score', () => {
+      const articles = prepareArticles([{ title: 'Unsubscribed' }, { title: 'Less Relevant', body: 'Unsubscribed' }, { title: 'Irrelevant' }]);
+      const results = search('close', articles, dictionary);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].title).toContain('Unsubscribed');
+      expect(results[1].title).toContain('Less Relevant');
+    });
+
     test('calls trackSearch', () => {
       const articles = prepareArticles([{ id: '/articles/my-article', title: 'My Article' }, { id: '/not-a-match' }]);
       const results = search('my', articles, {});

--- a/spec/_widget/components/search.spec.js
+++ b/spec/_widget/components/search.spec.js
@@ -1,4 +1,13 @@
 import { search, prepareArticles, dictionaryTermMatches, articleScore, fixRelativeImgSrcs } from '../../../_widget/src/components/app/search.js';
+import { trackSearch } from '../../../_widget/src/components/app/analytics.js';
+
+jest.mock('../../../_widget/src/components/app/analytics.js', () => ({
+  trackSearch: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('Search', () => {
   describe('.articleScore', () => {
@@ -95,13 +104,12 @@ describe('Search', () => {
       expect(results[0].title).toContain('Unsubscribed');
     });
 
-    test('ranks by score', () => {
-      const articles = prepareArticles([{ title: 'Unsubscribed' }, { title: 'Less Relevant', body: 'Unsubscribed' }, { title: 'Irrelevant' }]);
-      const results = search('close', articles, dictionary);
+    test('calls trackSearch', () => {
+      const articles = prepareArticles([{ id: '/articles/my-article', title: 'My Article' }, { id: '/not-a-match' }]);
+      const results = search('my', articles, {});
 
-      expect(results).toHaveLength(2);
-      expect(results[0].title).toContain('Unsubscribed');
-      expect(results[1].title).toContain('Less Relevant');
+      expect(trackSearch).toHaveBeenCalledTimes(1);
+      expect(trackSearch).toHaveBeenCalledWith('my', ['My Article']);
     });
   });
 });


### PR DESCRIPTION
Sends `query` and `results` to Posthog when searching from the support widget.

<img width="1444" alt="image" src="https://github.com/user-attachments/assets/cc632a4b-b3ac-4d7f-9785-a96c823926c8" />


# QA

- Visit https://deploy-preview-1372--dnsimple-support.netlify.app/
- Do some searching
- Verify that the search queries and results appear in our Posthog dashboard (might take a minute or two for it to reflect): https://us.posthog.com/project/18533/data-management/events/01938c7b-5109-7506-9687-68faa568a6a0