### PR TITLE
Fix category YAML title mismatches for Integrations and Enterprise pages

### DIFF
--- a/categories/enterprise.yaml
+++ b/categories/enterprise.yaml
@@ -21,8 +21,8 @@ Security:
   - "What Are CDS and CDNSKEY?"
   - "SSL/TLS Certificates"
   - "SSL Certificate Types"
-  - "Ordering a Let's Encrypt Certificate"
-  - "Ordering a Wildcard SSL Certificate"
+  - "How to Get a Free Let's Encrypt SSL Certificate"
+  - "How to Buy a Wildcard SSL Certificate"
 
 Infra:
   - "Manage Vanity Name Servers"

--- a/categories/integrations.yaml
+++ b/categories/integrations.yaml
@@ -2,6 +2,7 @@ Integrated Domain Providers:
 - "Integrated Domain Providers at DNSimple"
 - "Manage Integrated Domains"
 - "Integrated Domain Provider - GoDaddy"
+- "Link and Unlink Integrated Domain Providers"
 
 Integrated DNS Providers:
 - "Integrated DNS Providers at DNSimple"
@@ -16,16 +17,16 @@ Integrated DNS Providers:
 - "Manage Integrated Zones for Integrated DNS Providers"
 
 Let's Encrypt:
-- "Let's Encrypt and DNSimple"
+- "Let's Encrypt: Free SSL Certificates with DNSimple"
 
 Heroku:
 - "Pointing the Domain Apex to Heroku"
 - "Heroku Connector"
 - "Troubleshooting Heroku shows different app error"
 - "Troubleshooting Heroku \"No such app\" error"
-- "Troubleshooting Heroku SSL errors"
+- "Troubleshooting Heroku SSL Errors"
 - "Redirect www to Non-www Domain at Heroku"
-- "SSL Certificates with Heroku"
+- "How to Install an SSL Certificate on Heroku"
 
 Cloudflare:
 - "Use Cloudflare DNSSEC with DNSimple"


### PR DESCRIPTION
## Summary

- Fix 6 article title mismatches in `categories/integrations.yaml` and `categories/enterprise.yaml` that caused articles to appear under "Other" instead of their intended sections.

### Integrations (`/categories/integrations/`)
- "Let's Encrypt and DNSimple" -> "Let's Encrypt: Free SSL Certificates with DNSimple"
- "Troubleshooting Heroku SSL errors" -> "Troubleshooting Heroku SSL Errors" (capitalization)
- "SSL Certificates with Heroku" -> "How to Install an SSL Certificate on Heroku"
- Added missing "Link and Unlink Integrated Domain Providers" to Integrated Domain Providers section

### Enterprise (`/categories/enterprise/`)
- "Ordering a Let's Encrypt Certificate" -> "How to Get a Free Let's Encrypt SSL Certificate"
- "Ordering a Wildcard SSL Certificate" -> "How to Buy a Wildcard SSL Certificate"

## Test plan

- [x] Verify `/categories/integrations/` no longer has an "Other" section
- [x] Verify `/categories/enterprise/` no longer has an "Other" section
- [x] Confirm the 6 affected articles appear under their correct sections