### PR TITLE
Adding lazy loading to youtube embeds

### DIFF
--- a/content/articles/a-record.md
+++ b/content/articles/a-record.md
@@ -15,7 +15,7 @@ categories:
 ---
 
 <div class="aspect-ratio aspect-ratio--16x9 z-0 mb4">
-  <iframe src="https://www.youtube.com/embed/nJ53QG-gq8o" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/nJ53QG-gq8o" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## What's an A record?

--- a/content/articles/aaaa-record.md
+++ b/content/articles/aaaa-record.md
@@ -15,7 +15,7 @@ categories:
 ---
 
 <div class="aspect-ratio aspect-ratio--16x9 z-0 mb4">
-  <iframe src="https://www.youtube.com/embed/4SGgO5MSQLg?si=I5Hu7dj7-uuwA-xs" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/4SGgO5MSQLg?si=I5Hu7dj7-uuwA-xs" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## What's an AAAA record?

--- a/content/articles/api-access-token.md
+++ b/content/articles/api-access-token.md
@@ -21,7 +21,7 @@ To create an application that requires access to DNSimple, or let an external ap
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/oGBUQlbkyFM" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/oGBUQlbkyFM" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Account tokens vs user tokens

--- a/content/articles/common-dns-records.md
+++ b/content/articles/common-dns-records.md
@@ -16,7 +16,7 @@ categories:
 
 
 <div class="aspect-ratio aspect-ratio--16x9 z-0 mb4">
-  <iframe src="https://www.youtube.com/embed/bifh31N2hFQ?si=uM3Z1oS1SqzQNLT4" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/bifh31N2hFQ?si=uM3Z1oS1SqzQNLT4" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 The Domain Name System (DNS) is composed of many different record types (or resource records): `A`, `AAAA`, `CNAME`, `MX`, `CAA`, etc. Some record types are common. Others are less relevant, deprecated, or replaced.

--- a/content/articles/dashboard.md
+++ b/content/articles/dashboard.md
@@ -8,7 +8,7 @@ categories:
 
 # Getting to Know Your DNSimple Dashboard
 
-<iframe width="791" height="445" src="https://www.youtube.com/embed/TAJ8R12hLrI" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe loading="lazy" width="791" height="445" src="https://www.youtube.com/embed/TAJ8R12hLrI" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 Your DNSimple Dashboard contains all of the important highlights for each of your DNSimple accounts: important messages, account overviews and account activity.
 

--- a/content/articles/differences-between-a-cname-alias-url.md
+++ b/content/articles/differences-between-a-cname-alias-url.md
@@ -9,7 +9,7 @@ categories:
 
 
 <div class="aspect-ratio aspect-ratio--16x9 z-0 mb4">
-  <iframe src="https://www.youtube.com/embed/mn07RUxAJRA" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/mn07RUxAJRA" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 

--- a/content/articles/domain-access-control.md
+++ b/content/articles/domain-access-control.md
@@ -26,7 +26,7 @@ Combined with other DNSimple security features, like [multi-factor authenticatio
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/GlC2uvevIlc?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/GlC2uvevIlc?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Setting access for a team member

--- a/content/articles/domain-list.md
+++ b/content/articles/domain-list.md
@@ -8,7 +8,7 @@ categories:
 
 # Getting to Know Your DNSimple Domain List
 
-<iframe width="791" height="445" src="https://www.youtube.com/embed/PGa3Jk3nnGM" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe loading="lazy" width="791" height="445" src="https://www.youtube.com/embed/PGa3Jk3nnGM" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 The DNSimple Domain List is your home base for all the domains in your account. You'll see domains registered with DNSimple, with our Integrated Providers, and domains registered elsewhere that point to our name servers or those of an Integrated Provider.
 

--- a/content/articles/getting-started-clickfunnels.md
+++ b/content/articles/getting-started-clickfunnels.md
@@ -129,7 +129,7 @@ Let's explore the domain management options on your domain's homepage.
 You'll find your name servers listed under the <label>Registration</label> tab. [Name servers](/articles/what-is-a-nameserver/) work as a directory translating domain names into IP addresses. They make things easy to find across the Internet.
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/2WdF1zT01HY" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/2WdF1zT01HY" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 You don't need to change the name servers when you move your domain from ClickFunnels.

--- a/content/articles/guide-dashboard.md
+++ b/content/articles/guide-dashboard.md
@@ -17,10 +17,10 @@ You can access your DNSimple dashboard by clicking the <label>DNSimple</label> l
 
 The dashboard displays all of your accounts side-by-side. You can be a member of one or many accounts, managing your personal domains alongside company domains. Learn more in this [support article](https://support.dnsimple.com/articles/dashboard/), or take a video tour to see how it works.
 
-<iframe width="791" height="445" src="https://www.youtube.com/embed/TAJ8R12hLrI" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe loading="lazy" width="791" height="445" src="https://www.youtube.com/embed/TAJ8R12hLrI" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 The next stop is your Domain List. Here, you'll see the domains in your account, along with basic information for each, like if the domain is registered with DNSimple, has an active zone, certificates, and more. You can read about your [Domain List](https://support.dnsimple.com/articles/domain-list/), or watch our video tour to learn more.
 
-<iframe width="791" height="445" src="https://www.youtube.com/embed/PGa3Jk3nnGM" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe loading="lazy" width="791" height="445" src="https://www.youtube.com/embed/PGa3Jk3nnGM" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 If you have any questions about your dashboard or Domain List, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/heroku-connector.md
+++ b/content/articles/heroku-connector.md
@@ -20,7 +20,7 @@ categories:
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/Z1I0L1aSIA8" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/Z1I0L1aSIA8" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Creating a connection

--- a/content/articles/integrated-dns-provider-amazon-route53.md
+++ b/content/articles/integrated-dns-provider-amazon-route53.md
@@ -21,7 +21,7 @@ DNSimple supports the ability to view and manage zones that are deployed at [Ama
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/4LsTT0pgBaQ" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/4LsTT0pgBaQ" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Prerequisites

--- a/content/articles/integrated-dns-provider-coredns.md
+++ b/content/articles/integrated-dns-provider-coredns.md
@@ -21,7 +21,7 @@ DNSimple supports the ability to sync managed zones to [CoreDNS](https://coredns
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/9yO2Oo_N1ms" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/9yO2Oo_N1ms" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 <info>

--- a/content/articles/integrated-domain-provider-godaddy.md
+++ b/content/articles/integrated-domain-provider-godaddy.md
@@ -21,7 +21,7 @@ DNSimple supports the ability to manage domains that are registered through [GoD
 ## Video Walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/8p7npbNN2x0" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/8p7npbNN2x0" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Supported Features

--- a/content/articles/name-server-sets.md
+++ b/content/articles/name-server-sets.md
@@ -16,7 +16,7 @@ Changes to a name server set's definition will not affect any existing domain na
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/nuerJDLxMQA?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/nuerJDLxMQA?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Types of name server sets

--- a/content/articles/netlify-connector.md
+++ b/content/articles/netlify-connector.md
@@ -19,7 +19,7 @@ categories:
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/VnQq1uFO6l4" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/VnQq1uFO6l4" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Creating a connection

--- a/content/articles/okta-identity-provider.md
+++ b/content/articles/okta-identity-provider.md
@@ -33,7 +33,7 @@ To proceed with configuring login with SSO through Okta, you must:
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/XNJP2gwIIh4?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/XNJP2gwIIh4?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Linking an Okta organization to a DNSimple account

--- a/content/articles/record-notes.md
+++ b/content/articles/record-notes.md
@@ -20,7 +20,7 @@ When creating, updating, or deleting a DNS record from the [DNS record editor](/
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/-97jhZOmcm0?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/-97jhZOmcm0?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Creating a record note

--- a/content/articles/registering-domain.md
+++ b/content/articles/registering-domain.md
@@ -16,7 +16,7 @@ There are **two** reasons to register a domain with DNSimple:
 We recommend [enabling auto-renew](https://support.dnsimple.com/articles/domain-auto-renewal/#enabling-auto-renewal) whenever possible to avoid your domain expiring. Learn more about [what happens when a domain expires](https://support.dnsimple.com/articles/what-happens-when-domain-expires/), and why you want to avoid it.
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/WqhV6OgSEtQ?si=bRK8Ap4GIXiuIdgo" title="Registering a domain" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/WqhV6OgSEtQ?si=bRK8Ap4GIXiuIdgo" title="Registering a domain" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
 <div class="section-steps" markdown="1">

--- a/content/articles/secondary-dns-dnsimple-as-secondary.md
+++ b/content/articles/secondary-dns-dnsimple-as-secondary.md
@@ -18,7 +18,7 @@ For an overview of Secondary DNS, have a look at [our introduction article](/art
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/NPlkDqLL2Vo" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/NPlkDqLL2Vo" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -74,7 +74,7 @@ To make changes to a reserved name server, click on the configuration icon next 
 If you are adding a name server that is a child of the domain, glue records are required. You will be prompted about the missing glue records upon clicking <label>Change Name Servers</label>. To add glue record, create a [name server set](/articles/name-server-sets/#creating-an-account-name-server-set), and click <label>Add a name server set</label> on the <label>Edit delegation</label> page to apply it.
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/m_RaPIRNxFs?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/m_RaPIRNxFs?rel=0&modestbranding=1&cc_load_policy=1&cc_lang_pref=en" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 <info>

--- a/content/articles/terraform-provider.md
+++ b/content/articles/terraform-provider.md
@@ -22,7 +22,7 @@ you can easily manage your DNS infrastructure and set up the required DNS record
 ## Video walk-through
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/cTWP1MWA-0c" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/cTWP1MWA-0c" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 </div>
 
 ## Configuring the DNSimple provider

--- a/content/articles/what-is-a-nameserver.md
+++ b/content/articles/what-is-a-nameserver.md
@@ -12,7 +12,7 @@ Name servers work as a directory that translates domain names into IP addresses.
 When you type a domain name into the search bar of your browser (Chrome, Safari, etc.), the domain name hits the name server, which translates the domain name into the IP address so the browser can locate it. Once it's found the domain name in the name server, your web browser uses the IP address to connect to the server and load the site you request.
 
 <div class="mb4 aspect-ratio aspect-ratio--16x9 z-0">
-  <iframe src="https://www.youtube.com/embed/2WdF1zT01HY" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/2WdF1zT01HY" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 <info>

--- a/content/articles/what-is-ssl-san.md
+++ b/content/articles/what-is-ssl-san.md
@@ -8,7 +8,7 @@ categories:
 # What is the SSL Certificate Subject Alternative Name?
 
 <div class="aspect-ratio aspect-ratio--16x9 z-0 mb4">
-  <iframe src="https://www.youtube.com/embed/R5jdnZyusew" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/R5jdnZyusew" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ### Table of Contents {#toc}

--- a/content/articles/what-is-ttl.md
+++ b/content/articles/what-is-ttl.md
@@ -17,7 +17,7 @@ categories:
 ---
 
 <div class="aspect-ratio aspect-ratio--16x9 z-0 mb4">
-  <iframe src="https://www.youtube.com/embed/lZXu5ymxeks" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe loading="lazy" src="https://www.youtube.com/embed/lZXu5ymxeks" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 In DNS, resource records are held in cache on a resolver for an amount of time specified by time-to-live (TTL). This is a numeric value stored as a 32-bit signed integer and represents the amount of time in seconds that the record's content can be considered valid.

--- a/content/index.html
+++ b/content/index.html
@@ -83,7 +83,7 @@ meta: Explore comprehensive help documentation and tutorials for DNSimple domain
   <h2 class="mb2">Watch how DNSimple can help you manage your domains.</h2>
   <p class="ma0 pb2">In a short 90 seconds video.</p>
   <div class="aspect-ratio aspect-ratio--16x9 z-0">
-    <iframe src="https://www.youtube.com/embed/0Kt5yAWWwAI" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe loading="lazy" src="https://www.youtube.com/embed/0Kt5yAWWwAI" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
 </div>
 

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -11,7 +11,6 @@
 
   <link rel="shortcut icon" type="image/png" href="/assets/images/favicon.ico" />
   <link rel="stylesheet" type="text/css" href="/assets/css/style.css">
-  <script type="text/javascript" src="/dist/main.js"></script>
 
   <%= render "/colortheme.*" %>
   <%= render "/analytics.*" %>


### PR DESCRIPTION
According to lighthouse youtube embeds are "render blocking" adding lazy loading to the youtube iframes, so that the perceived page speed will increase.

Also, i discovered that `main.js` was loaded twice on the default layout, once in the header and then once at the bottom of the body. Removing the one in the header as that is render blocking as well. 