### PR TITLE
Add support for nested category structures

### DIFF
--- a/layouts/category_index.html
+++ b/layouts/category_index.html
@@ -1,14 +1,32 @@
 <h1><%= @item[:h1] %></h1>
 
-<% sub_categories(@category, @item[:items]).each do |section, articles| %>
-  <h2><%= section %></h2>
-  <ul>
-    <% articles.each do |article| %>
-      <% if article.instance_of?(String) %>
-        <!-- Article with title "<%= article %>" was not found when building the category page-->
-      <% else %>
-        <li><a href="<%= relative_path_to(@items[article.identifier]) %>"><%= article.attributes[:title] %></a></li>
-      <% end %>
+<% sub_categories(@category, @item[:items]).each do |section, content| %>
+  <% if content.is_a?(Hash) %>
+    <!-- Nested structure (e.g., "How-to" => { "Section" => [...] }) -->
+    <h2><%= section %></h2>
+    <% content.each do |subsection, articles| %>
+      <h3><%= subsection %></h3>
+      <ul>
+        <% articles.each do |article| %>
+          <% if article.instance_of?(String) %>
+            <!-- Article with title "<%= article %>" was not found when building the category page-->
+          <% else %>
+            <li><a href="<%= relative_path_to(@items[article.identifier]) %>"><%= article.attributes[:title] %></a></li>
+          <% end %>
+        <% end %>
+      </ul>
     <% end %>
-  </ul>
+  <% else %>
+    <!-- Flat structure (e.g., "Section" => [...]) -->
+    <h2><%= section %></h2>
+    <ul>
+      <% content.each do |article| %>
+        <% if article.instance_of?(String) %>
+          <!-- Article with title "<%= article %>" was not found when building the category page-->
+        <% else %>
+          <li><a href="<%= relative_path_to(@items[article.identifier]) %>"><%= article.attributes[:title] %></a></li>
+        <% end %>
+      <% end %>
+    </ul>
+  <% end %>
 <% end %>

--- a/lib/sub_categories.rb
+++ b/lib/sub_categories.rb
@@ -16,12 +16,27 @@ class SubCategories
         item_found = false
         title = item.attributes[:title]
 
-        yaml.each do |key, array|
-          index = array.find_index(title)
-          if !index.nil?
-            @content[key][index] = item
-            item_found = true
-            break
+        yaml.each do |key, value|
+          if value.is_a?(Hash)
+            # Handle nested structure (e.g., "How-to" => { "Section" => [...] })
+            value.each do |nested_key, nested_array|
+              if nested_array.is_a?(Array)
+                index = nested_array.find_index(title)
+                if !index.nil?
+                  @content[key][nested_key][index] = item
+                  item_found = true
+                  break
+                end
+              end
+            end
+          elsif value.is_a?(Array)
+            # Handle flat structure (e.g., "Section" => [...])
+            index = value.find_index(title)
+            if !index.nil?
+              @content[key][index] = item
+              item_found = true
+              break
+            end
           end
         end
 


### PR DESCRIPTION
## Summary

This PR adds support for nested category structures in the nanoc site, allowing category YAML files to use nested Hash structures in addition to the existing flat Array structures.

## Changes

### lib/sub_categories.rb
- Updated `show` method to detect and handle nested Hash structures
- When a category value is a Hash, recursively processes nested sections
- Maintains backward compatibility with existing flat Array structures

### layouts/category_index.html
- Updated template to render nested structures
- Checks if content is a Hash (nested) or Array (flat) and renders accordingly
- Nested structures render with h2 for parent section and h3 for subsections

## Example Structure

This enables category YAML files to use nested structures like:

```yaml
How-to:
  "Domain Registration & Setup":
    - "Adding a Domain"
    - "Registering a Domain"
  "Domain Renewal & Expiration":
    - "Renewing a Domain"
```

While still supporting the existing flat structure:

```yaml
Registering, renewing:
  - "Registering a Domain"
  - "Renewing a Domain"
```

## Testing

- YAML parsing tested with nested structures
- Backward compatibility verified with existing flat structures
- Article matching works correctly in both nested and flat structures