### PR TITLE
Ban em dashes and en dashes in content rule

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -105,7 +105,7 @@ A PR should contain **only** the changes described by its purpose:
 
 ## Characters in content
 
-macOS text substitution can silently insert smart/curly quotes (`"` `"` `'` `'`) and ellipsis (`…`) that cause rendering issues on GitHub. Use straight quotes (`"` `'`) and three periods (`...`) instead. Em dashes (`—`) and en dashes (`–`) are fine in body text, but use hyphens (`-`) in filenames, frontmatter values, and anchor names.
+macOS text substitution can silently insert smart/curly quotes (`"` `"` `'` `'`) and ellipsis (`…`) that cause rendering issues on GitHub. Use straight quotes (`"` `'`) and three periods (`...`) instead. Do not use em dashes (`—`) or en dashes (`–`) anywhere. Use hyphens (`-`) instead.
 
 ## Branch naming
 


### PR DESCRIPTION
## Summary

- Updates the Characters in content rule in `.cursor/rules/git-workflow.mdc` to prohibit em dashes and en dashes everywhere, not just in filenames and frontmatter
- Previously the rule allowed em/en dashes in body text; now hyphens are required instead

## Test plan

- [x] Verify the rule file renders correctly
- [x] Confirm AI agents respect the updated rule in future content work