### PR TITLE
Ignore modal key events when modal is not opened

### DIFF
--- a/_widget/src/components/app/component.vue
+++ b/_widget/src/components/app/component.vue
@@ -319,9 +319,7 @@ export default {
         this.focus();
       }
 
-      if (!this.isOpen) {
-        return;
-      }
+      if (!this.isOpen) return;
 
       if (event.key === "Escape")
         this.close();

--- a/_widget/src/components/app/component.vue
+++ b/_widget/src/components/app/component.vue
@@ -317,7 +317,13 @@ export default {
 
         this.open();
         this.focus();
-      } else if (event.key === "Escape")
+      }
+
+      if (!this.isOpen) {
+        return;
+      }
+
+      if (event.key === "Escape")
         this.close();
       else if (event.key === "ArrowDown" && this.currentRoute[0] === 'Articles') {
         event.preventDefault();

--- a/_widget/src/main.js
+++ b/_widget/src/main.js
@@ -1,7 +1,5 @@
 import initialize from './initialize.js';
 import storeRecentlyVisited from './recently-visited.js';
 
-const elementId = 'dnsimple-support-widget';
-
 const app = initialize(document);
 storeRecentlyVisited(app);


### PR DESCRIPTION
This PR adds a verification to return early on the widget modal when the modal is not opened.

## :mag: QA

- Open widget via command
- Search on widget

## :shipit: Pre/Post tasks


## :shipit: Verification

- [ ] QA