### PR TITLE
Bump rack to latest version (CVE-2025-61770)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     puma (7.0.4)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.2)
     rack-livereload (0.5.1)
       rack
     rackup (2.1.0)


### PR DESCRIPTION
Addresses dependabot security alerts:
- https://github.com/dnsimple/dnsimple-support/security/dependabot/104
- https://github.com/dnsimple/dnsimple-support/security/dependabot/103
- https://github.com/dnsimple/dnsimple-support/security/dependabot/102

