### PR TITLE
Search: Fix table of contents links

### DIFF
--- a/_widget/src/components/app/component.vue
+++ b/_widget/src/components/app/component.vue
@@ -155,7 +155,7 @@ export default {
 
       if (isHash) {
         event.preventDefault();
-        document.getElementById(url.split('#')[1]).scrollIntoView();
+        document.getElementById(url.split('#')[1])?.scrollIntoView();
         return;
       }
 

--- a/_widget/src/components/article/component.vue
+++ b/_widget/src/components/article/component.vue
@@ -53,7 +53,7 @@ export default {
       [...this.$el.querySelectorAll('.article a')].forEach((a) => {
         let url = a.getAttribute('href');
 
-        if (url[0] === '/' || url[0] === '#') {
+        if (url[0] === '/') {
           url = `${this.article.sourceUrl}${url}`;
           a.setAttribute('href', url);
         }

--- a/spec/_widget/components/app.spec.js
+++ b/spec/_widget/components/app.spec.js
@@ -352,5 +352,15 @@ describe('App', () => {
       expect(externalLinkProbe).not.toHaveBeenCalled();
       expect(subject.text()).toContain('DNSimple provides essential services for every Internet-connected system');
     });
+
+    it('opens hash links in the widget', async () => {
+      await subject.find('[aria-label="Open widget"]').trigger('click');
+      await subject.find('[aria-label="Visit Getting Started"]').trigger('click');
+      await subject.find('[href="https://support.dnsimple.com/articles/dnsimple-plans/"]').trigger('click');
+      await subject.find('[href$="#have-more-questions"]').trigger('click');
+
+      expect(externalLinkProbe).not.toHaveBeenCalled();
+      expect(subject.text()).toContain('Have more questions?');
+    });
   });
 });


### PR DESCRIPTION
This PR fixes the links in our Table of Contents (and any link that begins with a #).

Fixes https://github.com/dnsimple/dnsimple-support/issues/1448

## QA

- Visit https://deploy-preview-1490--dnsimple-support.netlify.app/
- Open the support widget
- Search for "tlds"
- Click a link in the table of contents
- You should be bumped down the page without the page re-loading