### PR TITLE
Optimize email forwarding article titles and URLs for search intent

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -139,3 +139,11 @@
 /articles/sharing-domain/                                                 /articles/domain-access-control/
 /articles/sharing-domain/index.html                                       /articles/domain-access-control/
 /articles/superlock/                                                     /articles/what-is-domain-lock/
+/articles/enabling-email-forwarding/                                     /articles/set-up-email-forwarding/
+/articles/managing-email-forwards/                                       /articles/add-and-remove-email-forwards/
+/articles/troubleshooting-email-forwarding-delivery-issues/              /articles/email-forwarding-not-working/
+/articles/troubleshooting-email-forwarding-gmail/                        /articles/email-forwarding-not-working-gmail/
+/articles/troubleshooting-email-forwarding-with-other-providers/         /articles/email-forwarding-not-working-outlook-yahoo/
+/articles/handling-email-bounces-with-email-forwarding/                  /articles/email-forwarding-bounces/
+/articles/migrating-email-forwarding-from-another-provider/              /articles/migrate-email-forwarding/
+/articles/managing-email-forwarding-for-multiple-domains/                /articles/email-forwarding-multiple-domains/

--- a/categories/emails.yaml
+++ b/categories/emails.yaml
@@ -28,11 +28,11 @@ Email authentication:
 
 How to:
   Email Forwarding:
-    - "Enabling Email Forwarding"
-    - "Creating and Deleting Email Forwards"
-    - "Managing Email Forwarding for Multiple Domains"
-    - "Migrating Email Forwarding from Another Provider"
-    - "Handling Email Bounces with Email Forwarding"
+    - "How to Set Up Email Forwarding"
+    - "How to Add and Remove Email Forwards"
+    - "Email Forwarding for Multiple Domains"
+    - "How to Migrate Email Forwarding to DNSimple"
+    - "Email Forwarding and Bounced Emails"
   Email Authentication:
     - "Setting Up SPF Records"
     - "Setting Up DKIM"
@@ -60,9 +60,9 @@ How to:
     - "Verifying DKIM with dig and Online Tools"
     - "Verifying DMARC with dig and Online Tools"
   Troubleshooting:
-    - "Troubleshooting Email Forwarding with Gmail"
-    - "Troubleshooting Email Forwarding Delivery Issues"
-    - "Troubleshooting Email Forwarding with Other Providers"
+    - "Email Forwarding Not Working with Gmail"
+    - "Email Forwarding Not Working"
+    - "Email Forwarding Not Working with Outlook, Yahoo, and Other Providers"
 Reference:
   Email Forwarding:
     - "Email Forwarding Management in DNSimple"

--- a/content/articles/add-and-remove-email-forwards.md
+++ b/content/articles/add-and-remove-email-forwards.md
@@ -1,12 +1,12 @@
 ---
-title: Creating and Deleting Email Forwards
-excerpt: Step-by-step instructions for creating, editing, and deleting email forwarding rules in DNSimple.
-meta: Complete how-to guide with step-by-step instructions for managing email forwards in DNSimple, including catch-all forwarding and best practices.
+title: How to Add and Remove Email Forwards
+excerpt: Step-by-step instructions for adding, editing, and removing email forwarding rules in DNSimple.
+meta: How to add, edit, and remove email forwarding rules in DNSimple, including catch-all email forwarding setup.
 categories:
 - Emails
 ---
 
-# Creating and Deleting Email Forwards
+# How to Add and Remove Email Forwards
 
 ### Table of Contents {#toc}
 
@@ -17,7 +17,7 @@ categories:
 
 Email forwards let you redirect emails sent to addresses at your domain to other email addresses. You can create, edit, and delete individual forwards from the domain page or the dashboard. For a visual guide to the interface, see [Email Forwarding Management in DNSimple](/articles/email-forwarding/).
 
-## Creating an email forward {#creating}
+## Add an email forward {#creating}
 
 You can create email forwards from either the domain's Email Forwarding page or directly from the Dashboard.
 
@@ -56,7 +56,7 @@ You can create email forwards from either the domain's Email Forwarding page or 
 1. Click <label>Create forward</label>.
 </div>
 
-## Creating a catch-all email forward {#catch-all}
+## Set up catch-all email forwarding {#catch-all}
 
 A catch-all email forward forwards emails sent to any address at your domain that does not have a specific forwarding rule.
 
@@ -84,7 +84,7 @@ To view all email forwards for a domain:
 
 For a visual guide to the email forwarding interface, see [Email Forwarding Management in DNSimple](/articles/email-forwarding-management/).
 
-## Editing an email forward {#editing}
+## Edit an email forward {#editing}
 
 <div class="section-steps" markdown="1">
 ##### Edit an existing email forward
@@ -96,7 +96,7 @@ For a visual guide to the email forwarding interface, see [Email Forwarding Mana
 1. Click <label>Update forward</label> to apply the changes.
 </div>
 
-## Deleting an email forward {#deleting}
+## Remove an email forward {#deleting}
 
 <div class="section-steps" markdown="1">
 ##### Delete an email forward

--- a/content/articles/email-forwarding-bounces.md
+++ b/content/articles/email-forwarding-bounces.md
@@ -1,12 +1,12 @@
 ---
-title: Handling Email Bounces with Email Forwarding
-excerpt: How email bounces work with email forwarding and how to handle them.
-meta: Guide to understanding and handling email bounces when using email forwarding services.
+title: Email Forwarding and Bounced Emails
+excerpt: How email bounces work with email forwarding and what to do when forwarded emails bounce at the destination.
+meta: Understand how email bounces work with email forwarding and what to do when forwarded emails bounce at the destination.
 categories:
 - Emails
 ---
 
-# Handling Email Bounces with Email Forwarding
+# Email Forwarding and Bounced Emails
 
 ### Table of Contents {#toc}
 

--- a/content/articles/email-forwarding-limits-and-quotas.md
+++ b/content/articles/email-forwarding-limits-and-quotas.md
@@ -1,7 +1,7 @@
 ---
 title: Email Forwarding Limits and Quotas
 excerpt: Detailed explanation of email forwarding limits, quotas, and billing at DNSimple.
-meta: Understand email forwarding limits, quotas, and billing to manage your email forwarding service at DNSimple.
+meta: Email forwarding limits, message quotas, and billing details for each DNSimple plan. Understand what happens when you reach your forwarding limit.
 categories:
 - Emails
 ---

--- a/content/articles/email-forwarding-management.md
+++ b/content/articles/email-forwarding-management.md
@@ -1,7 +1,7 @@
 ---
 title: Email Forwarding Management in DNSimple
 excerpt: Visual reference guide to the email forwarding interface in DNSimple with annotated screenshots.
-meta: Illustrated guide to understanding the email forwarding management interface in DNSimple, including UI elements and their functions.
+meta: Visual reference guide to the email forwarding interface in DNSimple, with annotated screenshots of the forwarding dashboard, creation form, and forwards list.
 categories:
 - Emails
 ---
@@ -39,7 +39,7 @@ When creating a new email forward, you will see the following fields and options
 4. <label>To</label> field - Enter the full email address where emails should be forwarded (e.g., `yourname@gmail.com`).
 5. <label>Create forward</label> button - Click to create the email forward.
 
-For step-by-step instructions on enabling email forwarding, see [Enabling Email Forwarding](/articles/enabling-email-forwarding/).
+For step-by-step instructions on setting up email forwarding, see [How to Set Up Email Forwarding](/articles/set-up-email-forwarding/).
 
 ## Email forwards list {#forwards-list}
 

--- a/content/articles/email-forwarding-multiple-domains.md
+++ b/content/articles/email-forwarding-multiple-domains.md
@@ -1,12 +1,12 @@
 ---
-title: Managing Email Forwarding for Multiple Domains
-excerpt: How to efficiently manage email forwarding across multiple domains in DNSimple.
-meta: Guide to managing email forwarding for multiple domains, including best practices and tips for efficient administration.
+title: Email Forwarding for Multiple Domains
+excerpt: How to set up and manage email forwarding across multiple domains in DNSimple.
+meta: How to set up and manage email forwarding across multiple domains in DNSimple, with configuration strategies and best practices.
 categories:
 - Emails
 ---
 
-# Managing Email Forwarding for Multiple Domains
+# Email Forwarding for Multiple Domains
 
 ### Table of Contents {#toc}
 

--- a/content/articles/email-forwarding-not-working-gmail.md
+++ b/content/articles/email-forwarding-not-working-gmail.md
@@ -1,12 +1,12 @@
 ---
-title: Troubleshooting Email Forwarding with Gmail
-excerpt: How to check and debug email forwarding issues.
-meta: Learn how to troubleshoot and resolve email forwarding issues with Gmail effectively. Follow our step-by-step guide for a seamless email experience.
+title: Email Forwarding Not Working with Gmail
+excerpt: Diagnose and fix email forwarding problems with Gmail, including spam filtering, missing test emails, and delayed delivery.
+meta: Fix email forwarding issues with Gmail, including forwarded emails going to spam, test emails not appearing, security warnings, and delayed delivery.
 categories:
 - Emails
 ---
 
-# Troubleshooting Email Forwarding
+# Email Forwarding Not Working with Gmail
 
 Once email forwarding is configured for your domain you may wish to confirm it is working as expected by sending a test message.
 
@@ -16,4 +16,3 @@ To properly test that email forwarding works with Gmail, please use an entirely 
 
 > [!NOTE] Test emails not appearing in Gmail
 > Google silently ignores messages it determines were sent and received from the same account. This will occur even if the message is forwarded through another address.
-

--- a/content/articles/email-forwarding-not-working-outlook-yahoo.md
+++ b/content/articles/email-forwarding-not-working-outlook-yahoo.md
@@ -1,12 +1,12 @@
 ---
-title: Troubleshooting Email Forwarding with Other Providers
-excerpt: Guide to troubleshooting email forwarding issues with email providers other than Gmail.
-meta: Step-by-step guide to diagnosing and fixing email forwarding issues with various email providers.
+title: Email Forwarding Not Working with Outlook, Yahoo, and Other Providers
+excerpt: Diagnose and fix email forwarding problems with Outlook, Yahoo Mail, Apple Mail, and other providers.
+meta: Fix email forwarding issues with Outlook, Yahoo Mail, Apple Mail, and other email providers. Troubleshoot forwarded emails going to spam or not arriving.
 categories:
 - Emails
 ---
 
-# Troubleshooting Email Forwarding with Other Providers
+# Email Forwarding Not Working with Outlook, Yahoo, and Other Providers
 
 ### Table of Contents {#toc}
 
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-If forwarded emails are not arriving or are going to spam at Outlook, Yahoo, Apple Mail, or other providers, use the steps below to diagnose and fix the issue. For Gmail-specific issues, see [Troubleshooting Email Forwarding with Gmail](/articles/troubleshooting-email-forwarding-gmail/).
+If forwarded emails are not arriving or are going to spam at Outlook, Yahoo, Apple Mail, or other providers, use the steps below to diagnose and fix the issue. For Gmail-specific issues, see [Email Forwarding Not Working with Gmail](/articles/email-forwarding-not-working-gmail/).
 
 ## Common issues by provider {#by-provider}
 

--- a/content/articles/email-forwarding-not-working.md
+++ b/content/articles/email-forwarding-not-working.md
@@ -1,12 +1,12 @@
 ---
-title: Troubleshooting Email Forwarding Delivery Issues
-excerpt: Guide to troubleshooting email delivery problems with email forwarding.
-meta: Step-by-step guide to diagnosing and fixing email forwarding delivery issues.
+title: Email Forwarding Not Working
+excerpt: Diagnose and fix email forwarding delivery problems, including emails not arriving, going to spam, or being delayed.
+meta: Fix email forwarding that is not working. Diagnose why forwarded emails are not arriving, going to spam, or being delayed.
 categories:
 - Emails
 ---
 
-# Troubleshooting Email Forwarding Delivery Issues
+# Email Forwarding Not Working
 
 ### Table of Contents {#toc}
 
@@ -17,7 +17,7 @@ categories:
 
 If emails are not being delivered through email forwarding, use this guide to diagnose and fix the issue.
 
-## Common issues {#common-issues}
+## Why email forwarding is not working {#common-issues}
 
 ### Emails not arriving at destination
 
@@ -106,7 +106,7 @@ If emails are not being delivered through email forwarding, use this guide to di
    - If issues persist, [contact DNSimple support](https://dnsimple.com/feedback)
    - Provide details about the issue
 
-## Testing email forwarding {#testing}
+## Test and verify email forwarding {#testing}
 
 ### Send test emails
 

--- a/content/articles/email-forwarding.md
+++ b/content/articles/email-forwarding.md
@@ -1,7 +1,7 @@
 ---
 title: Email Forwarding
 excerpt: Set up and manage email forwarding with DNSimple to receive emails at your domain and redirect them to another address.
-meta: Learn how to set up and manage email forwarding with DNSimple to direct emails from one address to another.
+meta: Set up, manage, and troubleshoot email forwarding with DNSimple. Forward emails from your domain to any email address.
 categories:
 - Emails
 ---
@@ -31,7 +31,7 @@ If you are new to email forwarding, start with these articles:
 
 ## Getting started {#getting-started}
 
-- [Enabling Email Forwarding](/articles/enabling-email-forwarding/): A step-by-step guide to turning email forwarding on for your domain.
+- [How to Set Up Email Forwarding](/articles/set-up-email-forwarding/): A step-by-step guide to turning email forwarding on for your domain.
 
 ## Managing email forwarding {#managing}
 
@@ -39,7 +39,7 @@ If you are new to email forwarding, start with these articles:
 
 ## Troubleshooting {#troubleshooting}
 
-- [Troubleshooting Email Forwarding with Gmail](/articles/troubleshooting-email-forwarding-gmail/): Diagnose and resolve common email forwarding problems with Gmail.
+- [Email Forwarding Not Working with Gmail](/articles/email-forwarding-not-working-gmail/): Diagnose and resolve common email forwarding problems with Gmail.
 
 ## Have more questions?
 

--- a/content/articles/migrate-email-forwarding.md
+++ b/content/articles/migrate-email-forwarding.md
@@ -1,12 +1,12 @@
 ---
-title: Migrating Email Forwarding from Another Provider
-excerpt: How to migrate email forwarding from another provider to DNSimple.
-meta: Step-by-step guide to migrating email forwarding configuration from another provider to DNSimple, ensuring a smooth transition.
+title: How to Migrate Email Forwarding to DNSimple
+excerpt: How to migrate your email forwarding configuration from another provider to DNSimple.
+meta: Step-by-step guide to migrating your email forwarding configuration from another provider to DNSimple.
 categories:
 - Emails
 ---
 
-# Migrating Email Forwarding from Another Provider
+# How to Migrate Email Forwarding to DNSimple
 
 ### Table of Contents {#toc}
 

--- a/content/articles/set-up-email-forwarding.md
+++ b/content/articles/set-up-email-forwarding.md
@@ -1,12 +1,12 @@
 ---
-title: Enabling Email Forwarding
-excerpt: Enable email forwarding for your domain. Understand the prerequisites, follow the configuration steps, and know what to expect after activation.
-meta: Step-by-step guide to enabling email forwarding for your domain in DNSimple, including prerequisites, configuration steps, and what to expect after activation.
+title: How to Set Up Email Forwarding
+excerpt: Set up email forwarding for your domain with this step-by-step guide covering prerequisites, configuration, and what to expect.
+meta: Step-by-step guide to setting up email forwarding for your domain in DNSimple. Learn how to configure email forwarding, what prerequisites you need, and what to expect after activation.
 categories:
 - Emails
 ---
 
-# Enabling Email Forwarding
+# How to Set Up Email Forwarding
 
 ### Table of Contents {#toc}
 
@@ -28,10 +28,10 @@ The domain must be delegated to DNSimple's name servers, and DNS hosting must be
 > [!WARNING]
 > Email forwarding is not supported for domains with a secondary zone. To configure email forwards, you must first convert the zone to a forward zone (primary zone).
 
-## Enable email forwarding {#enable}
+## Set up email forwarding for your domain {#enable}
 
 <div class="section-steps" markdown="1">
-##### Enable email forwarding for a domain
+##### Set up email forwarding for a domain
 
 1. Use the **account switcher** at the top of the page to select the appropriate account.
   ![screenshot of switching accounts](/files/switch-account.png)

--- a/content/articles/understanding-email-bounces.md
+++ b/content/articles/understanding-email-bounces.md
@@ -231,7 +231,7 @@ When using email forwarding:
 - Check your email forwarding service's bounce handling
 
 > [!NOTE]
-> For more information about handling bounces with email forwarding, see [Handling Email Bounces with Email Forwarding](/articles/handling-email-bounces-with-email-forwarding/).
+> For more information about handling bounces with email forwarding, see [Email Forwarding and Bounced Emails](/articles/email-forwarding-bounces/).
 
 ## Reducing bounces {#reducing}
 

--- a/content/articles/what-is-email-forwarding.md
+++ b/content/articles/what-is-email-forwarding.md
@@ -1,7 +1,7 @@
 ---
 title: What Is Email Forwarding?
 excerpt: Explains what email forwarding is and how it works at DNSimple.
-meta: Learn what email forwarding is, how it works, and how DNSimple email forwarding helps you manage email for your domains.
+meta: Learn what email forwarding is, how it works, and how it compares to email hosting. Covers email redirect, catch-all forwarding, and email alias use cases.
 categories:
 - Emails
 ---
@@ -29,7 +29,7 @@ When you set up email forwarding at DNSimple:
 
 4. **Delivery:** The forwarded email arrives in the inbox of your destination email address.
 
-## Key benefits {#benefits}
+## Why use email forwarding {#benefits}
 
 **Professional email addresses:** Use custom email addresses at your domain (like `info@yourdomain.com` or `support@yourdomain.com`) without the complexity of managing a full email server.
 
@@ -41,7 +41,7 @@ When you set up email forwarding at DNSimple:
 
 **No email client setup required:** Emails are forwarded to an existing email account, so you do not need to configure email clients or manage email servers.
 
-## Email forwarding vs. email hosting {#forwarding-vs-hosting}
+## Email forwarding vs. email hosting: which do you need {#forwarding-vs-hosting}
 
 Email forwarding and email hosting serve different purposes:
 
@@ -73,7 +73,7 @@ To start using email forwarding, you will need:
 > [!WARNING]
 > When you enable email forwarding, any existing MX records for your domain will be automatically removed. If you are currently using another email service provider, that service will stop working.
 
-For step-by-step instructions, see [Enabling Email Forwarding](/articles/enabling-email-forwarding/).
+For step-by-step instructions, see [How to Set Up Email Forwarding](/articles/set-up-email-forwarding/).
 
 ## Have more questions?
 


### PR DESCRIPTION
## Summary

- Rename 8 email forwarding articles to match actual search intent (e.g., "Enabling Email Forwarding" becomes "How to Set Up Email Forwarding", troubleshooting articles use "Email Forwarding Not Working" phrasing)
- Update titles, meta descriptions, excerpts, and H2 headings across all 12 email forwarding articles for better keyword coverage
- Add redirects for all renamed URLs and update all internal cross-links and category YAML references

## Context

The existing email forwarding article titles use product-centric language ("Enabling," "Creating and Deleting," "Troubleshooting") that has zero search volume. People search for natural terms like "how to set up email forwarding," "email forwarding not working," or just "email forwarding." This is a focused metadata pass -- body content is unchanged.

## Changes

### Renamed files (8)

| Old slug | New slug | New title |
|---|---|---|
| `enabling-email-forwarding` | `set-up-email-forwarding` | How to Set Up Email Forwarding |
| `managing-email-forwards` | `add-and-remove-email-forwards` | How to Add and Remove Email Forwards |
| `troubleshooting-email-forwarding-delivery-issues` | `email-forwarding-not-working` | Email Forwarding Not Working |
| `troubleshooting-email-forwarding-gmail` | `email-forwarding-not-working-gmail` | Email Forwarding Not Working with Gmail |
| `troubleshooting-email-forwarding-with-other-providers` | `email-forwarding-not-working-outlook-yahoo` | Email Forwarding Not Working with Outlook, Yahoo, and Other Providers |
| `handling-email-bounces-with-email-forwarding` | `email-forwarding-bounces` | Email Forwarding and Bounced Emails |
| `migrating-email-forwarding-from-another-provider` | `migrate-email-forwarding` | How to Migrate Email Forwarding to DNSimple |
| `managing-email-forwarding-for-multiple-domains` | `email-forwarding-multiple-domains` | Email Forwarding for Multiple Domains |

### Meta/heading updates only (4)

`what-is-email-forwarding.md`, `email-forwarding.md`, `email-forwarding-management.md`, `email-forwarding-limits-and-quotas.md`

### Supporting changes

- `_redirects` -- 8 new redirect entries for old URLs
- `categories/emails.yaml` -- updated all 8 title references
- `understanding-email-bounces.md` -- updated cross-link to bounces article

## Test plan

- [ ] Verify all 8 old URLs redirect correctly to their new slugs
- [ ] Confirm category page displays articles with updated titles
- [ ] Spot-check internal cross-links from hub pages (`email-forwarding.md`) resolve correctly