### PR TITLE
Update dictionary.js

### DIFF
--- a/_widget/src/components/app/dictionary.js
+++ b/_widget/src/components/app/dictionary.js
@@ -44,4 +44,5 @@ export default {
   "ipv6": "ipv6 address aaaa",
   "ptr": "reverse DNS",
   "ptr": "reverse spf",
+  "managing seats": "seats",
 };


### PR DESCRIPTION
Update the dictionary so that Managing Seats brings up the Managing Seats support page.

Searching for managing does not capture Managing Seats support.