### PR TITLE
Fix alert icons

### DIFF
--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -71,7 +71,7 @@
   box-shadow: -6px 0 0 0 var(--orange);
 
   &:before {
-    @include font-awesome("\f06a");
+    @include font-awesome("\f071");
     color: var(--orange);
   }
 }

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -33,9 +33,9 @@
   &:before {
     display: block;
     float: left;
-    margin-left: -25px;
-    font-size: 16px;
-    line-height: 140%;
+    margin-left: -30px;
+    font-size: 1.2rem;
+    line-height: 130%;
     color: var(--element2);
   }
 }

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -62,7 +62,7 @@
   box-shadow: -6px 0 0 0 var(--yellow);
 
   &:before {
-    @include font-awesome("\f071");
+    @include font-awesome("\f249");
     color: var(--yellow);
   }
 }

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -53,7 +53,7 @@
   box-shadow: -6px 0 0 0 var(--green);
 
   &:before {
-    @include font-awesome("\f00c");
+    @include font-awesome("\f0eb");
     color: var(--green);
   }
 }

--- a/content/assets/css/_application.scss
+++ b/content/assets/css/_application.scss
@@ -34,8 +34,8 @@
     display: block;
     float: left;
     margin-left: -30px;
-    font-size: 1.2rem;
-    line-height: 130%;
+    font-size: 1.4rem;
+    line-height: 100%;
     color: var(--element2);
   }
 }

--- a/content/assets/css/colorscheme.scss
+++ b/content/assets/css/colorscheme.scss
@@ -26,7 +26,7 @@
   --green: hsl(100, 100%, 30%);
   --gray: hsl(50, 0%, 50%);
   --orange: hsl(30, 100%, 50%);
-  --yellow: hsl(47, 100%, 50%);
+  --yellow: hsl(47, 100%, 47%);
   --icon-color: hsl(0deg 0% 70%);
 }
 


### PR DESCRIPTION
This PR updates various alert icons to ensure they align correctly with the corresponding semantic tags. It also updates the size and sightly adjust the color yellow for the light theme.

## Info

<img width="622" alt="Screenshot 2025-04-15 at 17 34 04" src="https://github.com/user-attachments/assets/4e9ff0e6-afb8-40b4-b0b8-ba39b0704302" />
<img width="622" alt="Screenshot 2025-04-15 at 17 35 18" src="https://github.com/user-attachments/assets/85816d89-9f1f-4d79-a64f-6f37d5dc3e73" />

## Note
<img width="617" alt="Screenshot 2025-04-15 at 17 35 49" src="https://github.com/user-attachments/assets/21f7e988-eae6-4a9c-856b-2f85595d0ecb" />

<img width="622" alt="Screenshot 2025-04-15 at 17 35 58" src="https://github.com/user-attachments/assets/ce1ab83d-f7e6-48ed-a4df-e23e55b172ef" />

## Tip
<img width="686" alt="Screenshot 2025-04-15 at 17 36 19" src="https://github.com/user-attachments/assets/df8b4767-efee-46a6-aa47-eeb5f68e6824" />

<img width="692" alt="Screenshot 2025-04-15 at 17 36 28" src="https://github.com/user-attachments/assets/3919cf87-4efe-431f-84ea-dc3e462c143d" />

## Warning
<img width="686" alt="Screenshot 2025-04-15 at 17 37 22" src="https://github.com/user-attachments/assets/3f4c1ed7-460a-4b5e-a660-3de5ee0c7b41" />
<img width="694" alt="Screenshot 2025-04-15 at 17 37 33" src="https://github.com/user-attachments/assets/92b7a839-884b-4ea2-8efd-fc872be740f1" />

