### PR TITLE
Convert old callout syntax to GitHub Flavored Markdown in reference articles

### DIFF
--- a/content/articles/name-server-management-in-dnsimple.md
+++ b/content/articles/name-server-management-in-dnsimple.md
@@ -77,9 +77,8 @@ Name server sets allow you to quickly apply predefined groups of name servers:
 
 ![Add a name server set](/files/domain-delegation-add-name-server-set.png)
 
-<info>
-If a name server in the set has glue IP addresses associated with it and is a child zone of the domain (e.g., `ns1.example.com` for `example.com`), glue records will be created automatically at the registry.
-</info>
+> [!NOTE]
+> If a name server in the set has glue IP addresses associated with it and is a child zone of the domain (e.g., `ns1.example.com` for `example.com`), glue records will be created automatically at the registry.
 
 ## Reserved name servers
 

--- a/content/articles/name-server-sets.md
+++ b/content/articles/name-server-sets.md
@@ -19,9 +19,8 @@ categories:
 
 Name server sets are reusable groups of [name server](/articles/what-is-a-nameserver/) records that can be applied to the [name server delegation](/articles/setting-name-servers/), [secondary DNS](/articles/secondary-dns/) configuration, and [zone NS records](/articles/zone-ns-records/) of your domains. They speed up the entry of name server and NS records and reduce possible mistakes, like typos and other errors.
 
-<info>
-Changes to a name server set's definition will not affect any existing domain name server or configurations that had included the name server set.
-</info>
+> [!NOTE]
+> Changes to a name server set's definition will not affect any existing domain name server or configurations that had included the name server set.
 
 ## Video walk-through
 
@@ -96,8 +95,7 @@ Account name server sets are private to an account and can contain custom name s
 
     ![Deleting a name server set](/files/name-server-sets-delete.png)
 
-<info>
-Deleting a name server set will not affect any existing domain name server or NS record configurations that had included the name server set.
-</info>
+> [!NOTE]
+> Deleting a name server set will not affect any existing domain name server or NS record configurations that had included the name server set.
 
 </div>

--- a/content/articles/understanding-name-server-propagation.md
+++ b/content/articles/understanding-name-server-propagation.md
@@ -41,11 +41,10 @@ Several factors influence how quickly name server changes propagate:
 
 TTL values determine how long DNS resolvers cache records before querying for fresh information, as defined in [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035). Lower TTL values can help changes propagate faster, but they don't eliminate propagation delays entirely. Name server delegation changes at the registry level still need time to propagate, regardless of TTL settings.
 
-<note>
-#### TTL and name server delegation
-
-While TTL affects how quickly DNS resolvers refresh cached NS records, the initial propagation of name server changes at the registry level is independent of TTL values. Even with very low TTLs, registry-level changes can take time to propagate globally.
-</note>
+> [!NOTE]
+> #### TTL and name server delegation
+>
+> While TTL affects how quickly DNS resolvers refresh cached NS records, the initial propagation of name server changes at the registry level is independent of TTL values. Even with very low TTLs, registry-level changes can take time to propagate globally.
 
 ### Regional differences
 
@@ -71,17 +70,15 @@ While propagation times can vary based on TLD registry processing, DNS resolver 
 - **4-24 hours**: Most of the internet has updated to the new name servers.
 - **Up to 48 hours**: Full global propagation is typically complete, though some isolated resolvers may take longer.
 
-<note>
-#### Propagation timeline variability
+> [!NOTE]
+> #### Propagation timeline variability
+>
+> The 48-hour maximum propagation time is a general guideline based on typical DNS resolver TTL values and caching behavior. Actual propagation times can vary significantly depending on specific TLD registry policies, DNS resolver configurations, and network conditions. Some changes may propagate faster, while others may take longer in certain regions.
 
-The 48-hour maximum propagation time is a general guideline based on typical DNS resolver TTL values and caching behavior. Actual propagation times can vary significantly depending on specific TLD registry policies, DNS resolver configurations, and network conditions. Some changes may propagate faster, while others may take longer in certain regions.
-</note>
-
-<info>
-#### WHOIS updates faster
-
-WHOIS records typically update within minutes of a name server change, making WHOIS a reliable way to verify that changes were submitted correctly, even before DNS propagation is complete.
-</info>
+> [!NOTE]
+> #### WHOIS updates faster
+>
+> WHOIS records typically update within minutes of a name server change, making WHOIS a reliable way to verify that changes were submitted correctly, even before DNS propagation is complete.
 
 ## Verifying propagation
 

--- a/content/articles/verifying-name-server-delegation.md
+++ b/content/articles/verifying-name-server-delegation.md
@@ -64,9 +64,8 @@ whois example.com
 
 Look for the "Name Server" or "Name Servers" field in the output. This shows which name servers are configured at the registry level.
 
-<note>
-WHOIS information may take some time to update after making changes, and the format varies by registrar and TLD.
-</note>
+> [!NOTE]
+> WHOIS information may take some time to update after making changes, and the format varies by registrar and TLD.
 
 ### Using online tools
 

--- a/content/articles/what-is-a-nameserver.md
+++ b/content/articles/what-is-a-nameserver.md
@@ -21,9 +21,8 @@ Name servers (also called nameservers) are specialized servers that form the bac
   <iframe loading="lazy" src="https://www.youtube.com/embed/2WdF1zT01HY" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-<info>
-"Name server", "nameserver", and other variants all refer to the same thing. For consistency, we refer to it here as a "name server".
-</info>
+> [!NOTE]
+> "Name server", "nameserver", and other variants all refer to the same thing. For consistency, we refer to it here as a "name server".
 
 ## The role of name servers in DNS
 
@@ -65,13 +64,12 @@ To change your domain's name servers (also called nameservers), you need to upda
 
 If you need to change nameservers for your domain to point to a different DNS provider, or switch back to DNSimple's name servers, see [Setting the Name Servers for a Domain](/articles/setting-name-servers/). Changing nameservers is a common task when migrating DNS hosting or switching between DNS providers.
 
-<note>
-#### Verify your name server delegation
-
-It's important to verify that your domain is properly delegated to the correct name servers. If your domain isn't delegated to DNSimple, [changes you make to DNS records](/articles/record-editor/) won't resolve.
-
-To check which name servers your domain is using, you can use tools like [zone.vision](https://zone.vision/#/) to perform a DNS lookup.
-</note>
+> [!NOTE]
+> #### Verify your name server delegation
+>
+> It's important to verify that your domain is properly delegated to the correct name servers. If your domain isn't delegated to DNSimple, [changes you make to DNS records](/articles/record-editor/) won't resolve.
+>
+> To check which name servers your domain is using, you can use tools like [zone.vision](https://zone.vision/#/) to perform a DNS lookup.
 
 ## Have more questions?
 


### PR DESCRIPTION
This PR converts old callout syntax (`<info>`, `<note>`) to GitHub Flavored Markdown callouts (`> [!NOTE]`) in reference/advanced articles:

- name-server-sets.md
- what-is-a-nameserver.md
- name-server-management-in-dnsimple.md
- verifying-name-server-delegation.md
- understanding-name-server-propagation.md

Part of splitting PR #1675 into smaller, more manageable PRs.