### PR TITLE
Adding marketing banner capabilities for the support site

### DIFF
--- a/banners.yml
+++ b/banners.yml
@@ -1,0 +1,8 @@
+- active: true
+  bg_color: "#e2d1e6"
+  text_color: "#333"
+  emoji: 📣 📣 📣
+  content: | #markdown
+    Ditch the manual DNS configurations. Join our webinar to learn how to automate your DNS infrastructure with **DNSimple's Terraform Provider!**
+  link_text: 🎟️ Secure your spot today! 🎟️
+  link_url: https://live.zoho.com/E41IwbdcDY

--- a/content/assets/css/_template.scss
+++ b/content/assets/css/_template.scss
@@ -27,3 +27,10 @@
   background-repeat: repeat-x;
   background-size: 900px 10px;
 }
+
+#marketing-banner {
+  // to make markdown rendering stay inline with the emoji and the link
+  p {
+    display: inline;
+  }
+}

--- a/layouts/banner.html
+++ b/layouts/banner.html
@@ -5,7 +5,7 @@
     id="marketing-banner"
     style="background-color:<%= banner[:bg_color] %>; color:<%= banner[:text_color] %>;"
   >
-    <div class="pv4 tc mw9 center">
+    <div class="pv4 tc mw8 center">
       <%= banner[:emoji] %>
       <%= as_markdown banner[:content] %>
       <a

--- a/layouts/banner.html
+++ b/layouts/banner.html
@@ -1,0 +1,20 @@
+
+ <% banner = find_active_banner %>
+ <% if banner %>
+  <div
+    id="marketing-banner"
+    style="background-color:<%= banner[:bg_color] %>; color:<%= banner[:text_color] %>;"
+  >
+    <div class="pv4 tc mw9 center">
+      <%= banner[:emoji] %>
+      <%= as_markdown banner[:content] %>
+      <a
+        style="color:<%= banner[:text_color] %>;"
+        href="<%= banner[:link_url] %>" target="_blank"
+      >
+        <%= banner[:link_text] %>
+      </a>
+    </div>
+  </div>
+<% end %>
+

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -21,6 +21,8 @@
 
 <body>
 
+  <%= render "/banner.*" %>
+
   <header class="global-header pv2">
     <div class="mw8 center ph2">
       <div class="flex justify-between pv2">

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -1,3 +1,5 @@
+require 'kramdown'
+
 include Nanoc::Helpers::Rendering
 include Nanoc::Helpers::XMLSitemap
 
@@ -11,6 +13,15 @@ end
 
 def sub_categories(what, items, &block)
   SubCategories.new.show(what, items, &block)
+end
+
+def find_active_banner
+  banners = YAML.load(File.read('banners.yml'), symbolize_names: true)
+  banners.find { |banner| banner[:active] == true }
+end
+
+def as_markdown str
+  Kramdown::Document.new(str).to_html
 end
 
 POPS = [

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -20,7 +20,7 @@ def find_active_banner
   banners&.find { |banner| banner[:active] == true }
 end
 
-def as_markdown str
+def as_markdown(str)
   Kramdown::Document.new(str).to_html
 end
 

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -17,7 +17,7 @@ end
 
 def find_active_banner
   banners = YAML.load(File.read('banners.yml'), symbolize_names: true)
-  banners.find { |banner| banner[:active] == true }
+  banners&.find { |banner| banner[:active] == true }
 end
 
 def as_markdown str


### PR DESCRIPTION
belongs to: https://github.com/dnsimple/dnsimple-marketing/issues/854

adds a yaml file for banners, finds the first `active` one and displays it if there is one