### PR TITLE
Improving Search Experience: Prioritize same-site results

### DIFF
--- a/_widget/src/components/app/component.vue
+++ b/_widget/src/components/app/component.vue
@@ -63,7 +63,7 @@ export default {
     },
     search: {
       type: Object,
-      default() { return new Search(); }
+      default(props) { return new Search(undefined, props.currentSiteUrl); }
     },
     sources: {
       type: Array,

--- a/_widget/src/components/app/search.js
+++ b/_widget/src/components/app/search.js
@@ -164,8 +164,12 @@ class Search {
 
     if (results.filter((r) => r.score > GOOD_SCORE).length === 0)
       results = results.filter((r) => r.score > LOWER_MIN_SCORE);
-     else
+    else
       results = results.filter((r) => r.score > MIN_SCORE);
+
+    const sameSiteResults = results.filter((r) => r.article.sourceUrl === this.currentSiteUrl);
+    const otherSiteResults = results.filter((r) => r.article.sourceUrl !== this.currentSiteUrl);
+    results = sameSiteResults.concat(otherSiteResults);
 
     results = results
       .filter((r, index) => index < MAX_RESULTS)

--- a/_widget/src/components/app/search.js
+++ b/_widget/src/components/app/search.js
@@ -117,9 +117,10 @@ const LOWER_MIN_SCORE = 1;
 const WHITESPACE = /\s+/;
 
 class Search {
-  constructor(dictionary = DICTIONARY) {
+  constructor(dictionary = DICTIONARY, currentSiteUrl = '') {
     this.articles = [];
-    this.dictionary = DICTIONARY;
+    this.dictionary = dictionary;
+    this.currentSiteUrl = currentSiteUrl;
   }
 
   addArticles(articles, sourceUrl) {

--- a/spec/_widget/components/search.spec.js
+++ b/spec/_widget/components/search.spec.js
@@ -56,6 +56,19 @@ describe('Search', () => {
     expect(results1.map((r) => r.title).slice(0, 2)).toContain('Record Notes');
   });
 
+  it('prioritizes same-site results', () => {
+    subject = new Search(undefined, 'https://developer.dnsimple.com');
+    subject.addArticles(ARTICLES, 'https://support.dnsimple.com');
+
+    const sameSiteArticle = { id: '/v2/zones/ns-records/', title: 'Zone NS Records API | Zones | DNSimple API v2' };
+    subject.addArticles([sameSiteArticle], 'https://developer.dnsimple.com');
+
+    const results = subject.query('records');
+
+    expect(results[0].id).toEqual(sameSiteArticle.id);
+    expect(results[0].title).toEqual(sameSiteArticle.title);
+  });
+
   describe('queries', () => {
     const queries = {
       'what\'s a cname record': {


### PR DESCRIPTION
Modifies the search algorithm to ensure that results from the same/current site appear at the top.

## QA

- Visit https://developer.dnsimple.com/
- Copy/paste into the console:
  ```js
  [...document.querySelectorAll('#dnsimple-support-widget')].forEach((el) => el && document.body.removeChild(el))
  
  const $script = document.createElement('script');
  $script.type = 'text/javascript';
  $script.src = `https://deploy-preview-1404--dnsimple-support.netlify.app/widget.js`;
  
  document.getElementsByTagName('head')[0].appendChild($script);
  ```
- Open the widget and search for `records`
- Verify that developer articles appear first
- Try out some other search queries