### PR TITLE
Remove reference to fTLD token from BANK / INSURANCE 

### DIFF
--- a/content/articles/domains-bank.md
+++ b/content/articles/domains-bank.md
@@ -48,13 +48,13 @@ DNSimple implements the following security requirements:
 
 ### Registration
 
-Before initiating the domain registration through DNSimple, you must request a registration token from the registry:
+Before initiating the domain registration through DNSimple, you must submit an application to the registry:
 
 1. Go to [https://register.bank/get-started/](https://register.bank/get-started/)
 2. When completing this form, under Registrar of Choice:
   - Select: Key-Systems, LLC.
   ![screenshot: bank registrar](/files/domains-ftld-registrar.png)
-3. Once completed, you'll receive a token. Keep this token;  you'll need it to complete the [registration in DNSimple](https://support.dnsimple.com/articles/registering-domain/).
+3. Once approved, you can proceed to [register the domain in DNSimple](https://support.dnsimple.com/articles/registering-domain/).
 
 ### DNSimple requirements
 

--- a/content/articles/domains-insurance.md
+++ b/content/articles/domains-insurance.md
@@ -48,13 +48,13 @@ DNSimple implements the following security requirements:
 
 ### Registration
 
-Before initiating the domain registration through DNSimple, you must request a registration token from the registry:
+Before initiating the domain registration through DNSimple, you must submit an application to the registry:
 
 1. Go to [https://register.insurance/get-started/](https://register.insurance/get-started/)
 2. When completing this form, under Registrar of Choice:
   - Select: Key-Systems, LLC.
   ![screenshot: insurance registrar](/files/domains-ftld-registrar.png)
-3. Once completed, you'll receive a token. Keep this token;  you'll need it to complete the [registration in DNSimple](https://support.dnsimple.com/articles/registering-domain/).
+3. Once approved, you can proceed to [register the domain in DNSimple](https://support.dnsimple.com/articles/registering-domain/).
 
 ### DNSimple requirements
 


### PR DESCRIPTION
Updates documentation to remove reference to fTLD token from BANK / INSURANCE pages

## :mag: QA

- https://support.dnsimple.com/articles/domains-bank/ makes no reference to fTLD registration token


## :clipboard: Deployment Pre/Post tasks


## :shipit: Deployment Verification

- [x] QA'd