### PR TITLE
Remove duplicate sections from emails category YAML

### DIFF
--- a/categories/emails.yaml
+++ b/categories/emails.yaml
@@ -17,15 +17,6 @@ Explanation:
     - "What Is an MX Record?"
     - "What Are Null MX Records?"
 
-How-to:
-- "Managing MX Records When Changing Email Providers"
-
-Email authentication:
-- "Email Authentication Best Practices"
-- "Understanding SPF, DKIM, and DMARC Alignment"
-- "Implementing a Gradual DMARC Policy"
-- "Managing Multiple DKIM Selectors"
-
 How to:
   Email Forwarding:
     - "How to Set Up Email Forwarding"


### PR DESCRIPTION
## Summary

- Remove orphaned `How-to:` and `Email authentication:` top-level sections from `categories/emails.yaml`
- All articles in the removed sections were already listed under the main `How to:` and `Explanation:` sections

The duplicates were introduced by a previous merge and caused multiple "How to" sections to render on the Emails category page.