### PR TITLE
Update docs to reference account tokens when pushing a domain to a new account

### DIFF
--- a/content/articles/getting-started-clickfunnels.md
+++ b/content/articles/getting-started-clickfunnels.md
@@ -45,10 +45,10 @@ Welcome to [DNSimple](/articles/dnsimple-services/)! We're here to make your tra
 
     > `YES`
 
-    > ii. Provide the email address associated with your ClickFunnels account and your DNSimple account token.
+    > ii. Provide the email address associated with your ClickFunnels account and your DNSimple domain push identifier.
 
     > - `Your ClickFunnels email address`
-    > - `Your DNSimple account token (found on your DNSimple account page)`
+    > - `Your DNSimple domain push identifier (found on your DNSimple account page)`
 
     > iii. Name of domain(s) you want to transfer.
 

--- a/content/articles/transferring-domain-between-accounts.md
+++ b/content/articles/transferring-domain-between-accounts.md
@@ -41,12 +41,12 @@ Once the domain is transferred, you can no longer control it under your current 
 1. In the **Share or transfer domain** card, click **Transfer**.
     ![transfer between accounts](/files/transfer-domains-between-accounts.png)
 
-1. Enter the destination account token of another DNSimple account. The recipient can find their account token in the Account card on their account page.
+1. Enter the destination domain push identifier of another DNSimple account. The recipient can find their domain push identifier in the Account card on their account page.
 1. Click **Move domain**.
 1. A banner will appear confirming the request to push the domain.
 
 <warning>
-Make sure to correctly enter the account token. **Once the transfer has been initiated, you won't be able to cancel the transfer on your own if the token is incorrect.** If the token is wrong, and you need to cancel the transfer, you will have to contact support for assistance.
+Make sure to correctly enter the domain push identifier. **Once the transfer has been initiated, you won't be able to cancel the transfer on your own if the identifier is incorrect.** If the identifier is wrong, and you need to cancel the transfer, you will have to contact support for assistance.
 </warning>
 
 ## Accepting a transfer


### PR DESCRIPTION
This PR updates our docs to use `new_account_token` when pushing a domain and marks `new_account_email` as a deprecated payload.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/2318

### 📋 Deployment Pre/Post tasks

- [x] PRE: Activate feature flag for all customers.
- [x] PRE: Give ClickFunnels a heads up