### PR TITLE
Create dnssec-at-dnsimple.md

### DIFF
--- a/content/articles/dnssec-at-dnsimple.md
+++ b/content/articles/dnssec-at-dnsimple.md
@@ -1,0 +1,53 @@
+---
+title: DNSSEC at DNSimple: Everything You Need to Know
+excerpt: Learn where to find everything you need to know about DNSSEC at DNSimple.
+meta: Links several relevant articles to learning What is DNSSEC and how to manage your DNSSEC in DNSimple.
+categories:
+- Account
+---
+
+# DNSSEC at DNSimple: Everything You Need to Know
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+---
+
+DNSSEC (Domain Name System Security Extensions) adds an essential layer of security to the DNS, protecting your domain from various attacks like cache poisoning. At DNSimple, we simplify the complexity of DNSSEC, offering features like automatic key rotation and support for both DS-data and KEY-data interfaces, making it easy to enable and manage DNSSEC for your domains and helping you ensure the integrity and authenticity of your DNS data.
+
+## What is DNSSEC?
+
+If you are new to DNSSEC, these articles will help you understand the fundamentals:
+
+- [What Is DNSSEC?](/articles/what-is-dnssec/) Learn what DNSSEC is and why it matters.
+- The DNSSEC Chain of Trust: Explore the concept of the Chain of Trust and how it ensures the validity of DNS data.
+- What Are DS Records?: Understand the role of Delegation Signer (DS) records in linking a child zone to its parent in the DNSSEC chain.
+- DNSKEY Records Explained: Dive into DNSKEY records, which contain the public keys used to verify DNSSEC signatures.
+- What Are the Types of DNSSEC Keys?: Discover the different types of DNSSEC keys and their specific functions.
+- Understanding RRSETs and RRSIGs in DNSSEC: Learn about Resource Record Sets (RRSETs) and RRSIG (Resource Record Signature) records, which provide cryptographic proof of data integrity.
+- Understanding NSEC and NSEC3 Records: Explore NSEC and NSEC3 records and how they help prevent zone walking.
+- [What Are CDS and CDNSKEY Records?](https://support.dnsimple.com/articles/what-are-cds-and-cdnskey/) Understand how these record types help automate DNSSEC management and simplify key rollovers.
+
+## Tutorials
+
+Ready to use DNSSEC? Learn how to manage your DNSSEC configurations effectively with these articles.
+
+- [Enabling DNSSEC](/articles/enabling-dnssec/): A step-by-step guide to turning DNSSEC **on** for your domain.
+- [Disabling DNSSEC](/articles/disabling-dnssec/):  A step-by-step guide to turning DNSSEC **off** for your domain.
+- [Managing DS Records](/articles/manage-ds-record/): Learn how to manually add or remove Delegation Signer (DS) records for your domain.
+- [Managing DS Records When Changing DNS](/articles/ds-records-changing-dns/): A guide to updating DS records when you migrate your DNS hosting to a different provider.
+- [Rotate DNSSEC Keys](https://support.dnsimple.com/articles/rotate-dnssec-key/): Learn how to manage DNSSEC key rotation and what to do when keys change.
+
+## Troubleshooting DNSSEC configurations
+
+Encountering issues with your DNSSEC setup? Find solutions and guidance here.
+
+- [Troubleshooting DNSSEC Configurations](https://support.dnsimple.com/articles/troubleshooting-dnssec-configurations/): A comprehensive guide to diagnosing and resolving common DNSSEC problems.
+
+## Reference articles
+
+Dive deeper into the specifics of DNSSEC with our comprehensive reference materials, including an overview of the settings and details available directly in your DNSimple account.
+
+- DNSSEC Management in DNSimple: A detailed look at the DNSSEC management interface within your DNSimple account, including available settings and information.
+- [DNSSEC Glossary](/articles/dnssec-glossary/): Familiarize yourself with common terms and definitions related to DNSSEC.


### PR DESCRIPTION
Creates a pillar page linking out to the various articles on DNSSEC at DNSimple. The goal of this page is to provide a TL;DR of each article and make it easy for users (especially those new to DNSSEC) to find what they're looking for. 