### PR TITLE
Fix broken link in changing-email.md

### DIFF
--- a/content/articles/changing-email.md
+++ b/content/articles/changing-email.md
@@ -22,7 +22,8 @@ If you want to update both your account and user email to the same address, you'
 ## Changing the account email
 
 <div class="section-steps" markdown="1">
-1. Go to [your account page](https://dnsimple.com/account).
+1. Use the account switcher at the top right of the page to select the appropriate account. 
+1. Click on **Account Settings**
 1. On the **Account** card, click <label>Edit</label>:
 
     ![Settings menu](/files/account-menu.png)


### PR DESCRIPTION
In [Changing Email](https://support.dnsimple.com/articles/changing-email/), the link in step one of the "Changing the account email" steps no longer works.

The link is to https://dnsimple.com/account, which now redirects to the user page with the account switcher changes.