### PR TITLE
Fix support widget for dev/ci

### DIFF
--- a/_widget/index.html
+++ b/_widget/index.html
@@ -10,9 +10,10 @@
     <a
       href="javascript:;"
       data-dnsimple-open-support-widget
-      data-dnsimple-current-site-url="https://support.dnsimple.com"
-      data-dnsimple-getting-started-url="https://support.dnsimple.com/articles/getting-started/"
-      data-comment="If you want the behavior to mimic the support site, use data-dnsimple-current-site-url=https://support.dnsimple.com"
+      data-dnsimple-current-site-url="http://localhost:3000"
+      data-dnsimple-getting-started-url="http://localhost:3000/articles/getting-started/"
+      data-dnsimple-sources='[{"name": "DNSimple Support", "url": "http://localhost:3000"}]'
+      data-comment="To mimic embedding from a different site, use data-dnsimple-current-site-url=https://dnsimple.com"
     >
       Click to open the support widget. Remove this DOM element to have it load automatically in the bottom corner.
     </a>

--- a/_widget/src/components/app/component.vue
+++ b/_widget/src/components/app/component.vue
@@ -67,12 +67,10 @@ export default {
     },
     sources: {
       type: Array,
-      default() {
-        return [
-          { name: 'DNSimple Support', url: 'https://support.dnsimple.com' },
-          { name: 'DNSimple Developer', url: 'https://developer.dnsimple.com' }
-        ];
-      }
+      default: () => [
+        { name: 'DNSimple Support', url: 'https://support.dnsimple.com' },
+        { name: 'DNSimple Developer', url: 'https://developer.dnsimple.com' }
+      ]
     }
   },
   data () {

--- a/_widget/src/initialize.js
+++ b/_widget/src/initialize.js
@@ -13,10 +13,14 @@ export default (doc, options = {}) => {
     doc.body.insertBefore($target, doc.body.firstChild);
   }
 
+  const sourcesAttr = doc.querySelector('[data-dnsimple-sources]')?.getAttribute('data-dnsimple-sources');
+  const sources = sourcesAttr ? JSON.parse(sourcesAttr) : undefined;
+
   const app = createApp(App, Object.assign({
     showPrompt: $openers.length === 0,
     currentSiteUrl: doc.querySelector('[data-dnsimple-current-site-url]')?.getAttribute('data-dnsimple-current-site-url') || '',
     gettingStartedUrl: doc.querySelector('[data-dnsimple-getting-started-url]')?.getAttribute('data-dnsimple-getting-started-url') || '/articles/getting-started/',
+    ...(sources && { sources }),
   }, options)).mount($target);
 
   $openers.forEach(($el) => {

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -141,12 +141,22 @@
       });
   </script>
 
+<% if ENV['NANOC_ENV'] == 'production' %>
   <script
     type="text/javascript"
     src="/widget.js"
     data-dnsimple-current-site-url="https://support.dnsimple.com"
     data-dnsimple-getting-started-url="https://support.dnsimple.com/articles/getting-started/"
   ></script>
+<% else %>
+  <script
+    type="text/javascript"
+    src="/widget.js"
+    data-dnsimple-current-site-url=""
+    data-dnsimple-getting-started-url="/articles/getting-started/"
+    data-dnsimple-sources='[{"name": "DNSimple Support", "url": ""}]'
+  ></script>
+<% end %>
   <script src="/dist/main.js" type="text/javascript" charset="utf-8"></script>
 </body>
 </html>

--- a/spec/_widget/components/app.spec.js
+++ b/spec/_widget/components/app.spec.js
@@ -15,7 +15,28 @@ describe('App', () => {
       gettingStartedUrl: 'https://support.dnsimple.com/articles/getting-started/',
       currentSiteUrl: 'https://support.dnsimple.com',
       fetch: () => Promise.resolve(ARTICLES),
+      // Explicitly set sources since tests run in localhost which defaults to relative URLs
+      sources: [
+        { name: 'DNSimple Support', url: 'https://support.dnsimple.com' },
+        { name: 'DNSimple Developer', url: 'https://developer.dnsimple.com' }
+      ],
     };
+  });
+
+  describe('sources prop', () => {
+    it('defaults to production URLs', () => {
+      const subject = mount(App);
+      expect(subject.vm.sources).toEqual([
+        { name: 'DNSimple Support', url: 'https://support.dnsimple.com' },
+        { name: 'DNSimple Developer', url: 'https://developer.dnsimple.com' }
+      ]);
+    });
+
+    it('can be overridden via props', () => {
+      const customSources = [{ name: 'Local', url: 'http://localhost:3000' }];
+      const subject = mount(App, { propsData: { sources: customSources } });
+      expect(subject.vm.sources).toEqual(customSources);
+    });
   });
 
   describe('init', () => {


### PR DESCRIPTION
The support widget hardcoded absolute URLs (`https://support.dnsimple.com/search.json`), making it impossible to test local article changes during development.

This PR:

- Added `data-dnsimple-sources` attribute support to inject custom sources
- Nanoc layout conditionally outputs relative URLs when `ENV['NANOC_ENV'] != 'production'`
- Widget dev page (`_widget/index.html`) points to `localhost:3000` for nanoc dev server

Fixes https://github.com/dnsimple/dnsimple-support/issues/1730

## :mag: QA

- **Dev mode (nanoc)**
  - Run `bundle exec nanoc && bundle exec nanoc live`
  - Open widget, search for an article
  - Verify network tab shows `/search.json` (relative), not `https://support.dnsimple.com/search.json`
- **Dev mode (vite)**
  - Run `npm run widget` (requires nanoc running on port 3000)
  - Verify widget loads and searches work against localhost
- **Production build**
  - Run `NANOC_ENV=production bundle exec nanoc`
  - Verify output contains `data-dnsimple-current-site-url="https://support.dnsimple.com"`

## :clipboard: Deployment Pre/Post tasks

None required.

## :shipit: Deployment Verification

- [ ] production: Open support site, open widget, verify search works (fetches from support.dnsimple.com)