### PR TITLE
Update DNSSEC documentation with TTL timing information

### DIFF
--- a/content/articles/disabling-dnssec.md
+++ b/content/articles/disabling-dnssec.md
@@ -29,11 +29,15 @@ categories:
 > [!IMPORTANT]
 > **TTL and propagation delays:** When you disable DNSSEC, it can take 24 to 48 hours for the process to completely finish. This is because of TTL (Time-to-Live) values, which control how long DNS records are cached. During this time, our system ensures that all DNSSEC-related records are properly torn down so that your zone continues to resolve correctly. The complete disable process will not finish until the TTL has expired and all DNSSEC records have been fully removed from the DNS system.
 
-If your domain is not registered with DNSimple, you must also remove the DS records at your domain registrar. The DS record removal at the registrar level is also subject to TTL propagation delays.
+If your domain is not registered with DNSimple, you must also remove the DS records at your domain registrar. The DS record removal at the registrar level is also subject to TTL propagation delays. For step-by-step instructions on removing DS records, see [Adding and Removing DS Records](/articles/manage-ds-record/).
 
 ## Troubleshooting
 
 If you encounter issues after disabling DNSSEC, see [Troubleshooting DNSSEC Configurations](/articles/troubleshooting-dnssec-configurations/) for comprehensive guidance. For information about managing DS records when changing DNS providers, see [Managing DS Records When Changing DNS](/articles/ds-records-changing-dns/).
+
+## Learn more
+
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For information about enabling DNSSEC, see [Enabling DNSSEC](/articles/enabling-dnssec/). For information about DS records and how they work, see [What Are DS Records?](/articles/what-are-ds-records/). To understand TTL and how it affects DNS record propagation, see [What Is Time-to-Live?](/articles/what-is-ttl/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 If you have any questions or need assistance disabling your DNSSEC, [contact support](https://dnsimple.com/contact), and we'll be happy to help.

--- a/content/articles/rotate-dnssec-key.md
+++ b/content/articles/rotate-dnssec-key.md
@@ -41,6 +41,10 @@ To do this, use the `dnssec.rotation_start` and `dnssec.rotation_complete` webho
 
 For details, refer to our [webhooks API documentation](https://developer.dnsimple.com/v2/webhooks/webhooks/).
 
+## Learn more
+
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For information about DS records and how they work, see [What Are DS Records?](/articles/what-are-ds-records/). For step-by-step instructions on managing DS records, see [Adding and Removing DS Records](/articles/manage-ds-record/). To understand TTL and how it affects DNS record propagation, see [What Is Time-to-Live?](/articles/what-is-ttl/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+
 ## Have more questions?
 If you have any questions or need assistance rotating DNSSEC keys, [contact support](https://dnsimple.com/contact), and we'll be happy to help.
 


### PR DESCRIPTION
This PR updates the DNSSEC documentation to inform customers about TTL-related timing considerations:

## Changes

### Rotate DNSSEC Keys ()
- Added IMPORTANT callout explaining that after adding DS records at the registrar, it can take up to 24 hours for the key rotation process to complete due to the 24-hour TTL for DS records

### Disabling DNSSEC ()
- Added "Important timing considerations" section explaining:
  - The disable process can take 24-48 hours to completely finish due to TTL values
  - The system ensures all DNSSEC-related records are properly torn down so that the zone continues to resolve correctly
  - For domains not registered with DNSimple, DS records must also be removed at the registrar, which is also subject to TTL propagation delays

## Purpose
These updates ensure customers understand the timing expectations during DNSSEC key rotation and disabling processes, helping them plan accordingly and avoid confusion about why these processes take time to complete.