### PR TITLE
Improving Search Experience: Prioritize current site results

### DIFF
--- a/_widget/src/components/articles/component.vue
+++ b/_widget/src/components/articles/component.vue
@@ -85,7 +85,7 @@ export default {
       );
     },
     articlesBySourceAndCategory() {
-      return this.app.filteredArticles.reduce((result, article) => {
+      const results = this.app.filteredArticles.reduce((result, article) => {
         const { sourceUrl, categories } = article;
         const category = categories?.[0];
 
@@ -99,6 +99,13 @@ export default {
 
         return result;
       }, {});
+
+      // prioritize results from the current site by ordering them at the top
+      const currentSiteUrl = this.app.getCurrentSiteUrl();
+      return {
+        ...(currentSiteUrl in results ? { [currentSiteUrl]: results[currentSiteUrl] } : {}),
+        ...results
+      };
     }
   },
   methods: {

--- a/spec/_widget/components/app.spec.js
+++ b/spec/_widget/components/app.spec.js
@@ -124,17 +124,28 @@ describe('App', () => {
   });
 
   describe('sources', () => {
-    let subject;
-
-    beforeEach(async () => {
-      subject = mount(App, { propsData });
-      await subject.vm.open();
-    });
-
     it('groups the articles by source', async () => {
+      const subject = mount(App, { propsData });
+      await subject.vm.open();
       await subject.find('input').setValue('getting');
 
       expect(subject.find('h4').text()).toContain('DNSimple Support');
+    });
+
+    it('prioritizes results from the current site', async () => {
+      const currentSiteUrl = 'https://developer.dnsimple.com';
+      const articles = [
+        { id: '/articles/foobar/', title: 'Foobar', body: 'Foobar', sourceUrl: 'https://support.dnsimple.com' },
+        { id: '/articles/foobaz/', title: 'Foobaz', body: 'Foobaz', sourceUrl: 'https://developer.dnsimple.com' },
+      ];
+      const subject = mount(App, { props: { ...propsData, currentSiteUrl }, computed: { filteredArticles() { return articles; } } });
+      await subject.vm.open();
+
+      await subject.find('input').setValue('fooba');
+
+      const sourceHeaders = subject.findAll('h4');
+      expect(sourceHeaders.at(0).text()).toContain('DNSimple Developer');
+      expect(sourceHeaders.at(1).text()).toContain('DNSimple Support');
     });
   });
 


### PR DESCRIPTION
Prioritizes search results from the current site by ordering them first. E.g. If I'm searching from the developer site, developer articles should be at the top.

## QA
- Change `data-dnsimple-current-site-url` in `_widget/index.html`:
```
data-dnsimple-current-site-url="https://developer.dnsimple.com"
```
- `yarn widget`
- Do some searching
- Verify that developer articles are at the top of the results.