### PR TITLE
Convert old callout syntax to GitHub Flavored Markdown in core delegation articles

### DIFF
--- a/content/articles/delegating-dnsimple-hosted.md
+++ b/content/articles/delegating-dnsimple-hosted.md
@@ -1,6 +1,7 @@
 ---
 title: Delegating a Domain registered with another Registrar to DNSimple
 excerpt: How to delegate a domain registered with a different registrar to DNSimple's name servers.
+meta: Learn how to delegate your domain to DNSimple's name servers when your domain is registered with another registrar, enabling DNS hosting with DNSimple.
 categories:
 - Name Servers
 ---
@@ -9,9 +10,8 @@ categories:
 
 This article explains how to delegate your domain to DNSimple's name servers when your domain is registered with another registrar. Pointing the name servers to DNSimple will cause the domain to resolve using the DNS records configured in your DNSimple account.
 
-<note>
-If you need to delegate name servers to another provider (not DNSimple), see [Setting the Name Servers for a Domain](/articles/setting-name-servers/). To delegate name servers to another provider, you'll update your domain's name server delegation at your registrar.
-</note>
+> [!NOTE]
+> If you need to delegate name servers to another provider (not DNSimple), see [Setting the Name Servers for a Domain](/articles/setting-name-servers/). To delegate name servers to another provider, you'll update your domain's name server delegation at your registrar.
 
 ## Delegating to another provider
 
@@ -32,13 +32,16 @@ This article focuses on delegating a domain registered with another registrar to
     - ns4.dnsimple-edge.org
 </div>
 
-<note>
-#### Name server propagation
-
-Please note that it may take up to 24 hours for a name server change to propagate. The whois response is normally a good way to [determine if the changes have been submitted properly](/articles/domain-resolution-issues/).
-</note>
+> [!NOTE]
+> #### Name server propagation
+>
+> Please note that it may take up to 24 hours for a name server change to propagate. The whois response is normally a good way to [determine if the changes have been submitted properly](/articles/domain-resolution-issues/).
 
 ### How to set custom name servers at some common registrars
 
 - [GoDaddy](https://uk.godaddy.com/help/set-custom-nameservers-for-domains-registered-with-us-12317)
 - [Namecheap](https://www.namecheap.com/support/knowledgebase/article.aspx/767/10/how-can-i-change-the-nameservers-for-my-domain)
+
+## Have more questions?
+
+If you have additional questions about delegating your domain to DNSimple's name servers, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/pointing-domain-to-dnsimple.md
+++ b/content/articles/pointing-domain-to-dnsimple.md
@@ -12,9 +12,8 @@ Pointing a domain name servers to DNSimple is required if you want to use DNSimp
 
 Pointing the name servers to DNSimple will cause the domain to resolve using the DNS records configured in your DNSimple account.
 
-<note>
-If you need to delegate name servers to another provider (not DNSimple), see [Setting the Name Servers for a Domain](/articles/setting-name-servers/).
-</note>
+> [!NOTE]
+> If you need to delegate name servers to another provider (not DNSimple), see [Setting the Name Servers for a Domain](/articles/setting-name-servers/).
 
 ## Domain registered with DNSimple
 
@@ -24,8 +23,11 @@ Follow these instructions to [delegate a domain registered with DNSimple to DNSi
 
 Follow these instructions to [delegate a domain registered with another registrar to DNSimple](/articles/delegating-dnsimple-hosted/).
 
-<note>
-#### Name server propagation
+> [!NOTE]
+> #### Name server propagation
+>
+> Please note that it may take up to 24 hours for a name server change to propagate. The whois response is normally a good way to [determine if the changes have been submitted properly](/articles/domain-resolution-issues/).
 
-Please note that it may take up to 24 hours for a name server change to propagate. The whois response is normally a good way to [determine if the changes have been submitted properly](/articles/domain-resolution-issues/).
-</note>
+## Have more questions?
+
+If you have additional questions about pointing your domain to DNSimple or need assistance with domain delegation, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -1,6 +1,7 @@
 ---
 title: Setting the Name Servers for a Domain
 excerpt: Learn how to delegate name servers to another provider or point your domain to DNSimple's name servers. To set the name servers, your domain must be registered with DNSimple.
+meta: Learn how to change your domain's name servers to point to another DNS provider or back to DNSimple when your domain is registered with DNSimple.
 categories:
   - Name Servers
 ---
@@ -51,9 +52,8 @@ To delegate name servers to another provider, you need to update your domain's n
 
 </div>
 
-<info>
-DNSimple's listing of NS records for the domain will be updated to match the name server changes.
-</info>
+> [!NOTE]
+> DNSimple's listing of NS records for the domain will be updated to match the name server changes.
 
 ## Pointing the name servers to DNSimple
 


### PR DESCRIPTION
This PR converts old callout syntax (`<info>`, `<note>`) to GitHub Flavored Markdown callouts (`> [!NOTE]`) in core delegation articles:

- setting-name-servers.md
- delegating-dnsimple-hosted.md  
- pointing-domain-to-dnsimple.md

Part of splitting PR #1675 into smaller, more manageable PRs.