### PR TITLE
Search: Relative links in an article on the same site should open via browser

### DIFF
--- a/_widget/src/components/app/search.js
+++ b/_widget/src/components/app/search.js
@@ -79,12 +79,9 @@ const articleScore = (article, wordsRegex) => {
 };
 
 const resultsWithScore = (articles, words) => {
-  if (words[words.length - 1].length <= 1) 
-    words.pop();
-  
   if (!words.length) return [];
 
-  var wordsRegex = words.map((w) => new RegExp(`(^|\\s)${w}(s|\\s|$)`, 'ig'));
+  var wordsRegex = words.map((w) => new RegExp(`(^|\\s)${w}`, 'ig'));
 
   return articles.map((article) => {
     return {
@@ -147,7 +144,7 @@ class Search {
 
     q = applyDictionary(this.dictionary, q);
 
-    let words = searchable(q + ' ').split(WHITESPACE);
+    let words = searchable(` ${q} `).split(WHITESPACE);
     let results = resultsWithScore(this.articles, words);
 
     if (results.filter((r) => r.score > GOOD_SCORE).length === 0)

--- a/_widget/src/components/article/component.vue
+++ b/_widget/src/components/article/component.vue
@@ -51,8 +51,9 @@ export default {
     fixLinks () {
       [...this.$el.querySelectorAll('a')].forEach((a) => {
         const href = a.getAttribute('href');
+        const isSameSite = this.article.sourceUrl.indexOf(this.app.getCurrentSiteUrl()) === 0;
 
-        if (href[0] === '/')
+        if (href[0] === '/' && !isSameSite)
           this.prepRelativeLink(a);
         else if (href[0] === '#')
           this.prepHashLink(a);

--- a/_widget/src/components/article/component.vue
+++ b/_widget/src/components/article/component.vue
@@ -57,7 +57,7 @@ export default {
           this.prepRelativeLink(a);
         else if (href[0] === '#')
           this.prepHashLink(a);
-        else if (href.indexOf('javascript') !== 0)
+        else if (href.indexOf('javascript') !== 0 && (!isSameSite || href.startsWith('http')))
           this.prepAbsoluteLink(a);
       });
     },

--- a/spec/_widget/components/app.spec.js
+++ b/spec/_widget/components/app.spec.js
@@ -106,6 +106,22 @@ describe('App', () => {
     });
   });
 
+  describe('article links', () => {
+    let subject;
+
+    describe('when using the widget in the same site', () => {
+      beforeEach(async () => {
+        subject = mount(App, { propsData });
+        await subject.vm.open();
+        await subject.vm.go('Article', subject.vm.findArticle(subject.find('.articles li a').element.href), true);
+      });
+
+      it('does not open article links of the same site in the widget', () => {
+        expect(subject.find('.article a').element.onclick).toBeNull();
+      });
+    });
+  });
+
   describe('sources', () => {
     let subject;
 

--- a/spec/_widget/components/article.spec.js
+++ b/spec/_widget/components/article.spec.js
@@ -2,15 +2,16 @@ import { mount } from '@vue/test-utils';
 import Article from '../../../_widget/src/components/article/component.vue';
 
 describe('Article', () => {
-  const article = { id: '1', title: 'Title One', body: 'Article One' };
+  const article = { id: '1', title: 'Title One', body: 'Article One', sourceUrl: 'https://support.dnsimple.com' };
   const subject = mount(Article, {
     propsData: {
       app: {
         track () {},
         q: '',
-        articles: [article, { id: '2', title: 'Title Two', body: 'Article Two' }],
+        articles: [article, { id: '2', title: 'Title Two', body: 'Article Two', sourceUrl: 'https://support.dnsimple.com' }],
         hasHistory() { return false; },
-        findArticle() { return article; }
+        findArticle() { return article; },
+        getCurrentSiteUrl() { return 'https://support.dnsimple.com'; }
       },
       article
     }

--- a/spec/_widget/components/search.spec.js
+++ b/spec/_widget/components/search.spec.js
@@ -45,8 +45,8 @@ describe('Search', () => {
   describe('queries', () => {
     const queries = {
       'a record': {
-        'Managing A Records': 1,
-        'What\'s an A Record?': 2
+        'Managing A Records': 4,
+        'What\'s an A Record?': 1
       },
       'enable dnssec': {
         'DNSSEC': 1,
@@ -70,18 +70,19 @@ describe('Search', () => {
       },
       'auto-renew certificate': {
         "Renewing an SSL Certificate": 2,
-        "Renewing a standard SSL Certificate": 6,
-        "How does an SSL Certificate Renewal work?": 5,
+        "Renewing a standard SSL Certificate": 5,
+        "How does an SSL Certificate Renewal work?": 6,
         "Renewing a Let's Encrypt SSL Certificate": 7,
       },
       'delegate name servers to another provider': {
         'Setting the Name Servers for a Domain': 3,
         'Pointing a Domain to DNSimple': 4,
         'DNSimple Name Servers': 2,
-        'Delegating a Domain registered with another Registrar to DNSimple': 6
+        'Delegating a Domain registered with another Registrar to DNSimple': 7
       },
       'create a record': {
-        "Managing A Records": 1
+        'What\'s an A Record?': 1,
+        "Managing A Records": 4
       },
       'retry payment': {
         'Account Invoice History': 2,


### PR DESCRIPTION
# QA

At https://deploy-preview-1382--dnsimple-support.netlify.app/, the getting started article should open via browser (not in the support widget)

On dnsimple.com:

```js
[...document.querySelectorAll('#dnsimple-support-widget')].forEach((el) => el && document.body.removeChild(el))

const $script = document.createElement('script');
$script.type = 'text/javascript';
$script.src = `https://deploy-preview-1382--dnsimple-support.netlify.app/widget.js`;

document.getElementsByTagName('head')[0].appendChild($script);
```

The getting started article should open in the widget.