### PR TITLE
Add clarification on where to find the domain push identifier

### DIFF
--- a/content/articles/getting-started-clickfunnels.md
+++ b/content/articles/getting-started-clickfunnels.md
@@ -48,7 +48,10 @@ Welcome to [DNSimple](/articles/dnsimple-services/)! We're here to make your tra
     > ii. Provide the email address associated with your ClickFunnels account and your DNSimple domain push identifier.
 
     > - `Your ClickFunnels email address`
-    > - `Your DNSimple domain push identifier (found on your DNSimple account page)`
+    > - `Your DNSimple domain push identifier`
+    
+    You can find your domain push identifier in your DNSimple account by opening the account switcher in the top-left corner, selecting the correct account, clicking Settings in the left sidebar, and locating the Domain Push Identifier in the Account card. Copy that value and paste it here.
+    
 
     > iii. Name of domain(s) you want to transfer.
 


### PR DESCRIPTION
I added a short clarification in the CF doc to help customers who want to get ownership of their domains understand where to find the domain push identifier.