### PR TITLE
Add transfer information for AU and US domains

### DIFF
--- a/content/articles/domains-au.md
+++ b/content/articles/domains-au.md
@@ -140,4 +140,4 @@ Please complete them to the best of your abilities — if you have any concerns,
 
 ## Have more questions? 
 
-If you have any questions about registering, transferring, or renewing your .AU domain, [contact us](https://dnsimple.com/feedback), and we’ll be happy to help. 
+If you have any questions about registering, transferring, or renewing your .AU domain, [contact us](https://dnsimple.com/feedback), and we'll be happy to help. 

--- a/content/articles/domains-au.md
+++ b/content/articles/domains-au.md
@@ -90,6 +90,29 @@ If the domain name is not redeemed within 31 days, it will be removed from our s
 
 .AU domains are not renewed for one year upon transfer. We do not charge for .AU transfers.
 
+### Required Acknowledgment
+
+All AU domain transfers into DNSimple require your explicit acknowledgment before they can be completed.
+After initiating the transfer, you will receive the acknowledgement email within the same day. Once acknowledgment is completed, your transfer will take up to a week to complete. There are no further steps needed after acknowledging the transfer.
+
+<warning>
+All unacknowledged transfers will be canceled after 14 days.
+</warning>
+
+#### Acknowledgment Process
+
+##### Check your email
+An acknowledgment email will be sent to the domain registrant's email address <strong>(this may be different from your DNSimple account email)</strong>.
+
+If you do not have access to the registrant's email address, we recommend updating this first via the domain's current registrar. Otherwise, your transfer won't succeed.
+
+If you don't see the email, check your spam/junk folders.
+
+##### Complete the Process
+Click the link provided in the acknowledgment email to confirm and complete your transfer.
+
+If you don't receive the acknowledgement email, experience problems with the link, or need any help with your domain transfer, please [contact](https://dnsimple.com/contact) our support team.
+
 ## Changes in ownership
 
 Any contact change that results in a change of registrant must be executed manually. A change of registrant occurs when you are modifying the *Organization Name*, *First/Last Name*, *Eligibility ID type*, or *Eligibility ID number*.

--- a/content/articles/domains-au.md
+++ b/content/articles/domains-au.md
@@ -90,16 +90,17 @@ If the domain name is not redeemed within 31 days, it will be removed from our s
 
 .AU domains are not renewed for one year upon transfer. We do not charge for .AU transfers.
 
-### Required Acknowledgment
+### Required acknowledgment
 
-All AU domain transfers into DNSimple require your explicit acknowledgment before they can be completed.
+All .AU domain transfers into DNSimple require your explicit acknowledgment before they can be completed.
+
 After initiating the transfer, you will receive the acknowledgement email within the same day. Once acknowledgment is completed, your transfer will take up to a week to complete. There are no further steps needed after acknowledging the transfer.
 
 <warning>
 All unacknowledged transfers will be canceled after 14 days.
 </warning>
 
-#### Acknowledgment Process
+#### Acknowledgment process
 
 ##### Check your email
 An acknowledgment email will be sent to the domain registrant's email address <strong>(this may be different from your DNSimple account email)</strong>.
@@ -108,7 +109,7 @@ If you do not have access to the registrant's email address, we recommend updati
 
 If you don't see the email, check your spam/junk folders.
 
-##### Complete the Process
+##### Complete the process
 Click the link provided in the acknowledgment email to confirm and complete your transfer.
 
 If you don't receive the acknowledgement email, experience problems with the link, or need any help with your domain transfer, please [contact](https://dnsimple.com/contact) our support team.
@@ -136,3 +137,7 @@ If your domain has a deregistered ABN/ACN (where the legal entity has been dereg
 - [Transfer of Domain Name Chain of Title Form](/files/transfer-of-domain-name-chain-of-title.docx)
 
 Please complete them to the best of your abilities — if you have any concerns, please [contact the registry directly](https://www.auda.org.au/au-domain-names/general-enquiry-form).
+
+## Have more questions? 
+
+If you have any questions about registering, transferring, or renewing your .AU domain, [contact us](https://dnsimple.com/feedback), and we’ll be happy to help. 

--- a/content/articles/domains-us.md
+++ b/content/articles/domains-us.md
@@ -1,0 +1,45 @@
+---
+title: .US Domains
+excerpt: This article explains the requirements and special procedures for .US domain names.
+categories:
+- Domains
+---
+
+# .SG Domain Names
+
+* TOC
+{:toc}
+
+---
+
+This article explains the requirements and special procedures for .US domain names.
+
+## Transfers
+
+### Required Acknowledgment
+
+All US domain transfers into DNSimple require your explicit acknowledgment before they can be completed.
+
+After initiating the transfer, you will receive the acknowledgement email within the same day. Once acknowledgment is completed, your transfer will take up to a week to complete. There are no further steps needed after acknowledging the transfer.
+
+<warning>
+All unacknowledged transfers will be canceled after 14 days.
+</warning>
+
+#### Acknowledgment Process
+
+##### Check your email
+An acknowledgment email will be sent to the domain registrant's email address <strong>(this may be different from your DNSimple account email)</strong>. 
+
+If you do not have access to the registrant's email address, we recommend updating this first via the domain's current registrar. Otherwise, your transfer won't succeed.
+
+If you don't see the email, check your spam/junk folders.
+
+##### Complete the Process
+Click the link provided in the acknowledgment email to confirm and complete your transfer.
+
+If you don't receive the acknowledgement email, experience problems with the link, or need any help with your domain transfer, please [contact](https://dnsimple.com/contact) our support team.
+
+## Have more questions?
+
+If you have any questions, don't receive the acknowledgement email, or experience problems with the link, [contact us](https://dnsimple.com/contact), and we'll be happy to help.

--- a/content/articles/domains-us.md
+++ b/content/articles/domains-us.md
@@ -5,7 +5,7 @@ categories:
 - Domains
 ---
 
-# .SG Domain Names
+# .US Domain Names
 
 * TOC
 {:toc}
@@ -16,9 +16,9 @@ This article explains the requirements and special procedures for .US domain nam
 
 ## Transfers
 
-### Required Acknowledgment
+### Required acknowledgment
 
-All US domain transfers into DNSimple require your explicit acknowledgment before they can be completed.
+All .US domain transfers into DNSimple require your explicit acknowledgment before they can be completed.
 
 After initiating the transfer, you will receive the acknowledgement email within the same day. Once acknowledgment is completed, your transfer will take up to a week to complete. There are no further steps needed after acknowledging the transfer.
 
@@ -26,7 +26,7 @@ After initiating the transfer, you will receive the acknowledgement email within
 All unacknowledged transfers will be canceled after 14 days.
 </warning>
 
-#### Acknowledgment Process
+#### Acknowledgment process
 
 ##### Check your email
 An acknowledgment email will be sent to the domain registrant's email address <strong>(this may be different from your DNSimple account email)</strong>. 
@@ -35,7 +35,7 @@ If you do not have access to the registrant's email address, we recommend updati
 
 If you don't see the email, check your spam/junk folders.
 
-##### Complete the Process
+##### Complete the process
 Click the link provided in the acknowledgment email to confirm and complete your transfer.
 
 If you don't receive the acknowledgement email, experience problems with the link, or need any help with your domain transfer, please [contact](https://dnsimple.com/contact) our support team.


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/27619.

This adds the transfer section for AU and US domains.

As Centralnic has not responded to what emails we will specifically receive from the registries, I will add those information in a subsequent PR.