### PR TITLE
Improving Search Experience: Store recently visited even when outside support widget

### DIFF
--- a/_widget/src/main.js
+++ b/_widget/src/main.js
@@ -1,5 +1,7 @@
 import initialize from './initialize.js';
+import storeRecentlyVisited from './recently-visited.js';
 
 const elementId = 'dnsimple-support-widget';
 
-initialize(document);
+const app = initialize(document);
+storeRecentlyVisited(app);

--- a/_widget/src/recently-visited.js
+++ b/_widget/src/recently-visited.js
@@ -1,0 +1,9 @@
+export default (widget) => {
+  const { origin, pathname, href } = window.location;
+
+  if (!['https://support.dnsimple.com', 'https://developer.dnsimple.com'].includes(origin)) return;
+
+  const pattern = /^\/(articles|v2)\/.+/; // Matches "/articles/anything" or "/v2/anything"
+  if (pattern.test(pathname))
+    widget.storeRecentlyVisited(href);
+};

--- a/spec/_widget/components/recently-visited.spec.js
+++ b/spec/_widget/components/recently-visited.spec.js
@@ -1,0 +1,58 @@
+import storeRecentlyVisited from '../../../_widget/src/recently-visited.js';
+
+describe('storeRecentlyVisited', () => {
+  let widget;
+
+  beforeEach(() => {
+    widget = { storeRecentlyVisited: jest.fn() };
+  });
+
+  it('delegates to the widget if visiting a support article', () => {
+    const location = {
+      origin: 'https://support.dnsimple.com',
+      pathname: '/articles/example-article',
+      href: 'https://support.dnsimple.com/articles/example-article'
+    };
+    Object.defineProperty(window, "location", { value: location });
+
+    storeRecentlyVisited(widget);
+
+    expect(widget.storeRecentlyVisited).toHaveBeenCalledWith(location.href);
+  });
+
+  it('delegates to the widget if visiting a developer article', () => {
+    const location = {
+      origin: 'https://developer.dnsimple.com',
+      pathname: '/articles/example-article',
+      href: 'https://developer.dnsimple.com/articles/example-article'
+    };
+    Object.defineProperty(window, "location", { value: location });
+
+    storeRecentlyVisited(widget);
+
+    expect(widget.storeRecentlyVisited).toHaveBeenCalledWith(location.href);
+  });
+
+  it('does not delegate to the widget if not in the support or developer site', () => {
+    const location = {
+      origin: 'https://other.dnsimple.com',
+    };
+    Object.defineProperty(window, "location", { value: location });
+
+    storeRecentlyVisited(widget);
+
+    expect(widget.storeRecentlyVisited).not.toHaveBeenCalled();
+  });
+
+  it('does not delegate to the widget if not visiting a support article', () => {
+    const location = {
+      origin: 'https://support.dnsimple.com',
+      pathname: '/categories/example-category',
+    };
+    Object.defineProperty(window, "location", { value: location });
+
+    storeRecentlyVisited(widget);
+
+    expect(widget.storeRecentlyVisited).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
E.g. when I click on an article from the sidebar, it should appear in the recently visited list.

Context: https://github.com/dnsimple/dnsimple-support/pull/1391#pullrequestreview-2627294612

## QA

- Visit https://support.dnsimple.com/
- Clear your localStorage: `localStorage.clear()`
- Visit an article e.g. https://support.dnsimple.com/articles/registering-domain/
- Copy/paste into the console:
```js
[...document.querySelectorAll('#dnsimple-support-widget')].forEach((el) => el && document.body.removeChild(el))

const $script = document.createElement('script');
$script.type = 'text/javascript';
$script.src = `https://deploy-preview-1401--dnsimple-support.netlify.app/widget.js`;

document.getElementsByTagName('head')[0].appendChild($script);
```
- Verify that the article URL is in your `localStorage.recentlyVisitedUrls`
- Open the widget
- Verify that the article appears in `Recently Visited`