### PR TITLE
Add transfer instructions for .ES domains

### DIFF
--- a/content/articles/domains-es.md
+++ b/content/articles/domains-es.md
@@ -31,6 +31,33 @@ Provide any of the following identification details:
 - **Resident alien ID (NIE)**: Select this option for foreigners in Spain, composed of a letter at the beginning, 7 numbers, and a final letter. Do not add any hyphens; only include letters and numbers.
 - **Generic ID**: Select this option for passports, company registration numbers, and foreign documents.
 
+
+## Transferring a .ES domain #{transferring}
+
+### Required acknowledgment
+
+All .ES domain transfers into DNSimple require your explicit acknowledgment before they can be completed.
+
+After initiating the transfer, you will receive the acknowledgement email within the same day. Once acknowledgment is completed, your transfer will take up to a week to complete. There are no further steps needed after acknowledging the transfer.
+
+<warning>
+All unacknowledged transfers will be canceled after 14 days.
+</warning>
+
+#### Acknowledgment process
+
+##### Check your email
+An acknowledgment email will be sent to the domain registrant's email address <strong>(this may be different from your DNSimple account email)</strong>.
+
+If you do not have access to the registrant's email address, we recommend updating this first via the domain's current registrar. Otherwise, your transfer won't succeed.
+
+If you don't see the email, check your spam/junk folders.
+
+##### Complete the process
+Click the link provided in the acknowledgment email to confirm and complete your transfer.
+
+If you don't receive the acknowledgement email, experience problems with the link, or need any help with your domain transfer, please [contact](https://dnsimple.com/contact) our support team.
+
 ## Renewing a .ES domain {#renewing}
 
 ### Auto-renewal only {#auto-renewal-required}


### PR DESCRIPTION
Related to https://github.com/dnsimple/dnsimple-app/pull/31173.

We recently identified that ES transfers need manual approval. This PR amends our support documentation to include instructions for approving ES transfers.

This text was copied over from ourexisting support documentation for TLDs that have a manual transfer approval process like US and AU.