### PR TITLE
Fix: Change article source back to support.dnsimple.com

### DIFF
--- a/_widget/src/components/app/search.js
+++ b/_widget/src/components/app/search.js
@@ -58,7 +58,7 @@ const prepareArticles = (articles, source) => {
     article.searchBody = article.searchBody || (article.body || '').toLowerCase().replace(PUNCTUATION, '');
     article.body = fixRelativeImgSrcs(article.body || '');
     article.categories = article.categories || [];
-    article.source = source;
+    article.source = 'https://support.dnsimple.com';
 
     return article;
   });


### PR DESCRIPTION
Fixes a bug in the search widget where clicking on articles in support.dnsimple.com would open them in the widget, and not redirect to the actual article.