### PR TITLE
Add Emails category to service articles and clean up emails.yaml

### DIFF
--- a/categories/emails.yaml
+++ b/categories/emails.yaml
@@ -1,11 +1,10 @@
 Getting started:
-  - "Email Services at DNSimple"
+- "Email Forwarding"
+- "Email Hosting Support"
 
 Explanation:
   Email Forwarding:
-    - "Email Forwarding"
     - "What Is Email Forwarding?"
-    - "Email Hosting Support"
   Email Authentication:
     - "What Is an SPF Record?"
     - "What Is a DKIM Record?"
@@ -13,11 +12,7 @@ Explanation:
     - "Understanding SPF, DKIM, and DMARC Alignment"
     - "Email Authentication Best Practices"
   Email Deliverability:
-    - "Understanding Email Deliverability"
     - "Understanding Email Bounces"
-    - "Impact of Name Server Changes on Email Delivery"
-  Email Security:
-    - "Email Security Best Practices"
   MX Records:
     - "What Is an MX Record?"
     - "What Are Null MX Records?"
@@ -58,10 +53,6 @@ How to:
     - "Postmark Service"
     - "Atmail Service"
     - "DMARC Reports by Postmark Service"
-  Email Deliverability:
-    - "Improving Email Deliverability"
-    - "Monitoring Email Deliverability"
-    - "Protecting Your Domain from Email Spoofing"
   MX Records:
     - "Querying MX Records"
   Verification:
@@ -72,8 +63,6 @@ How to:
     - "Troubleshooting Email Forwarding with Gmail"
     - "Troubleshooting Email Forwarding Delivery Issues"
     - "Troubleshooting Email Forwarding with Other Providers"
-    - "Troubleshooting Email Authentication"
-    - "Troubleshooting Email Issues Related to Name Servers"
 Reference:
   Email Forwarding:
     - "Email Forwarding Management in DNSimple"

--- a/content/articles/atmail-service.md
+++ b/content/articles/atmail-service.md
@@ -4,6 +4,7 @@ excerpt: How to set up Atmail DNS using DNSimple's One-click Service.
 meta: Learn how to effortlessly set up Atmail DNS with DNSimple's One-click Service. Streamline your email management and enhance your online communication today!
 categories:
 - Services
+- Emails
 ---
 
 # Atmail One-click Service

--- a/content/articles/fastmail-service.md
+++ b/content/articles/fastmail-service.md
@@ -4,6 +4,7 @@ excerpt: How to set up Fastmail DNS using DNSimple's One-click Service.
 meta: Easily set up Fastmail DNS with DNSimple's One-click Service. Follow our step-by-step guide to streamline your email hosting and enhance your communication.
 categories:
 - Services
+- Emails
 ---
 
 # Fastmail One-click Service

--- a/content/articles/mailgun-service.md
+++ b/content/articles/mailgun-service.md
@@ -4,6 +4,7 @@ excerpt: How to set up Mailgun DNS using DNSimple's One-click Service.
 meta: Easily set up Mailgun DNS with DNSimple's One-Click Service. Follow our step-by-step guide to streamline your email delivery and improve performance.
 categories:
 - Services
+- Emails
 ---
 
 # Mailgun One-click Service

--- a/content/articles/pobox-service.md
+++ b/content/articles/pobox-service.md
@@ -4,6 +4,7 @@ excerpt: How to set up Pobox DNS using DNSimple's one-click service.
 meta: Easily point your domain to Pobox using DNSimple's one-click service. Follow our step-by-step guide to streamline your email and domain management effortlessly.
 categories:
 - Services
+- Emails
 ---
 
 # Pobox One-click Service

--- a/content/articles/postmark-dmarc-service.md
+++ b/content/articles/postmark-dmarc-service.md
@@ -4,6 +4,7 @@ excerpt: How to set up DMARC Reports by Postmark DNS using DNSimple's one-click 
 meta: Easily set up Postmark DNS with DNSimple's One-click Service. Follow our step-by-step guide to ensure seamless email delivery and reliable performance.
 categories:
 - Services
+- Emails
 ---
 
 # DMARC Reports by Postmark One-click Service

--- a/content/articles/postmark-service.md
+++ b/content/articles/postmark-service.md
@@ -4,6 +4,7 @@ excerpt: How to set up Postmark DNS using DNSimple's One-click Service.
 meta: Easily set up Postmark DNS with DNSimple's One-click Service. Follow our step-by-step guide to streamline your email delivery and enhance your communication.
 categories:
 - Services
+- Emails
 ---
 
 # Postmark One-click Service

--- a/content/articles/rackspace-email-service.md
+++ b/content/articles/rackspace-email-service.md
@@ -4,6 +4,7 @@ excerpt: How to set up Rackspace Email DNS using DNSimple's One-click Service.
 meta: Easily set up Rackspace Email with DNSimple's One-click Service. Follow our comprehensive guide to configure your DNS settings and ensure seamless email functionality.
 categories:
 - Services
+- Emails
 ---
 
 # Rackspace Email One-click Service

--- a/content/articles/set-up-dkim.md
+++ b/content/articles/set-up-dkim.md
@@ -1,5 +1,5 @@
 ---
-title: Setting up DKIM
+title: Setting Up DKIM
 excerpt: How to set up DKIM on your domains.
 meta: Learn how to set up DKIM by using a specially formatted DNS text record storing a public key.
 categories:

--- a/content/articles/set-up-dmarc.md
+++ b/content/articles/set-up-dmarc.md
@@ -1,5 +1,5 @@
 ---
-title: Setting up DMARC
+title: Setting Up DMARC
 excerpt: How to set up DMARC in your DNSimple account.
 meta: Learn how to set up DMARC and what to expect from your email provider.
 categories:


### PR DESCRIPTION
## Summary

- Added `- Emails` category to 7 email service articles (Fastmail, Pobox, Rackspace Email, Mailgun, Postmark, Postmark DMARC, Atmail) so they appear in the Emails category alongside Google Workspace and Microsoft 365
- Fixed APA style title casing: "Setting up DKIM" -> "Setting Up DKIM", "Setting up DMARC" -> "Setting Up DMARC"
- Cleaned up emails.yaml: removed 9 phantom entries for nonexistent articles, reorganized Getting started section

## Test plan

- [x] Verify all 7 service articles now appear under the Emails category page
- [x] Verify "Setting Up DKIM" and "Setting Up DMARC" display correctly and are no longer in the "Other" section
- [x] Confirm no articles with the Emails category are missing from emails.yaml