### PR TITLE
Add meta descriptions to all DNSSEC category articles

### DIFF
--- a/content/articles/disabling-dnssec.md
+++ b/content/articles/disabling-dnssec.md
@@ -1,6 +1,7 @@
 ---
 title: Disabling DNSSEC
 excerpt: Learn how to disable DNSSEC for your domain, including critical warnings about removing DS records to prevent DNSSEC validation failures.
+meta: Learn how to disable DNSSEC for your domain at DNSimple. Understand critical warnings about removing DS records to prevent DNSSEC validation failures.
 categories:
 - DNSSEC
 - Enterprise

--- a/content/articles/dnssec.md
+++ b/content/articles/dnssec.md
@@ -1,6 +1,7 @@
 ---
 title: DNSSEC at DNSimple
 excerpt: Learn where to find everything you need to know about DNSSEC at DNSimple.
+meta: Discover everything you need to know about DNSSEC at DNSimple. Learn how to enable, manage, and troubleshoot DNSSEC for enhanced DNS security.
 categories:
 - DNSSEC
 ---

--- a/content/articles/enabling-dnssec.md
+++ b/content/articles/enabling-dnssec.md
@@ -1,6 +1,7 @@
 ---
 title: Enabling DNSSEC
 excerpt: Enable DNSSEC for your domain. Understand the prerequisites, follow the configuration steps, and know what to expect after activation.
+meta: Learn how to enable DNSSEC for your domain at DNSimple. Understand prerequisites, follow step-by-step configuration, and know what to expect after activation.
 categories:
   - DNSSEC
   - Enterprise

--- a/content/articles/rotate-dnssec-key.md
+++ b/content/articles/rotate-dnssec-key.md
@@ -1,6 +1,7 @@
 ---
 title: Rotate DNSSEC Keys
 excerpt: Guides DNSSEC key rotation for DNSimple users, detailing auto-rotation and essential manual steps to maintain domain security.
+meta: Learn about DNSSEC key rotation at DNSimple. Understand automatic key rotation, manual DS record updates, and how to maintain domain security.
 categories:
 - DNS
 - DNSSEC

--- a/content/articles/what-are-cds-and-cdnskey.md
+++ b/content/articles/what-are-cds-and-cdnskey.md
@@ -1,6 +1,7 @@
 ---
 title: What Are CDS and CDNSKEY?
 excerpt: CDS and CDNSKEY records help automate DNSSEC key updates by signaling parent zones, reducing manual errors and keeping your domain resolvable.
+meta: Learn about CDS and CDNSKEY records and how they automate DNSSEC key updates. Understand how these records reduce manual errors and keep domains resolvable.
 categories:
 - DNSSEC
 - Enterprise


### PR DESCRIPTION
## Summary
This PR adds SEO meta descriptions to all 18 articles in the DNSSEC category. Related to https://github.com/dnsimple/dnsimple-customer-success/issues/144

## Changes
- Added meta descriptions (110-160 characters) to 5 DNSSEC category articles that were missing them
- Meta descriptions accurately describe article content and follow existing style guidelines
- All DNSSEC articles now have complete frontmatter with title, excerpt, meta, and categories
- Verified all 18 DNSSEC articles have excerpts (all already had them)

## Articles Updated
5 DNSSEC articles that were missing meta descriptions:
- Disabling DNSSEC
- DNSSEC at DNSimple
- Enabling DNSSEC
- Rotate DNSSEC Keys
- What Are CDS and CDNSKEY?

## SEO Impact
All meta descriptions are optimized for search engines (110-160 characters) and provide clear, concise descriptions of each article's content.

## Verification
- ✓ All 18 DNSSEC articles have meta descriptions
- ✓ All 18 DNSSEC articles have excerpts
- ✓ No linting errors