### PR TITLE
Backlinks to whois privacy page and add link to enable whois privacy

### DIFF
--- a/content/articles/what-is-whois-privacy.md
+++ b/content/articles/what-is-whois-privacy.md
@@ -63,4 +63,4 @@ To learn how to turn WHOIS Privacy protection on or off for your domain, see our
 
 ## Have more questions?
 
-If you have additional questions about WHOIS Privacy, just [contact support](https://dnsimple.com/feedback), and we’ll be happy to help.
+If you have additional questions about WHOIS Privacy, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.


### PR DESCRIPTION
As per marketing issue https://github.com/dnsimple/dnsimple-marketing/issues/812 adding backlinks to support documentation related to Whois privacy and adding a link at the end of the article to instruction how to able or unable whois privacy. 