### PR TITLE
Add incident communications and DNS redundancy articles

### DIFF
--- a/categories/dnsimple.yaml
+++ b/categories/dnsimple.yaml
@@ -30,6 +30,7 @@ DNSimple Products:
 
 About DNSimple:
 - "DNSimple Status Page"
+- "How DNSimple Handles Incidents"
 - "How to pronounce DNSimple"
 
 Contact Support:

--- a/categories/secondary_dns.yaml
+++ b/categories/secondary_dns.yaml
@@ -1,4 +1,5 @@
 Configurations:
+- "DNS Redundancy Options at DNSimple"
 - "Add a secondary DNS server to DNSimple"
 - "Add DNSimple as a secondary DNS server"
 - "Add DNSimple as Secondary DNS with a Hidden Primary"

--- a/content/articles/dns-redundancy.md
+++ b/content/articles/dns-redundancy.md
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-DNS redundancy means having more than one DNS provider answering queries for your domains. If one provider experiences an outage, the other continues serving DNS responses, keeping your domains online.
+DNS redundancy means having more than one DNS provider answering queries for your domains. If one provider experiences an outage, the other continues serving DNS responses, helping keep DNS resolution available.
 
 ## How DNSimple provides resilience by default {#default-resilience}
 

--- a/content/articles/dns-redundancy.md
+++ b/content/articles/dns-redundancy.md
@@ -1,0 +1,76 @@
+---
+title: DNS Redundancy Options at DNSimple
+excerpt: How to add DNS redundancy to your domains using secondary DNS or multi-provider setups.
+meta: Learn when and how to add DNS redundancy at DNSimple. Compare secondary DNS via zone transfer (AXFR) with multi-provider DNS sync to protect your domains from outages.
+categories:
+- Secondary DNS
+---
+
+# DNS Redundancy Options at DNSimple
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+DNS redundancy means having more than one DNS provider answering queries for your domains. If one provider experiences an outage, the other continues serving DNS responses, keeping your domains online.
+
+## How DNSimple provides resilience by default {#default-resilience}
+
+Every zone hosted on DNSimple is served by multiple name servers distributed across independent networks using [Anycast DNS](/articles/why-anycast-dns/). This means queries are automatically routed to the nearest healthy server, and single-server failures do not cause resolution failures.
+
+For many domains, this built-in redundancy is sufficient. Adding a secondary DNS provider is an additional layer of protection for domains where any downtime is unacceptable.
+
+## When to add a secondary DNS provider {#when}
+
+Consider adding a secondary DNS provider if:
+
+- Your domain serves production traffic that cannot tolerate any DNS downtime.
+- You have contractual or compliance requirements for multi-provider DNS.
+- You want resilience against a complete provider-level outage, not just individual server failures.
+
+## Option 1: Secondary DNS with zone transfers (AXFR) {#axfr}
+
+This is the standard approach. DNSimple acts as the primary DNS server and automatically transfers zone data to a secondary provider via [AXFR](https://en.wikipedia.org/wiki/DNS_zone_transfer). The secondary provider answers queries using its own name servers.
+
+**How it works:**
+
+1. You configure a secondary DNS provider (such as Dyn, DNSMadeEasy, or EasyDNS) or any provider that supports AXFR.
+2. You [enable secondary DNS](/articles/secondary-dns/) in your DNSimple account for the domain.
+3. DNSimple sends zone transfers to the secondary provider whenever records change.
+4. You update your domain's delegation at the registrar to include the secondary provider's name servers alongside DNSimple's.
+
+**Considerations:**
+
+- [ALIAS records](/articles/alias-and-secondary-dns/) are resolved into A/AAAA records before being transferred, since ALIAS is not a standard record type.
+- [DNSSEC and secondary DNS](/articles/dnssec-and-secondary-dns/) require careful coordination. Read the compatibility article before enabling both.
+
+For setup instructions, see [Add a secondary DNS server to DNSimple](/articles/secondary-dns/).
+
+## Option 2: Multi-provider DNS without zone transfers {#multi-provider}
+
+If your secondary provider does not support AXFR, or you prefer manual control, you can keep zones in sync across providers using the DNSimple API, zone imports, or infrastructure-as-code tools.
+
+This approach requires more operational overhead since records must be updated in both providers when changes are made.
+
+For details, see [Using DNSimple alongside other DNS providers](/articles/secondary-dnsimple/).
+
+## Provider-specific guides {#provider-guides}
+
+DNSimple provides pre-configured setup guides for these secondary DNS providers:
+
+- [Dyn](/articles/secondary-dns-provider-dyn/)
+- [DNSMadeEasy](/articles/secondary-dns-provider-dns-made-easy/)
+- [EasyDNS](/articles/secondary-dns-provider-easy-dns/)
+
+You can also use any provider that supports AXFR by choosing the custom option in the [secondary DNS setup](/articles/secondary-dns/).
+
+## DNSimple as the secondary provider {#dnsimple-as-secondary}
+
+If you use another DNS provider as your primary, you can [configure DNSimple as a secondary DNS server](/articles/secondary-dns-dnsimple-as-secondary/) or set up a [hidden primary with DNSimple as secondary](/articles/secondary-dns-dnsimple-with-hidden-primary/).
+
+## Have more questions?
+
+If you have any questions about setting up DNS redundancy for your domains, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/dnsimple-status.md
+++ b/content/articles/dnsimple-status.md
@@ -1,16 +1,46 @@
 ---
 title: DNSimple Status Page
 excerpt: We make our current system status, as well as our uptime history, available at dnsimplestatus.com.
-meta: Check DNSimple's system status and uptime history. Monitor our name server availability and service status in real-time.
+meta: Check DNSimple's system status and uptime history. Monitor our name server availability and service status in real-time. Subscribe to incident notifications via email, SMS, or webhook.
 categories:
 - DNSimple
 ---
 
 # DNSimple Status Page
 
-View our current system status and uptime history at [dnsimplestatus.com](http://dnsimplestatus.com).
+View our current system status and uptime history at [dnsimplestatus.com](https://dnsimplestatus.com).
 
-We strive to always have at least one name server responding to queries at all times.
+The status page shows the health of all DNSimple services, including DNS resolution, the web application, API, and certificate provisioning.
+
+## Subscribing to notifications {#subscribe}
+
+Visit [dnsimplestatus.com](https://dnsimplestatus.com) and click **Subscribe to Updates** to receive automatic notifications when an incident is created, updated, or resolved. Available notification channels:
+
+- **Email** -- Incident updates delivered to your inbox.
+- **SMS** -- Text message alerts.
+- **RSS/Atom** -- Add the feed to your reader.
+- **Webhook** -- HTTP POST requests for integration with monitoring tools.
+
+## Understanding service status {#status-levels}
+
+The status page displays the current state of each service component:
+
+| Status | Meaning |
+|--------|---------|
+| **Operational** | The service is functioning normally. |
+| **Degraded Performance** | The service is available but responding slower than usual. |
+| **Partial Outage** | Some users or some functionality is affected. |
+| **Major Outage** | The service is unavailable for most or all users. |
 
 > [!NOTE]
-> Downtime on a single server does not indicate downtime for the system as a whole.
+> DNSimple operates multiple name servers across independent networks. Downtime on a single server does not indicate downtime for the system as a whole. Resolvers will automatically use any available name server.
+
+## During an incident {#during-incident}
+
+The status page is hosted on separate infrastructure from the DNSimple application. If the DNSimple dashboard is unavailable during an incident, the status page will still be accessible.
+
+For details on how DNSimple communicates during incidents and what to expect from postmortems, see [How DNSimple Handles Incidents](/articles/how-dnsimple-handles-incidents/).
+
+## Have more questions?
+
+If you have any questions about DNSimple service status, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/domain-resolution-issues.md
+++ b/content/articles/domain-resolution-issues.md
@@ -134,7 +134,7 @@ When troubleshooting domain resolution, you may encounter specific error message
 - The DNS query did not receive a response in time
 - May indicate network issues or name server problems
 - Try querying a different DNSimple name server
-- Check [DNSimple's status page](https://dnsimple.statuspage.io) for known issues
+- Check the [DNSimple Status Page](/articles/dnsimple-status/) for known issues. You can [subscribe to notifications](/articles/dnsimple-status/#subscribe) to receive alerts during incidents.
 
 ## Have more questions?
 If you have additional questions or need any assistance with your domain resolution, just [contact support](https://dnsimple.com/feedback), and we will be happy to help.   

--- a/content/articles/how-dnsimple-handles-incidents.md
+++ b/content/articles/how-dnsimple-handles-incidents.md
@@ -1,0 +1,67 @@
+---
+title: How DNSimple Handles Incidents
+excerpt: How DNSimple communicates during service incidents and where to find status updates.
+meta: Learn how DNSimple communicates during service incidents, where to check system status, how to subscribe to status notifications, and what to expect from postmortems.
+categories:
+- DNSimple
+---
+
+# How DNSimple Handles Incidents
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+DNSimple uses a public [status page](https://dnsimplestatus.com) to communicate service health in real time. During incidents, we post updates there and follow up with a postmortem when the issue is resolved.
+
+## Checking service status {#status-page}
+
+Visit [dnsimplestatus.com](https://dnsimplestatus.com) to see the current state of all DNSimple services, including DNS resolution, the web application, API, and certificate provisioning. The page also displays uptime history for each component.
+
+> [!NOTE]
+> Downtime on a single name server does not indicate downtime for the system as a whole. DNSimple operates multiple name servers across different networks, and resolvers will use any available server. See [DNSimple Status Page](/articles/dnsimple-status/) for details.
+
+## Subscribing to notifications {#subscribe}
+
+You do not need to check the status page manually. Subscribe to receive notifications automatically when an incident is created, updated, or resolved.
+
+To subscribe, visit [dnsimplestatus.com](https://dnsimplestatus.com) and click **Subscribe to Updates** at the top of the page. You can choose to receive notifications by:
+
+- **Email** -- Incident updates delivered to your inbox.
+- **SMS** -- Text message alerts for incidents.
+- **RSS/Atom** -- Add the feed to your reader.
+- **Webhook** -- Receive HTTP POST requests for integration with your own monitoring tools.
+
+We recommend subscribing all team members who manage DNS or domains, especially those responsible for production infrastructure.
+
+## What happens during an incident {#during}
+
+When DNSimple detects or is notified of a service disruption:
+
+1. An incident is created on the status page with the affected components identified.
+2. Updates are posted as the investigation progresses, including what is known and what is being done.
+3. When the issue is resolved, the incident is marked resolved with a summary of what happened.
+
+If the DNSimple dashboard is unavailable during an incident, the status page remains accessible because it is hosted on separate infrastructure.
+
+## Postmortems {#postmortems}
+
+For significant incidents, DNSimple publishes a postmortem on the [DNSimple blog](https://blog.dnsimple.com/). Postmortems typically include:
+
+- A timeline of the incident.
+- The root cause and contributing factors.
+- What was done to resolve the issue.
+- Steps being taken to prevent recurrence.
+
+Postmortems are published after the engineering team completes its investigation. The timeline varies depending on the complexity of the incident.
+
+## Protecting your domains during outages {#protection}
+
+To reduce the impact of any DNS provider outage, consider adding a [secondary DNS provider](/articles/dns-redundancy/) as a resilience layer. Secondary DNS ensures your domains continue to resolve even if one provider is temporarily unavailable.
+
+## Have more questions?
+
+If you have any questions about how DNSimple handles incidents or want to report an issue, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/secondary-dns.md
+++ b/content/articles/secondary-dns.md
@@ -15,6 +15,8 @@ categories:
 
 ---
 
+For an overview of when and why to add DNS redundancy, see [DNS Redundancy Options at DNSimple](/articles/dns-redundancy/).
+
 > [!WARNING]
 > Secondary DNS and [DNSSEC](/articles/dnssec/) requires special considerations. Please read our [Why DNSSEC and Secondary DNS May Not Work Together](/articles/dnssec-and-secondary-dns/) article for more information.
 


### PR DESCRIPTION
## Summary

- New article: **How DNSimple Handles Incidents** (`how-dnsimple-handles-incidents.md`) - covers the status page, subscribing to notifications (email/SMS/RSS/webhook), what happens during incidents, postmortems, and protecting domains during outages.
- New article: **DNS Redundancy Options at DNSimple** (`dns-redundancy.md`) - decision guide for when to add secondary DNS, comparing AXFR-based secondary DNS with multi-provider sync, linking to provider-specific setup guides.
- Expanded **DNSimple Status Page** (`dnsimple-status.md`) from 17 lines to a full article with notification subscription instructions, status level definitions, and cross-links.
- Added cross-links from `domain-resolution-issues.md` and `secondary-dns.md`.
- Updated `dnsimple.yaml` and `secondary_dns.yaml` categories.

Addresses Q1 2026 newsletter finding: February 10 outage generated 28 tickets, customers questioned redundancy architecture, set up secondary DNS with competitors, and requested postmortems. No incident communications or DNS redundancy decision guide existed.

## Test plan

- [x] Verify `how-dnsimple-handles-incidents.md` renders correctly and all links resolve
- [x] Verify `dns-redundancy.md` renders correctly and all links resolve
- [x] Verify expanded `dnsimple-status.md` renders correctly
- [x] Confirm new articles appear in their respective categories
- [x] Verify cross-links in `domain-resolution-issues.md` and `secondary-dns.md` work