### PR TITLE
Improve results for `domain validation`

### DIFF
--- a/_widget/src/components/app/dictionary.js
+++ b/_widget/src/components/app/dictionary.js
@@ -28,4 +28,5 @@ export default {
   "expiry": "expiration",
   "comment": "note",
   "axfr": "secondary dns",
+  "validation": "icann validation"
 };

--- a/spec/_widget/components/search.spec.js
+++ b/spec/_widget/components/search.spec.js
@@ -183,6 +183,9 @@ describe('Search', () => {
         "Secondary DNS IP Address Changes": 5,
         "Integrated DNS Providers at DNSimple": 6,
         "Using DNSimple alongside other DNS providers": 7,
+      },
+      'domain validation': {
+        'ICANN Domain Validation Requirements': 1
       }
     };
 


### PR DESCRIPTION
This PR adds a dictionary item for `validation` so that our [ICANN Domain Validation Requirements](https://support.dnsimple.com/articles/icann-domain-validation/) article shows up.

The case that was brought up was `domain validation`. With our new dictionary entry, this will be converted to `domain icann validation`, so the "domain" part of the query is still preserved. As a general rule, I've noticed that 1-word dictionary terms that simply add additional words (like in this PR) are preferable – so that we don't skew other results (eg. results for `certificate validation`).

Related to https://dnsimple.slack.com/archives/C08CHR32Z2M/p1740563758239829?thread_ts=1740068284.101949&cid=C08CHR32Z2M

## 👓 Preview

<img width="785" alt="image" src="https://github.com/user-attachments/assets/67e779e7-57e6-44ad-8e32-7551d1f822f3" />