### PR TITLE
Adjust the scroll margin to show the section header

### DIFF
--- a/content/assets/css/_typography.scss
+++ b/content/assets/css/_typography.scss
@@ -17,6 +17,7 @@ body {
 
 h1, h2, h3 {
   font-weight: normal;
+  scroll-margin-top: 65px;
 }
 
 h1 {
@@ -32,7 +33,6 @@ h2 {
   font-weight: bold;
   margin: 0;
   padding: 18px 0 8px 0;
-  scroll-margin-top: 60px;
 }
 
 h3 {

--- a/content/assets/css/_typography.scss
+++ b/content/assets/css/_typography.scss
@@ -32,6 +32,7 @@ h2 {
   font-weight: bold;
   margin: 0;
   padding: 18px 0 8px 0;
+  scroll-margin-top: 60px;
 }
 
 h3 {


### PR DESCRIPTION
When navigating via the table of contents or an anchor link, section headings were disappearing under our sticky header. This PR adds a top scroll margin to each heading so that, when you jump to a section, its title is fully visible below the header.

There is good support for [scroll-margin](https://caniuse.com/?search=scroll-margin).

### Before

https://support.dnsimple.com/articles/secondary-dns/#getting-started

<img width="1045" alt="Screenshot 2025-05-22 at 11 43 40" src="https://github.com/user-attachments/assets/afa79f17-0cfc-4cb1-bed8-34858a2f1105" />


### After

https://deploy-preview-1497--dnsimple-support.netlify.app/articles/secondary-dns/#getting-started

<img width="1057" alt="Screenshot 2025-05-22 at 11 43 18" src="https://github.com/user-attachments/assets/67fc3da4-930b-4640-aa29-9bd74bbfd8e1" />
