### PR TITLE
Add email authentication and deliverability articles for SEO

### DIFF
--- a/categories/emails.yaml
+++ b/categories/emails.yaml
@@ -7,13 +7,14 @@ Explanation:
     - "What Is Email Forwarding?"
     - "Email Hosting Support"
   Email Authentication:
+    - "How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)"
     - "What Is an SPF Record?"
     - "What Is a DKIM Record?"
     - "What Is a DMARC Record?"
     - "Understanding SPF, DKIM, and DMARC Alignment"
     - "Email Authentication Best Practices"
   Email Deliverability:
-    - "Understanding Email Deliverability"
+    - "Email Deliverability: How to Get Your Emails to the Inbox"
     - "Understanding Email Bounces"
   Email Security:
     - "Protecting Your Domain from Email Spoofing"

--- a/categories/emails.yaml
+++ b/categories/emails.yaml
@@ -7,17 +7,16 @@ Explanation:
     - "What Is Email Forwarding?"
     - "Email Hosting Support"
   Email Authentication:
-    - "How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)"
     - "What Is an SPF Record?"
     - "What Is a DKIM Record?"
     - "What Is a DMARC Record?"
-    - "Understanding SPF, DKIM, and DMARC Alignment"
+    - "SPF, DKIM, and DMARC Alignment"
     - "Email Authentication Best Practices"
   Email Deliverability:
     - "Email Deliverability: How to Get Your Emails to the Inbox"
-    - "Understanding Email Bounces"
+    - "Email Bounces"
   Email Security:
-    - "Protecting Your Domain from Email Spoofing"
+    - "Email Spoofing Protection"
   MX Records:
     - "What Is an MX Record?"
     - "What Are Null MX Records?"
@@ -30,11 +29,12 @@ How to:
     - "How to Migrate Email Forwarding to DNSimple"
     - "Email Forwarding and Bounced Emails"
   Email Authentication:
+    - "How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)"
     - "Set Up SPF Records"
     - "Set Up DKIM"
     - "Set Up DMARC"
-    - "Implementing a Gradual DMARC Policy"
-    - "Managing Multiple DKIM Selectors"
+    - "Implement a Gradual DMARC Policy"
+    - "Manage Multiple DKIM Selectors"
   Email Hosting:
     - "Set Up MX Records for Email Hosting"
     - "Set Up Null MX Records"
@@ -50,8 +50,8 @@ How to:
     - "Atmail Service"
     - "DMARC Reports by Postmark Service"
   Email Deliverability:
-    - "Improving Email Deliverability"
-    - "Monitoring Email Deliverability"
+    - "Improve Email Deliverability"
+    - "Monitor Email Deliverability"
   MX Records:
     - "Query MX Records"
   Verification:
@@ -62,7 +62,7 @@ How to:
     - "Email Forwarding Not Working with Gmail"
     - "Email Forwarding Not Working"
     - "Email Forwarding Not Working with Outlook, Yahoo, and Other Providers"
-    - "Troubleshooting Email Authentication"
+    - "Troubleshoot Email Authentication"
 
 Reference:
   Email Forwarding:

--- a/content/articles/dkim-record.md
+++ b/content/articles/dkim-record.md
@@ -46,7 +46,7 @@ If the signature matches, it confirms:
 
 **Enhances reputation:** Helps build and maintain a positive sending reputation for your domain.
 
-DKIM is often used in conjunction with [SPF](/articles/spf-record/) (Sender Policy Framework) and [DMARC](/articles/dmarc-record/) (Domain-based Message Authentication, Reporting, and Conformance) to form a comprehensive email authentication strategy.
+DKIM is one of three protocols that make up [email authentication](/articles/email-authentication/). It works alongside [SPF](/articles/spf-record/) (Sender Policy Framework) and [DMARC](/articles/dmarc-record/) (Domain-based Message Authentication, Reporting, and Conformance).
 
 ## Setting up and verifying DKIM {#setting-up-and-verifying-dkim}
 For step-by-step instructions on how to add a DKIM record to your DNSimple zone, including details on formatting and specific fields, please refer to our dedicated How-To Guide: [Set Up DKIM](/articles/set-up-dkim/).

--- a/content/articles/dmarc-record.md
+++ b/content/articles/dmarc-record.md
@@ -75,9 +75,10 @@ For more on the technical specifications and intricacies of the DMARC protocol, 
 
 ## Related articles {#related}
 
-- [Email Authentication Best Practices](/articles/email-authentication-best-practices/) - Guidance on implementing SPF, DKIM, and DMARC together
-- [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - How alignment requirements affect email authentication
-- [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) - How to move from monitoring to enforcement
+- [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/) - Set up SPF, DKIM, and DMARC together
+- [Email Authentication Best Practices](/articles/email-authentication-best-practices/) - Ongoing maintenance for SPF, DKIM, and DMARC
+- [SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - How alignment requirements affect email authentication
+- [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) - How to move from monitoring to enforcement
 
 ## Have more questions?
 

--- a/content/articles/email-authentication-best-practices.md
+++ b/content/articles/email-authentication-best-practices.md
@@ -92,7 +92,7 @@ Once you have [set up email authentication](/articles/email-authentication/) (SP
 - Test each selector regularly
 
 > [!NOTE]
-> For detailed information, see [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
+> For detailed information, see [Manage Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
 
 ### Verify DKIM signatures
 
@@ -135,7 +135,7 @@ Once you have [set up email authentication](/articles/email-authentication/) (SP
 6. Gradually increase to full reject
 
 > [!NOTE]
-> For detailed steps, see [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
+> For detailed steps, see [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
 
 ### Set up reporting
 
@@ -225,10 +225,10 @@ Once you have [set up email authentication](/articles/email-authentication/) (SP
 ## Related articles {#related}
 
 - [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/) - Initial setup and common mistakes
-- [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements
-- [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) - Gradual DMARC rollout
-- [Monitoring Email Deliverability](/articles/monitoring-email-deliverability/) - Ongoing monitoring routine
-- [Troubleshooting Email Authentication](/articles/troubleshooting-email-authentication/) - Diagnosing failures
+- [SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements
+- [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) - Gradual DMARC rollout
+- [Monitor Email Deliverability](/articles/monitoring-email-deliverability/) - Ongoing monitoring routine
+- [Troubleshoot Email Authentication](/articles/troubleshooting-email-authentication/) - Diagnosing failures
 
 ## Have more questions?
 

--- a/content/articles/email-authentication-best-practices.md
+++ b/content/articles/email-authentication-best-practices.md
@@ -15,36 +15,9 @@ categories:
 
 ---
 
-Following email authentication best practices is essential for good email deliverability, security, and protection against spoofing. This guide covers best practices for SPF, DKIM, and DMARC.
-
-## Overview {#overview}
-
-Email authentication best practices include:
-
-- **Proper configuration:** Set up SPF, DKIM, and DMARC correctly
-- **Regular monitoring:** Monitor authentication status and reports
-- **Gradual implementation:** Implement policies gradually
-- **Ongoing maintenance:** Keep authentication records updated
-- **Documentation:** Document your email ecosystem
+Once you have [set up email authentication](/articles/email-authentication/) (SPF, DKIM, and DMARC), these best practices help you maintain, monitor, and optimize your configuration over time.
 
 ## SPF best practices {#spf}
-
-### Include all authorized senders
-
-**Best practice:** Include all services that send email on your behalf in your SPF record.
-
-**Why:** Missing authorized senders can cause SPF failures and delivery issues.
-
-**How:**
-- List all email hosting providers
-- Include all transactional email services
-- Include all marketing platforms
-- Include any other services that send email
-
-**Example:**
-```
-v=spf1 include:_spf.google.com include:spf.mtasv.net include:sendgrid.net ~all
-```
 
 ### Use appropriate qualifiers
 
@@ -68,17 +41,6 @@ v=spf1 include:_spf.google.com include:spf.mtasv.net include:sendgrid.net ~all
 - Use `ip4:` and `ip6:` for direct IPs when possible
 - Consolidate services when possible
 - Remove unused includes
-
-### One SPF record per domain
-
-**Best practice:** Have only one SPF record per domain.
-
-**Why:** Multiple SPF records cause SPF to fail.
-
-**How:**
-- Check for existing SPF records before adding a new one
-- Modify existing SPF record instead of creating a new one
-- Combine multiple SPF records into one
 
 ### Test SPF regularly
 
@@ -210,19 +172,6 @@ v=spf1 include:_spf.google.com include:spf.mtasv.net include:sendgrid.net ~all
 - Identify unknown email sources
 - Fix issues promptly
 
-### Document your email ecosystem
-
-**Best practice:** Document all services that send email from your domain.
-
-**Why:** Documentation helps manage authentication and identify issues.
-
-**How:**
-- List all email hosting providers
-- Document all transactional email services
-- Note all marketing platforms
-- Keep DKIM selectors documented
-- Update documentation when services change
-
 ## General best practices {#general}
 
 ### Test before major changes
@@ -273,67 +222,13 @@ v=spf1 include:_spf.google.com include:spf.mtasv.net include:sendgrid.net ~all
 - Use `marketing.example.com` for marketing emails
 - Configure authentication for each subdomain
 
-### Document your configuration
-
-**Best practice:** Document your email authentication configuration.
-
-**Why:** Documentation helps with troubleshooting and future management.
-
-**How:**
-- Document all SPF includes
-- List all DKIM selectors
-- Note DMARC policy and settings
-- Keep records of changes
-
-## Common mistakes to avoid {#mistakes}
-
-### Do not start with reject policy
-
-**Mistake:** Starting DMARC with `p=reject` immediately.
-
-**Why:** Can block legitimate emails if authentication is not properly configured.
-
-**Solution:** Always start with `p=none` (monitoring).
-
-### Do not ignore DMARC reports
-
-**Mistake:** Setting up DMARC but not reviewing reports.
-
-**Why:** Reports provide valuable information about authentication status.
-
-**Solution:** Review reports regularly and act on findings.
-
-### Do not have multiple SPF records
-
-**Mistake:** Creating multiple SPF records instead of combining them.
-
-**Why:** Multiple SPF records cause SPF to fail.
-
-**Solution:** Have only one SPF record and combine all includes.
-
-### Do not forget to update records
-
-**Mistake:** Not updating authentication records when services change.
-
-**Why:** Can cause authentication failures.
-
-**Solution:** Keep records updated and review regularly.
-
-### Do not skip testing
-
-**Mistake:** Making changes without testing.
-
-**Why:** Can break email delivery.
-
-**Solution:** Always test changes before full implementation.
-
 ## Related articles {#related}
 
-- [SPF Records](/articles/spf-record/) - SPF setup
-- [Set Up DKIM](/articles/set-up-dkim/) - DKIM setup
-- [Set Up DMARC](/articles/set-up-dmarc/) - DMARC setup
-- [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment
-- [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) - Gradual implementation
+- [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/) - Initial setup and common mistakes
+- [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements
+- [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) - Gradual DMARC rollout
+- [Monitoring Email Deliverability](/articles/monitoring-email-deliverability/) - Ongoing monitoring routine
+- [Troubleshooting Email Authentication](/articles/troubleshooting-email-authentication/) - Diagnosing failures
 
 ## Have more questions?
 

--- a/content/articles/email-authentication.md
+++ b/content/articles/email-authentication.md
@@ -1,7 +1,7 @@
 ---
 title: How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)
-excerpt: What email authentication is, how SPF, DKIM, and DMARC work together, and how to set them up for your domain.
-meta: Email authentication (also called email validation) uses SPF, DKIM, and DMARC DNS records to verify that emails sent from your domain are legitimate. Learn how these protocols work together and how to set them up.
+excerpt: How to set up SPF, DKIM, and DMARC for your domain to authenticate your email and protect against spoofing.
+meta: Set up email authentication (also called email validation) for your domain using SPF, DKIM, and DMARC DNS records. Step-by-step instructions for configuring all three protocols.
 categories:
 - Emails
 ---
@@ -15,69 +15,23 @@ categories:
 
 ---
 
-Email authentication (also called email validation) is a set of DNS-based protocols that verify emails sent from your domain are legitimate. The three protocols - [SPF](/articles/spf-record/), [DKIM](/articles/dkim-record/), and [DMARC](/articles/dmarc-record/) - work together to prove to receiving mail servers that a message was authorized by the domain owner and was not altered in transit.
+Email authentication uses three DNS protocols - [SPF](/articles/spf-record/), [DKIM](/articles/dkim-record/), and [DMARC](/articles/dmarc-record/) - to verify that emails sent from your domain are legitimate. Setting up all three protects your domain from [spoofing](/articles/protecting-your-domain-from-email-spoofing/) and improves [email deliverability](/articles/understanding-email-deliverability/).
 
-Without email authentication, anyone can send email claiming to come from your domain. Mailbox providers like Gmail, Outlook, and Yahoo have no way to distinguish legitimate messages from forgeries, so they are more likely to filter your email as spam or reject it outright.
+Since February 2024, Google and Yahoo require SPF, DKIM, and DMARC for bulk email senders. Microsoft Outlook enforced similar requirements starting May 2025.
 
-## What is email authentication? {#what-is}
+## Before starting
 
-Email authentication is the process of verifying that an email message was sent by an authorized sender and was not tampered with during delivery. It solves a fundamental problem with email: the SMTP protocol, designed in the early 1980s, has no built-in way to verify sender identity. Any server can send email claiming to be from any domain.
+You will need:
 
-Three DNS-based protocols address this gap:
+- Access to your domain's DNS records in DNSimple
+- Access to your email service provider's admin panel to retrieve SPF includes and DKIM keys
+- A list of every service that sends email using your domain in the `From:` address (email provider, transactional email, marketing platforms, support tools, your application)
 
-- **SPF** verifies that the sending server is authorized to send email for the domain.
-- **DKIM** verifies that the message content was not altered after sending, using a cryptographic signature.
-- **DMARC** ties SPF and DKIM together with a policy that tells receiving servers what to do when authentication fails.
+## Step 1: Set up SPF {#step-1}
 
-These protocols are sometimes grouped under the term "email validation" because they validate that the sender is who they claim to be.
+An [SPF record](/articles/spf-record/) is a TXT record that lists every server authorized to send email for your domain.
 
-## How SPF, DKIM, and DMARC work together {#how-it-works}
-
-Each protocol covers a gap the others leave open:
-
-| Protocol | What it verifies | Limitation |
-|---|---|---|
-| [SPF](/articles/spf-record/) | The sending server's IP is authorized for the domain | Fails when email is forwarded, because the forwarding server's IP is not in the original sender's SPF record |
-| [DKIM](/articles/dkim-record/) | The message was signed by the domain owner and was not modified | Does not tell receiving servers what to do if verification fails |
-| [DMARC](/articles/dmarc-record/) | SPF or DKIM passed and the domain in the `From:` header matches (alignment) | Depends on SPF and DKIM to function |
-
-A domain with only SPF will have forwarded emails fail authentication. A domain with SPF and DKIM but no DMARC leaves enforcement up to each receiving server. All three together give receiving servers clear proof of legitimacy and clear instructions for handling failures.
-
-For a deeper explanation of how alignment works across the three protocols, see [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/).
-
-## Why email authentication matters {#why-it-matters}
-
-### Inbox placement
-
-Mailbox providers use authentication results as a primary signal when deciding whether to deliver email to the inbox or the spam folder. Missing or failing authentication is one of the most common reasons email lands in spam. See [Email Deliverability](/articles/understanding-email-deliverability/) for more on how authentication affects inbox placement.
-
-### Protection against spoofing
-
-Without authentication records, attackers can send phishing emails that appear to come from your domain. SPF, DKIM, and DMARC make spoofing significantly harder. See [Protecting Your Domain from Email Spoofing](/articles/protecting-your-domain-from-email-spoofing/) for details.
-
-### Compliance with sender requirements
-
-Since February 2024, Google and Yahoo require SPF, DKIM, and DMARC for all bulk email senders (5,000+ messages per day to their users). Microsoft Outlook enforced similar requirements starting May 2025. Even below those thresholds, having all three configured improves deliverability with every major mailbox provider.
-
-## How to set up email authentication {#setup}
-
-### Step 1: Identify all services that send email as your domain {#step-1}
-
-Before configuring any DNS records, list every service that sends email using your domain in the `From:` address:
-
-- Primary email provider (Google Workspace, Microsoft 365, Fastmail)
-- Transactional email services (SendGrid, Postmark, Amazon SES)
-- Marketing platforms (Mailchimp, HubSpot, ConvertKit)
-- Support tools (Zendesk, Intercom, Help Scout)
-- Your application, if it sends email directly (password resets, notifications)
-
-Every service on this list needs to be authorized in your SPF record and configured with DKIM signing.
-
-### Step 2: Set up SPF {#step-2}
-
-An [SPF record](/articles/spf-record/) is a TXT record on your domain that lists every server authorized to send email on your behalf.
-
-Example for a domain using Google Workspace and Postmark:
+Create a single SPF record that includes all your sending services. Example for Google Workspace and Postmark:
 
 ```
 v=spf1 include:_spf.google.com include:spf.mtasv.net ~all
@@ -87,15 +41,15 @@ Key rules:
 
 - Your domain must have exactly **one** SPF record. Multiple SPF records cause all SPF checks to fail.
 - SPF allows a maximum of **10 DNS lookups**. Each `include:` counts as at least one. See the [SPF Record Syntax and Validation Reference](/articles/spf-syntax-validation-reference/) for details.
-- Start with `~all` (soft fail), then move to `-all` (hard fail) after confirming all services are included.
+- Start with `~all` (soft fail). Move to `-all` (hard fail) after confirming all services are included.
 
-For full setup instructions, see [Set Up SPF Records](/articles/setting-up-spf/).
+For full setup instructions in DNSimple, see [Set Up SPF Records](/articles/setting-up-spf/).
 
-### Step 3: Set up DKIM {#step-3}
+## Step 2: Set up DKIM {#step-2}
 
-A [DKIM record](/articles/dkim-record/) publishes a public key as a TXT record at a specific selector subdomain (e.g., `google._domainkey.yourdomain.com`). Your email provider signs each outgoing message with the corresponding private key, and receiving servers verify the signature against the public key in DNS.
+A [DKIM record](/articles/dkim-record/) publishes a public key as a TXT record at a selector subdomain. Your email provider signs each outgoing message with the corresponding private key.
 
-Each email service uses its own selector:
+Each service uses its own selector:
 
 | Provider | Selector |
 |---|---|
@@ -104,13 +58,16 @@ Each email service uses its own selector:
 | Mailchimp | `k1._domainkey` |
 | SendGrid | `s1._domainkey`, `s2._domainkey` |
 
-If you use more than one email service, each needs its own DKIM record. See [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
+Add a DKIM record for every service on your list. If you use more than one, see [Manage Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
 
-For full setup instructions, see [Set Up DKIM](/articles/set-up-dkim/).
+> [!TIP]
+> Wait 15 to 30 minutes after adding a DKIM record before testing. DNS propagation means the record may not be visible immediately.
 
-### Step 4: Set up DMARC {#step-4}
+For full setup instructions in DNSimple, see [Set Up DKIM](/articles/set-up-dkim/).
 
-A [DMARC record](/articles/dmarc-record/) is a TXT record at `_dmarc.yourdomain.com` that tells receiving servers what to do when SPF and DKIM checks fail, and where to send authentication reports.
+## Step 3: Set up DMARC {#step-3}
+
+A [DMARC record](/articles/dmarc-record/) is a TXT record at `_dmarc.yourdomain.com` that tells receiving servers what to do when SPF and DKIM checks fail.
 
 Start with a monitoring-only policy:
 
@@ -118,13 +75,13 @@ Start with a monitoring-only policy:
 v=DMARC1; p=none; rua=mailto:dmarc-reports@yourdomain.com
 ```
 
-This lets you see authentication results without affecting delivery. After reviewing reports for two to four weeks and confirming all legitimate email passes, gradually tighten the policy from `p=none` to `p=quarantine` to `p=reject`. See [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for the full rollout process.
+Leave `p=none` in place for two to four weeks while you review the aggregate reports. Once all legitimate email passes authentication, gradually tighten the policy to `p=quarantine` and then `p=reject`. See [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for the rollout process.
 
-For setup instructions, see [Set Up DMARC](/articles/set-up-dmarc/).
+For setup instructions in DNSimple, see [Set Up DMARC](/articles/set-up-dmarc/).
 
-### Step 5: Verify your records {#step-5}
+## Step 4: Verify your records {#step-4}
 
-After adding all three records, verify they are published correctly:
+After adding all three records, confirm they are published correctly:
 
 ```bash
 dig +short TXT yourdomain.com | grep "v=spf1"
@@ -132,7 +89,7 @@ dig +short TXT selector._domainkey.yourdomain.com
 dig +short TXT _dmarc.yourdomain.com
 ```
 
-Send a test email to a Gmail address, open it, and select "Show original" to check the `Authentication-Results` header. All three should show `pass`:
+Send a test email to a Gmail address. Open the message, select "Show original," and check the `Authentication-Results` header. All three should show `pass`:
 
 ```
 spf=pass
@@ -142,32 +99,29 @@ dmarc=pass
 
 For detailed verification steps, see [Verify SPF](/articles/verifying-spf/), [Verify DKIM](/articles/verify-dkim/), and [Verify DMARC](/articles/verifying-dmarc/).
 
-## Common email authentication mistakes {#common-mistakes}
+## Common mistakes {#common-mistakes}
 
 ### Multiple SPF records on one domain {#multiple-spf}
 
-Adding a second TXT record starting with `v=spf1` instead of modifying the existing one causes all SPF checks to fail. Your domain must have exactly one SPF record that combines all authorized senders.
+Adding a second TXT record starting with `v=spf1` instead of modifying the existing one causes all SPF checks to fail. Your domain must have exactly one SPF record.
 
 ### DKIM record on the wrong selector or domain {#wrong-dkim}
 
-DKIM records must be published at the exact selector subdomain your email provider specifies. A typo in the selector name, or adding the record to the wrong domain, means receiving servers cannot find the public key.
-
-> [!TIP]
-> Wait 15 to 30 minutes after adding a DKIM record before testing. DNS propagation means the record may not be visible immediately.
+DKIM records must be at the exact selector subdomain your email provider specifies. A typo in the selector name or adding the record to the wrong domain means receiving servers cannot find the public key.
 
 ### Exceeding the SPF 10-lookup limit {#spf-lookups}
 
-Each `include:` in your SPF record triggers at least one DNS lookup, and some providers chain to additional lookups internally. Google's `_spf.google.com` alone can consume three to four lookups. If you use multiple services, audit your total with a tool like [MXToolbox SPF Check](https://mxtoolbox.com/spf.aspx).
+Each `include:` triggers at least one DNS lookup. Some providers chain to additional lookups internally. Google's `_spf.google.com` alone can consume three to four lookups. Audit your total with [MXToolbox SPF Check](https://mxtoolbox.com/spf.aspx).
 
 ### DMARC stuck at p=none {#dmarc-none}
 
-A DMARC record with `p=none` provides monitoring but no protection. It does not prevent spoofing or improve deliverability signals. Treat `p=none` as a temporary state and move to enforcement after reviewing your DMARC reports.
+A DMARC record with `p=none` provides monitoring but no protection. Treat it as a temporary state and move to enforcement after reviewing your reports.
 
 ### Forgetting to authenticate all sending services {#missing-services}
 
-If one of your services is missing from your SPF record or does not have DKIM configured, emails from that service will fail authentication. This is especially common with CRM tools, billing systems, and marketing platforms that send email on your behalf.
+If a service is missing from your SPF record or does not have DKIM configured, emails from that service will fail authentication. This is especially common with CRM tools, billing systems, and marketing platforms.
 
-For more diagnostic steps, see [Troubleshooting Email Authentication](/articles/troubleshooting-email-authentication/).
+For more diagnostic steps, see [Troubleshoot Email Authentication](/articles/troubleshooting-email-authentication/).
 
 ## Frequently asked questions {#faq}
 
@@ -177,19 +131,19 @@ You need all three. SPF alone fails on forwarded email. DKIM alone has no enforc
 
 ### What happens if email authentication fails? {#faq-fails}
 
-The result depends on your DMARC policy. With `p=none`, nothing happens (the email is delivered normally). With `p=quarantine`, failing emails are sent to the spam folder. With `p=reject`, failing emails are blocked entirely.
+The result depends on your DMARC policy. With `p=none`, failing emails are delivered normally. With `p=quarantine`, they go to spam. With `p=reject`, they are blocked entirely.
 
-### How long does it take to set up email authentication? {#faq-how-long}
+### How long does it take to set up? {#faq-how-long}
 
-The DNS changes take minutes. The DMARC monitoring period (starting at `p=none` and reviewing reports before enforcing) typically takes two to six weeks, depending on how many services send email from your domain.
+The DNS changes take minutes. The DMARC monitoring period (reviewing reports before enforcing) typically takes two to six weeks.
 
 ### Does email authentication prevent all spam and phishing? {#faq-prevent-spam}
 
-It prevents unauthorized senders from using your domain. It does not stop spam or phishing that uses other domains. It also does not guarantee inbox placement - other factors like [sender reputation and content](/articles/understanding-email-deliverability/) also affect delivery.
+It prevents unauthorized senders from using your domain. It does not stop spam or phishing from other domains. It also does not guarantee inbox placement - [sender reputation and content](/articles/understanding-email-deliverability/) also affect delivery.
 
 ### What about domains that do not send email? {#faq-non-sending}
 
-Non-sending domains still need protection. Without authentication records, attackers can spoof them for phishing. Configure `v=spf1 -all` (authorize no senders), a DMARC record with `p=reject`, and a [null MX record](/articles/what-are-null-mx-records/) to declare the domain does not accept email.
+Non-sending domains still need protection. Configure `v=spf1 -all` (authorize no senders), a DMARC record with `p=reject`, and a [null MX record](/articles/what-are-null-mx-records/) to declare the domain does not accept email.
 
 ## Have more questions?
 

--- a/content/articles/email-authentication.md
+++ b/content/articles/email-authentication.md
@@ -1,0 +1,196 @@
+---
+title: How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)
+excerpt: What email authentication is, how SPF, DKIM, and DMARC work together, and how to set them up for your domain.
+meta: Email authentication (also called email validation) uses SPF, DKIM, and DMARC DNS records to verify that emails sent from your domain are legitimate. Learn how these protocols work together and how to set them up.
+categories:
+- Emails
+---
+
+# How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+Email authentication (also called email validation) is a set of DNS-based protocols that verify emails sent from your domain are legitimate. The three protocols - [SPF](/articles/spf-record/), [DKIM](/articles/dkim-record/), and [DMARC](/articles/dmarc-record/) - work together to prove to receiving mail servers that a message was authorized by the domain owner and was not altered in transit.
+
+Without email authentication, anyone can send email claiming to come from your domain. Mailbox providers like Gmail, Outlook, and Yahoo have no way to distinguish legitimate messages from forgeries, so they are more likely to filter your email as spam or reject it outright.
+
+## What is email authentication? {#what-is}
+
+Email authentication is the process of verifying that an email message was sent by an authorized sender and was not tampered with during delivery. It solves a fundamental problem with email: the SMTP protocol, designed in the early 1980s, has no built-in way to verify sender identity. Any server can send email claiming to be from any domain.
+
+Three DNS-based protocols address this gap:
+
+- **SPF** verifies that the sending server is authorized to send email for the domain.
+- **DKIM** verifies that the message content was not altered after sending, using a cryptographic signature.
+- **DMARC** ties SPF and DKIM together with a policy that tells receiving servers what to do when authentication fails.
+
+These protocols are sometimes grouped under the term "email validation" because they validate that the sender is who they claim to be.
+
+## How SPF, DKIM, and DMARC work together {#how-it-works}
+
+Each protocol covers a gap the others leave open:
+
+| Protocol | What it verifies | Limitation |
+|---|---|---|
+| [SPF](/articles/spf-record/) | The sending server's IP is authorized for the domain | Fails when email is forwarded, because the forwarding server's IP is not in the original sender's SPF record |
+| [DKIM](/articles/dkim-record/) | The message was signed by the domain owner and was not modified | Does not tell receiving servers what to do if verification fails |
+| [DMARC](/articles/dmarc-record/) | SPF or DKIM passed and the domain in the `From:` header matches (alignment) | Depends on SPF and DKIM to function |
+
+A domain with only SPF will have forwarded emails fail authentication. A domain with SPF and DKIM but no DMARC leaves enforcement up to each receiving server. All three together give receiving servers clear proof of legitimacy and clear instructions for handling failures.
+
+For a deeper explanation of how alignment works across the three protocols, see [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/).
+
+## Why email authentication matters {#why-it-matters}
+
+### Inbox placement
+
+Mailbox providers use authentication results as a primary signal when deciding whether to deliver email to the inbox or the spam folder. Missing or failing authentication is one of the most common reasons email lands in spam. See [Email Deliverability](/articles/understanding-email-deliverability/) for more on how authentication affects inbox placement.
+
+### Protection against spoofing
+
+Without authentication records, attackers can send phishing emails that appear to come from your domain. SPF, DKIM, and DMARC make spoofing significantly harder. See [Protecting Your Domain from Email Spoofing](/articles/protecting-your-domain-from-email-spoofing/) for details.
+
+### Compliance with sender requirements
+
+Since February 2024, Google and Yahoo require SPF, DKIM, and DMARC for all bulk email senders (5,000+ messages per day to their users). Microsoft Outlook enforced similar requirements starting May 2025. Even below those thresholds, having all three configured improves deliverability with every major mailbox provider.
+
+## How to set up email authentication {#setup}
+
+### Step 1: Identify all services that send email as your domain {#step-1}
+
+Before configuring any DNS records, list every service that sends email using your domain in the `From:` address:
+
+- Primary email provider (Google Workspace, Microsoft 365, Fastmail)
+- Transactional email services (SendGrid, Postmark, Amazon SES)
+- Marketing platforms (Mailchimp, HubSpot, ConvertKit)
+- Support tools (Zendesk, Intercom, Help Scout)
+- Your application, if it sends email directly (password resets, notifications)
+
+Every service on this list needs to be authorized in your SPF record and configured with DKIM signing.
+
+### Step 2: Set up SPF {#step-2}
+
+An [SPF record](/articles/spf-record/) is a TXT record on your domain that lists every server authorized to send email on your behalf.
+
+Example for a domain using Google Workspace and Postmark:
+
+```
+v=spf1 include:_spf.google.com include:spf.mtasv.net ~all
+```
+
+Key rules:
+
+- Your domain must have exactly **one** SPF record. Multiple SPF records cause all SPF checks to fail.
+- SPF allows a maximum of **10 DNS lookups**. Each `include:` counts as at least one. See the [SPF Record Syntax and Validation Reference](/articles/spf-syntax-validation-reference/) for details.
+- Start with `~all` (soft fail), then move to `-all` (hard fail) after confirming all services are included.
+
+For full setup instructions, see [Set Up SPF Records](/articles/setting-up-spf/).
+
+### Step 3: Set up DKIM {#step-3}
+
+A [DKIM record](/articles/dkim-record/) publishes a public key as a TXT record at a specific selector subdomain (e.g., `google._domainkey.yourdomain.com`). Your email provider signs each outgoing message with the corresponding private key, and receiving servers verify the signature against the public key in DNS.
+
+Each email service uses its own selector:
+
+| Provider | Selector |
+|---|---|
+| Google Workspace | `google._domainkey` |
+| Microsoft 365 | `selector1._domainkey`, `selector2._domainkey` |
+| Mailchimp | `k1._domainkey` |
+| SendGrid | `s1._domainkey`, `s2._domainkey` |
+
+If you use more than one email service, each needs its own DKIM record. See [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
+
+For full setup instructions, see [Set Up DKIM](/articles/set-up-dkim/).
+
+### Step 4: Set up DMARC {#step-4}
+
+A [DMARC record](/articles/dmarc-record/) is a TXT record at `_dmarc.yourdomain.com` that tells receiving servers what to do when SPF and DKIM checks fail, and where to send authentication reports.
+
+Start with a monitoring-only policy:
+
+```
+v=DMARC1; p=none; rua=mailto:dmarc-reports@yourdomain.com
+```
+
+This lets you see authentication results without affecting delivery. After reviewing reports for two to four weeks and confirming all legitimate email passes, gradually tighten the policy from `p=none` to `p=quarantine` to `p=reject`. See [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for the full rollout process.
+
+For setup instructions, see [Set Up DMARC](/articles/set-up-dmarc/).
+
+### Step 5: Verify your records {#step-5}
+
+After adding all three records, verify they are published correctly:
+
+```bash
+dig +short TXT yourdomain.com | grep "v=spf1"
+dig +short TXT selector._domainkey.yourdomain.com
+dig +short TXT _dmarc.yourdomain.com
+```
+
+Send a test email to a Gmail address, open it, and select "Show original" to check the `Authentication-Results` header. All three should show `pass`:
+
+```
+spf=pass
+dkim=pass
+dmarc=pass
+```
+
+For detailed verification steps, see [Verify SPF](/articles/verifying-spf/), [Verify DKIM](/articles/verify-dkim/), and [Verify DMARC](/articles/verifying-dmarc/).
+
+## Common email authentication mistakes {#common-mistakes}
+
+### Multiple SPF records on one domain {#multiple-spf}
+
+Adding a second TXT record starting with `v=spf1` instead of modifying the existing one causes all SPF checks to fail. Your domain must have exactly one SPF record that combines all authorized senders.
+
+### DKIM record on the wrong selector or domain {#wrong-dkim}
+
+DKIM records must be published at the exact selector subdomain your email provider specifies. A typo in the selector name, or adding the record to the wrong domain, means receiving servers cannot find the public key.
+
+> [!TIP]
+> Wait 15 to 30 minutes after adding a DKIM record before testing. DNS propagation means the record may not be visible immediately.
+
+### Exceeding the SPF 10-lookup limit {#spf-lookups}
+
+Each `include:` in your SPF record triggers at least one DNS lookup, and some providers chain to additional lookups internally. Google's `_spf.google.com` alone can consume three to four lookups. If you use multiple services, audit your total with a tool like [MXToolbox SPF Check](https://mxtoolbox.com/spf.aspx).
+
+### DMARC stuck at p=none {#dmarc-none}
+
+A DMARC record with `p=none` provides monitoring but no protection. It does not prevent spoofing or improve deliverability signals. Treat `p=none` as a temporary state and move to enforcement after reviewing your DMARC reports.
+
+### Forgetting to authenticate all sending services {#missing-services}
+
+If one of your services is missing from your SPF record or does not have DKIM configured, emails from that service will fail authentication. This is especially common with CRM tools, billing systems, and marketing platforms that send email on your behalf.
+
+For more diagnostic steps, see [Troubleshooting Email Authentication](/articles/troubleshooting-email-authentication/).
+
+## Frequently asked questions {#faq}
+
+### Do I need SPF, DKIM, and DMARC, or is one enough? {#faq-all-three}
+
+You need all three. SPF alone fails on forwarded email. DKIM alone has no enforcement policy. DMARC depends on SPF and DKIM to function. Google, Yahoo, and Microsoft all require or strongly recommend all three.
+
+### What happens if email authentication fails? {#faq-fails}
+
+The result depends on your DMARC policy. With `p=none`, nothing happens (the email is delivered normally). With `p=quarantine`, failing emails are sent to the spam folder. With `p=reject`, failing emails are blocked entirely.
+
+### How long does it take to set up email authentication? {#faq-how-long}
+
+The DNS changes take minutes. The DMARC monitoring period (starting at `p=none` and reviewing reports before enforcing) typically takes two to six weeks, depending on how many services send email from your domain.
+
+### Does email authentication prevent all spam and phishing? {#faq-prevent-spam}
+
+It prevents unauthorized senders from using your domain. It does not stop spam or phishing that uses other domains. It also does not guarantee inbox placement - other factors like [sender reputation and content](/articles/understanding-email-deliverability/) also affect delivery.
+
+### What about domains that do not send email? {#faq-non-sending}
+
+Non-sending domains still need protection. Without authentication records, attackers can spoof them for phishing. Configure `v=spf1 -all` (authorize no senders), a DMARC record with `p=reject`, and a [null MX record](/articles/what-are-null-mx-records/) to declare the domain does not accept email.
+
+## Have more questions?
+
+If you have any questions about email authentication, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/email-dns-records-quick-reference.md
+++ b/content/articles/email-dns-records-quick-reference.md
@@ -96,7 +96,7 @@ Content: v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3...
 - Various - Other email services
 
 > [!NOTE]
-> See [Set Up DKIM](/articles/set-up-dkim/) and [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/) for details.
+> See [Set Up DKIM](/articles/set-up-dkim/) and [Manage Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/) for details.
 
 ## DMARC records {#dmarc}
 
@@ -125,7 +125,7 @@ Content: v=DMARC1; p=none; rua=mailto:dmarc@example.com
 - `pct=25` - Apply policy to 25% of emails
 
 > [!NOTE]
-> See [Set Up DMARC](/articles/set-up-dmarc/) and [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for details.
+> See [Set Up DMARC](/articles/set-up-dmarc/) and [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for details.
 
 ## CNAME records for email {#cname}
 

--- a/content/articles/emails.md
+++ b/content/articles/emails.md
@@ -25,6 +25,7 @@ DNSimple provides email forwarding and DNS-based email authentication (SPF, DKIM
 
 ## Email authentication {#authentication}
 
+- [How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)](/articles/email-authentication/) - What email authentication is and how to set up SPF, DKIM, and DMARC.
 - [What Is an SPF Record?](/articles/spf-record/) - How SPF authorizes email senders for your domain.
 - [What Is a DKIM Record?](/articles/dkim-record/) - How DKIM uses digital signatures to verify email authenticity.
 - [What Is a DMARC Record?](/articles/dmarc-record/) - How DMARC ties SPF and DKIM together with a policy.
@@ -72,7 +73,7 @@ DNSimple provides email forwarding and DNS-based email authentication (SPF, DKIM
 
 ### Email deliverability {#deliverability}
 
-- [Understanding Email Deliverability](/articles/understanding-email-deliverability/) - What affects whether your emails reach recipients' inboxes.
+- [Email Deliverability](/articles/understanding-email-deliverability/) - What email deliverability is, why emails end up in spam, and how to fix it.
 - [Improving Email Deliverability](/articles/improving-email-deliverability/) - Configure DNS-based authentication and manage sender reputation.
 - [Monitoring Email Deliverability](/articles/monitoring-email-deliverability/) - Track authentication results, sender reputation, and inbox placement.
 

--- a/content/articles/emails.md
+++ b/content/articles/emails.md
@@ -67,30 +67,30 @@ DNSimple provides email forwarding and DNS-based email authentication (SPF, DKIM
 - [Email Forwarding Not Working with Gmail](/articles/email-forwarding-not-working-gmail/) - Diagnose forwarding problems with Gmail.
 - [Email Forwarding Not Working](/articles/email-forwarding-not-working/) - Resolve email delivery problems with forwarding.
 - [Email Forwarding Not Working with Outlook, Yahoo, and Other Providers](/articles/email-forwarding-not-working-outlook-yahoo/) - Fix forwarding issues with providers other than Gmail.
-- [Troubleshooting Email Authentication](/articles/troubleshooting-email-authentication/) - Diagnose SPF, DKIM, and DMARC failures.
+- [Troubleshoot Email Authentication](/articles/troubleshooting-email-authentication/) - Diagnose SPF, DKIM, and DMARC failures.
 
 ## Advanced topics {#advanced}
 
 ### Email deliverability {#deliverability}
 
 - [Email Deliverability](/articles/understanding-email-deliverability/) - What email deliverability is, why emails end up in spam, and how to fix it.
-- [Improving Email Deliverability](/articles/improving-email-deliverability/) - Configure DNS-based authentication and manage sender reputation.
-- [Monitoring Email Deliverability](/articles/monitoring-email-deliverability/) - Track authentication results, sender reputation, and inbox placement.
+- [Improve Email Deliverability](/articles/improving-email-deliverability/) - Configure DNS-based authentication and manage sender reputation.
+- [Monitor Email Deliverability](/articles/monitoring-email-deliverability/) - Track authentication results, sender reputation, and inbox placement.
 
 ### Advanced authentication {#authentication-advanced}
 
-- [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements and how they affect authentication.
-- [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) - Move safely from `p=none` to `p=reject`.
-- [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/) - Handle DKIM for multiple email services.
+- [SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements and how they affect authentication.
+- [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) - Move safely from `p=none` to `p=reject`.
+- [Manage Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/) - Handle DKIM for multiple email services.
 - [Email Authentication Best Practices](/articles/email-authentication-best-practices/) - Best practices for SPF, DKIM, and DMARC configuration.
 
 ### Email security {#security}
 
-- [Protecting Your Domain from Email Spoofing](/articles/protecting-your-domain-from-email-spoofing/) - How SPF, DKIM, and DMARC prevent domain spoofing.
+- [Email Spoofing Protection](/articles/protecting-your-domain-from-email-spoofing/) - How SPF, DKIM, and DMARC prevent domain spoofing.
 
 ### Email bounces {#bounces}
 
-- [Understanding Email Bounces](/articles/understanding-email-bounces/) - Types of bounces and what causes them.
+- [Email Bounces](/articles/understanding-email-bounces/) - Types of bounces and what causes them.
 - [Email Forwarding and Bounced Emails](/articles/email-forwarding-bounces/) - How bounces work with forwarding and how to handle them.
 
 ### MX records {#mx-records}

--- a/content/articles/implementing-a-gradual-dmarc-policy.md
+++ b/content/articles/implementing-a-gradual-dmarc-policy.md
@@ -1,12 +1,12 @@
 ---
-title: Implementing a Gradual DMARC Policy
+title: Implement a Gradual DMARC Policy
 excerpt: Step-by-step guide to gradually implementing DMARC policies, starting with monitoring and moving to quarantine and reject.
 meta: Learn how to implement DMARC gradually, starting with monitoring, then moving to quarantine, and finally to reject policies safely.
 categories:
 - Emails
 ---
 
-# Implementing a Gradual DMARC Policy
+# Implement a Gradual DMARC Policy
 
 ### Table of Contents {#toc}
 
@@ -278,7 +278,7 @@ Here is a typical timeline for gradual DMARC implementation:
 ## Related articles {#related}
 
 - [Set Up DMARC](/articles/set-up-dmarc/) - Initial DMARC setup
-- [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements
+- [SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements
 
 ## Have more questions?
 

--- a/content/articles/improving-email-deliverability.md
+++ b/content/articles/improving-email-deliverability.md
@@ -1,12 +1,12 @@
 ---
-title: Improving Email Deliverability
+title: Improve Email Deliverability
 excerpt: How to improve email deliverability by configuring DNS-based authentication and managing sender reputation.
-meta: Step-by-step guide to improving email deliverability through SPF, DKIM, and DMARC configuration, sender reputation management, and bounce handling.
+meta: Step-by-step guide to improving email deliverability through SPF, DKIM, and DMARC configuration, sender reputation management, list hygiene, domain warm-up, and content fixes.
 categories:
 - Emails
 ---
 
-# Improving Email Deliverability
+# Improve Email Deliverability
 
 ### Table of Contents {#toc}
 
@@ -17,7 +17,7 @@ categories:
 
 Most deliverability problems trace back to missing or misconfigured DNS records and poor sender reputation. This guide walks through the changes you can make in DNSimple (and alongside your email provider) to improve inbox placement.
 
-For background on what deliverability is and why it matters, see [Understanding Email Deliverability](/articles/understanding-email-deliverability/).
+For background on what deliverability is and why it matters, see [Email Deliverability](/articles/understanding-email-deliverability/).
 
 ## Before starting
 
@@ -29,7 +29,7 @@ You will need:
 
 ## Set up email authentication {#authentication}
 
-Proper authentication is the single most impactful thing you can do for deliverability. Mailbox providers use SPF, DKIM, and DMARC to decide whether incoming mail is legitimate.
+Proper [email authentication](/articles/email-authentication/) is the single most impactful thing you can do for deliverability. Mailbox providers use SPF, DKIM, and DMARC to decide whether incoming mail is legitimate.
 
 ### Configure SPF {#spf}
 
@@ -65,7 +65,7 @@ A [DKIM record](/articles/dkim-record/) publishes a public key that receiving se
 1. Verify the record is published: see [Verify DKIM](/articles/verify-dkim/).
 </div>
 
-Repeat this for each service that sends email on your behalf. Each service typically uses its own selector. See [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/) if you have more than one.
+Repeat this for each service that sends email on your behalf. Each service typically uses its own selector. See [Manage Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/) if you have more than one.
 
 For full setup details, see [Set Up DKIM](/articles/set-up-dkim/).
 
@@ -80,14 +80,14 @@ A [DMARC record](/articles/dmarc-record/) tells receiving servers what to do whe
 1. Add a TXT record at `_dmarc.yourdomain.com`.
 1. Start with a monitoring-only policy: `v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com`
 1. Review the aggregate reports you receive over the following weeks. Fix any authentication failures before tightening the policy.
-1. Gradually move to `p=quarantine`, then `p=reject`. See [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
+1. Gradually move to `p=quarantine`, then `p=reject`. See [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
 1. Verify the record is published: see [Verify DMARC](/articles/verifying-dmarc/).
 </div>
 
 > [!TIP]
 > DMARC aggregate reports are XML files that are difficult to read raw. Services like [dmarcian](https://dmarcian.com/) and [Postmark DMARC](https://dmarc.postmarkapp.com/) parse them into readable dashboards for free.
 
-For alignment requirements between SPF, DKIM, and DMARC, see [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/).
+For alignment requirements between SPF, DKIM, and DMARC, see [SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/).
 
 ## Manage sender reputation {#reputation}
 
@@ -110,11 +110,10 @@ If your domain or sending IP is on a blacklist, deliverability drops significant
 
 ### Reduce bounce rates {#bounces}
 
-High [bounce rates](/articles/understanding-email-bounces/) - especially hard bounces - are one of the fastest ways to damage sender reputation.
+High [bounce rates](/articles/understanding-email-bounces/) are one of the fastest ways to damage sender reputation. Keep your overall bounce rate below 2% and hard bounces below 0.5%.
 
-- Remove hard-bounce addresses from your list immediately. These are permanent failures (invalid address, domain does not exist) that will never succeed.
 - Investigate persistent soft bounces (mailbox full, server temporarily unavailable). If an address soft-bounces repeatedly, treat it as a hard bounce.
-- Keep your overall bounce rate below 2% and hard bounces below 0.5%.
+- See [Clean your email list](#list-hygiene) for practices that prevent bounces from accumulating.
 
 ### Reduce spam complaints {#complaints}
 
@@ -123,6 +122,37 @@ Mailbox providers weigh spam complaints heavily. Keep your complaint rate below 
 - Only send to recipients who opted in.
 - Make the unsubscribe link easy to find and honor it immediately.
 - If you see a spike in complaints after a specific campaign, review what changed.
+
+## Clean your email list {#list-hygiene}
+
+Sending to invalid or unengaged addresses inflates bounce rates and spam complaints, which directly damage sender reputation.
+
+- **Use double opt-in** for new subscribers. This confirms valid addresses and reduces the chance of spam trap hits.
+- **Remove hard-bounce addresses immediately.** These are permanent failures that will never succeed. Most email service providers do this automatically.
+- **Sunset inactive subscribers.** If a recipient has not opened or clicked in 6 to 12 months, remove them or move them to a re-engagement campaign.
+- **Never use purchased or scraped email lists.** These contain invalid addresses and spam traps that will damage your reputation quickly.
+
+## Warm up new domains and IPs {#warm-up}
+
+New domains and IP addresses have no sending history. Mailbox providers treat unknown senders with caution and are more likely to filter their email as spam.
+
+Ramp up sending volume gradually:
+
+- Start with your most engaged recipients (people who regularly open and click).
+- Increase daily volume by 20-50% per week.
+- Monitor bounce rates and spam complaints at each stage. Pause if either spikes.
+- Ensure [email authentication](/articles/email-authentication/) is fully configured before sending the first message.
+
+A warm-up period typically takes two to four weeks for a new domain and four to eight weeks for a new dedicated IP.
+
+## Fix content and sending patterns {#content}
+
+Content is less impactful than authentication and reputation, but can still cause spam filtering.
+
+- **Include a visible unsubscribe link** in every marketing email. Google and Yahoo require one-click unsubscribe for bulk senders.
+- **Avoid sudden volume spikes.** If you need to send a large campaign, spread it over multiple days.
+- **Use a consistent `From:` name and address** so recipients recognize your email.
+- **Test before sending.** Tools like [Mail Tester](https://www.mail-tester.com/) check your message against common spam filters and flag content-level issues.
 
 ## Troubleshoot common problems {#troubleshooting}
 
@@ -141,15 +171,11 @@ If authentication passes for some messages but fails for others:
 
 1. Verify all sending services are included in your SPF record. A forgotten service (e.g., a CRM that sends on your behalf) causes SPF failures for those messages.
 2. Check that DKIM is configured for each sending service, not just your primary email provider.
-3. Review DMARC aggregate reports to identify which source IPs or services are failing. See [Monitoring Email Deliverability](/articles/monitoring-email-deliverability/) for guidance on interpreting reports.
+3. Review DMARC aggregate reports to identify which source IPs or services are failing. See [Monitor Email Deliverability](/articles/monitoring-email-deliverability/) for guidance on interpreting reports.
 
 ### High bounce rates on a new domain
 
-New domains have no sending history, so mailbox providers are cautious:
-
-1. Start with low volume and increase gradually over several weeks.
-2. Send to your most engaged recipients first to build positive engagement signals.
-3. Ensure authentication is fully configured before sending the first message.
+See [Warm up new domains and IPs](#warm-up). New domains have no sending history, so mailbox providers are more likely to filter or reject messages. Ramp volume gradually and start with engaged recipients.
 
 ## Have more questions?
 

--- a/content/articles/managing-email-dns-records.md
+++ b/content/articles/managing-email-dns-records.md
@@ -70,7 +70,7 @@ v=spf1 include:_spf.google.com include:spf.mtasv.net ~all
 1. If you use multiple email services, each one may require its own selector. Add a separate record for each.
 
 > [!NOTE]
-> For detailed DKIM setup, see [Set Up DKIM](/articles/set-up-dkim/) and [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
+> For detailed DKIM setup, see [Set Up DKIM](/articles/set-up-dkim/) and [Manage Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
 
 ## DMARC records {#dmarc}
 
@@ -85,7 +85,7 @@ v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com
 ```
 
 > [!NOTE]
-> For detailed DMARC setup, see [Set Up DMARC](/articles/set-up-dmarc/) and [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
+> For detailed DMARC setup, see [Set Up DMARC](/articles/set-up-dmarc/) and [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
 
 ## CNAME records for email services {#cname}
 

--- a/content/articles/managing-multiple-dkim-selectors.md
+++ b/content/articles/managing-multiple-dkim-selectors.md
@@ -1,12 +1,12 @@
 ---
-title: Managing Multiple DKIM Selectors
+title: Manage Multiple DKIM Selectors
 excerpt: How to manage multiple DKIM selectors for different email services and ensure proper email authentication.
 meta: Guide to managing multiple DKIM selectors when using different email services, ensuring proper authentication for all email sources.
 categories:
 - Emails
 ---
 
-# Managing Multiple DKIM Selectors
+# Manage Multiple DKIM Selectors
 
 ### Table of Contents {#toc}
 
@@ -247,7 +247,7 @@ If an email service changes their DKIM selector:
 ## Related articles {#related}
 
 - [Set Up DKIM](/articles/set-up-dkim/) - Initial DKIM setup
-- [Understanding SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements
+- [SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements
 - [Set Up DMARC](/articles/set-up-dmarc/) - DMARC configuration
 
 ## Have more questions?

--- a/content/articles/monitoring-email-deliverability.md
+++ b/content/articles/monitoring-email-deliverability.md
@@ -1,12 +1,12 @@
 ---
-title: Monitoring Email Deliverability
+title: Monitor Email Deliverability
 excerpt: How to monitor email authentication, sender reputation, and deliverability using free tools and DMARC reports.
 meta: Guide to monitoring email deliverability by tracking DMARC reports, sender reputation, blacklist status, and authentication pass rates with free tools.
 categories:
 - Emails
 ---
 
-# Monitoring Email Deliverability
+# Monitor Email Deliverability
 
 ### Table of Contents {#toc}
 
@@ -17,7 +17,7 @@ categories:
 
 Deliverability problems are easier to fix when you catch them early. Regular monitoring of authentication status, sender reputation, and bounce rates helps you identify issues before they damage your domain's reputation with mailbox providers.
 
-For background on the factors that affect deliverability, see [Understanding Email Deliverability](/articles/understanding-email-deliverability/).
+For background on the factors that affect deliverability, see [Email Deliverability](/articles/understanding-email-deliverability/).
 
 ## Monitor authentication with DMARC reports {#dmarc-reports}
 
@@ -47,7 +47,7 @@ Raw DMARC reports are XML files that are difficult to read manually. Use a parsi
 - **Unexpected source IPs** - These may indicate a service you forgot to authorize, or someone spoofing your domain. Cross-reference with your SPF record.
 - **SPF failures from legitimate services** - A service sending on your behalf is missing from your SPF `include:` list. Add it. See [Set Up SPF Records](/articles/setting-up-spf/).
 - **DKIM failures** - The sending service may not have DKIM enabled, or the DNS record may be missing or incorrect. See [Set Up DKIM](/articles/set-up-dkim/).
-- **High failure rates after a policy change** - If you recently moved from `p=none` to `p=quarantine` or `p=reject`, failures you previously ignored now affect delivery. Review and fix before tightening further. See [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
+- **High failure rates after a policy change** - If you recently moved from `p=none` to `p=quarantine` or `p=reject`, failures you previously ignored now affect delivery. Review and fix before tightening further. See [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
 
 ## Monitor sender reputation {#reputation}
 
@@ -111,7 +111,7 @@ High bounce rates damage sender reputation quickly. Your email service provider'
 
 A sudden increase in hard bounces usually means a batch of invalid addresses entered your list. A gradual increase in soft bounces may indicate recipient server issues or sending volume problems.
 
-For more on bounce types and handling, see [Understanding Email Bounces](/articles/understanding-email-bounces/).
+For more on bounce types and handling, see [Email Bounces](/articles/understanding-email-bounces/).
 
 ## Set up a monitoring routine {#routine}
 

--- a/content/articles/protecting-your-domain-from-email-spoofing.md
+++ b/content/articles/protecting-your-domain-from-email-spoofing.md
@@ -1,12 +1,12 @@
 ---
-title: Protecting Your Domain from Email Spoofing
+title: Email Spoofing Protection
 excerpt: What email spoofing is, how attackers exploit it, and how SPF, DKIM, and DMARC work together to stop it.
 meta: How email spoofing works, what damage it causes, and how to protect your domain using SPF, DKIM, and DMARC authentication records in DNS.
 categories:
 - Emails
 ---
 
-# Protecting Your Domain from Email Spoofing
+# Email Spoofing Protection
 
 ### Table of Contents {#toc}
 
@@ -55,11 +55,11 @@ A `p=reject` policy is the strongest protection against spoofing. It tells recei
 
 ## Setting up protection {#setup}
 
-Configuring all three protocols requires adding TXT records in DNS. DNSimple's [Record Editor](/articles/record-editor/) handles all of them. The dedicated setup guides walk through each one:
+Configuring all three protocols requires adding TXT records in DNS. [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/) walks through the full process. The dedicated setup guides cover each protocol individually:
 
 1. **SPF** - [Set Up SPF Records](/articles/setting-up-spf/) covers listing all authorized senders and staying under the 10-lookup limit.
-2. **DKIM** - [Set Up DKIM](/articles/set-up-dkim/) covers adding the public key for each email service. If you use multiple services, see [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
-3. **DMARC** - [Set Up DMARC](/articles/set-up-dmarc/) covers publishing a policy and setting up reporting. Start with `p=none` and tighten gradually - see [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
+2. **DKIM** - [Set Up DKIM](/articles/set-up-dkim/) covers adding the public key for each email service. If you use multiple services, see [Manage Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
+3. **DMARC** - [Set Up DMARC](/articles/set-up-dmarc/) covers publishing a policy and setting up reporting. Start with `p=none` and tighten gradually - see [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/).
 
 > [!WARNING]
 > Do not jump straight to `p=reject` without monitoring first. A misconfigured SPF or missing DKIM selector can cause your own legitimate email to be blocked. Start with `p=none`, review DMARC reports for several weeks, fix any issues, then move to `p=quarantine` and finally `p=reject`.

--- a/content/articles/spf-record.md
+++ b/content/articles/spf-record.md
@@ -45,7 +45,7 @@ This mechanism allows you, the domain owner, to explicitly declare your sending 
 
 **Enhances domain reputation:** Helps maintain a positive sending reputation for your domain, which is crucial for overall email success.
 
-SPF is often used as part of a comprehensive email authentication strategy. It works in conjunction with [DKIM](/articles/dkim-record/) (DomainKeys Identified Mail) and [DMARC](/articles/dmarc-record/) (Domain-based Message Authentication, Reporting & Conformance) to provide robust email security.
+SPF is one of three protocols that make up [email authentication](/articles/email-authentication/). It works in conjunction with [DKIM](/articles/dkim-record/) (DomainKeys Identified Mail) and [DMARC](/articles/dmarc-record/) (Domain-based Message Authentication, Reporting & Conformance) to provide robust email security.
 
 ## Creating, managing, and validating SPF records {#creating-managing-and-validating-spf-records}
 For step-by-step instructions on how to create, edit, or remove SPF records in your DNSimple zone, refer to [Set Up SPF Records](/articles/setting-up-spf/).

--- a/content/articles/troubleshooting-email-authentication.md
+++ b/content/articles/troubleshooting-email-authentication.md
@@ -1,12 +1,12 @@
 ---
-title: Troubleshooting Email Authentication
+title: Troubleshoot Email Authentication
 excerpt: How to diagnose SPF, DKIM, and DMARC failures using email headers and DNS verification.
 meta: Diagnose email authentication failures by reading email headers, identifying SPF, DKIM, and DMARC issues, and resolving common problems like alignment failures and missing records.
 categories:
 - Emails
 ---
 
-# Troubleshooting Email Authentication
+# Troubleshoot Email Authentication
 
 ### Table of Contents {#toc}
 
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-When email authentication fails, messages may be rejected, sent to spam, or flagged as suspicious. The fastest way to find the root cause is to check the email headers, identify which protocol is failing, then verify the corresponding DNS record.
+When [email authentication](/articles/email-authentication/) fails, messages may be rejected, sent to spam, or flagged as suspicious. The fastest way to find the root cause is to check the email headers, identify which protocol is failing, then verify the corresponding DNS record.
 
 ## Reading email headers {#headers}
 
@@ -86,7 +86,7 @@ The impact of a DMARC failure depends on your published policy:
 - `p=quarantine` - Failing messages are sent to spam.
 - `p=reject` - Failing messages are blocked entirely.
 
-If legitimate email is being blocked or sent to spam, your DMARC policy may be stricter than your authentication setup supports. See [Implementing a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for how to move safely from `p=none` to `p=reject`.
+If legitimate email is being blocked or sent to spam, your DMARC policy may be stricter than your authentication setup supports. See [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for how to move safely from `p=none` to `p=reject`.
 
 To confirm your DMARC record is published correctly, see [Verify DMARC with dig and Online Tools](/articles/verifying-dmarc/).
 

--- a/content/articles/understanding-email-bounces.md
+++ b/content/articles/understanding-email-bounces.md
@@ -1,12 +1,12 @@
 ---
-title: Understanding Email Bounces
+title: Email Bounces
 excerpt: About email bounces, the different types of bounces, and what causes them.
 meta: Learn about email bounces, including hard bounces, soft bounces, DSN codes, and how to handle them.
 categories:
 - Emails
 ---
 
-# Understanding Email Bounces
+# Email Bounces
 
 ### Table of Contents {#toc}
 

--- a/content/articles/understanding-email-deliverability.md
+++ b/content/articles/understanding-email-deliverability.md
@@ -1,6 +1,6 @@
 ---
 title: "Email Deliverability: How to Get Your Emails to the Inbox"
-excerpt: What email deliverability is, why emails end up in spam, and how to fix it through DNS authentication, sender reputation, and list management.
+excerpt: What email deliverability is, why emails end up in spam, and the factors that determine inbox placement.
 meta: Email deliverability is the ability to land emails in recipients' inboxes rather than spam folders. Learn how DNS authentication (SPF, DKIM, DMARC), sender reputation, list hygiene, and sending patterns determine inbox placement.
 categories:
 - Emails
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-Email deliverability is the ability to land emails in recipients' inboxes rather than spam folders. It is not the same as email delivery (whether the message reached the mail server at all). An email can be successfully delivered to a mail server and still end up in spam. Deliverability is determined by DNS authentication, sender reputation, list quality, and sending patterns.
+Email deliverability is the ability to land emails in recipients' inboxes rather than spam folders. An email can be successfully delivered to a mail server and still end up in spam. Deliverability depends on DNS authentication, sender reputation, list quality, and sending patterns.
 
 ## What is email deliverability? {#what-is}
 
@@ -26,9 +26,9 @@ Email deliverability measures how consistently your emails reach the inbox inste
 These two terms describe different things:
 
 - **Email delivery** - Whether the email reached the recipient's mail server. A delivery failure is a [bounce](/articles/understanding-email-bounces/) (the server rejected the message entirely).
-- **Email deliverability** - Whether the email reached the inbox rather than the spam folder. A delivered email can still have poor deliverability if it lands in spam.
+- **Email deliverability** - Whether the email reached the inbox rather than the spam folder.
 
-A 99% delivery rate means almost no bounces. It says nothing about how many of those delivered emails actually reached the inbox.
+A 99% delivery rate means almost no bounces. It says nothing about how many of those delivered emails reached the inbox.
 
 ### What is a good deliverability rate? {#good-rate}
 
@@ -45,29 +45,29 @@ Most email service providers show delivery and bounce rates in their dashboards.
 
 ## Why emails end up in spam {#why-spam}
 
-Emails land in spam for specific, diagnosable reasons. The most common causes, in order of impact:
+Emails land in spam for specific, diagnosable reasons. These are the most common causes, in order of impact.
 
 ### Missing or broken email authentication {#spam-authentication}
 
-If your domain does not have [SPF](/articles/spf-record/), [DKIM](/articles/dkim-record/), and [DMARC](/articles/dmarc-record/) records configured, or if they are misconfigured, mailbox providers have no way to verify that your email is legitimate. This is the single most common cause of deliverability problems for domains managed through DNS.
+If your domain does not have [SPF](/articles/spf-record/), [DKIM](/articles/dkim-record/), and [DMARC](/articles/dmarc-record/) configured correctly, mailbox providers have no way to verify that your email is legitimate. This is the single most common cause of deliverability problems for domains managed through DNS.
 
-Since February 2024, Google and Yahoo require SPF, DKIM, and DMARC for bulk senders. Microsoft Outlook enforced similar requirements starting May 2025. Missing records can result in outright rejection, not just spam placement.
+Since February 2024, Google and Yahoo require SPF, DKIM, and DMARC for bulk senders. Microsoft Outlook enforced similar requirements starting May 2025. Missing records can result in outright rejection.
 
-See [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/) for the full setup process.
+To configure authentication, see [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/).
 
 ### Poor sender reputation {#spam-reputation}
 
 Mailbox providers assign a reputation score to your domain and sending IP based on historical behavior. Factors that damage reputation:
 
-- High bounce rates (sending to invalid addresses)
+- High bounce rates from sending to invalid addresses
 - Spam complaints from recipients
 - Sending to spam trap addresses
 - Sudden volume spikes from a domain with little sending history
-- Appearing on a public blacklist (e.g., Spamhaus, Barracuda)
+- Appearing on a public blacklist (Spamhaus, Barracuda)
 
 ### Dirty email lists {#spam-list}
 
-Sending to outdated, purchased, or unverified email lists inflates bounce rates and spam complaints, which directly damages reputation.
+Sending to outdated, purchased, or unverified email lists inflates bounce rates and spam complaints. Both directly damage sender reputation.
 
 ### Content triggers {#spam-content}
 
@@ -79,107 +79,43 @@ Spam-triggering content is less impactful than authentication and reputation, bu
 - Broken HTML
 - Missing unsubscribe link
 
-## How to improve email deliverability {#improve}
+### Email forwarding {#spam-forwarding}
 
-Address these areas in priority order. DNS authentication is the foundation - fix it first.
+When email is forwarded, the forwarding server's IP replaces the original sender's IP. This causes SPF to fail because the forwarding server is not in the original sender's SPF record. DKIM signatures survive forwarding (they are part of the message), which is one reason DKIM is essential alongside SPF.
 
-### 1. Set up email authentication {#improve-authentication}
+For forwarding-specific issues, see [Email Forwarding Not Working](/articles/email-forwarding-not-working/).
 
-Configure all three DNS-based authentication protocols:
+## How DNS affects email deliverability {#dns}
 
-- **[Set Up SPF Records](/articles/setting-up-spf/)** - Authorize every service that sends email for your domain in a single TXT record.
-- **[Set Up DKIM](/articles/set-up-dkim/)** - Add a DKIM public key for each sending service at its designated selector subdomain.
-- **[Set Up DMARC](/articles/set-up-dmarc/)** - Publish a policy record and enable reporting. Start with `p=none` (monitoring), then move to enforcement.
+DNS is where email deliverability starts. Every authentication signal that mailbox providers check is a DNS record:
 
-For a full walkthrough of the authentication setup process, see [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/).
+- **[SPF records](/articles/spf-record/)** tell receiving servers which IPs are authorized to send for your domain.
+- **[DKIM records](/articles/dkim-record/)** publish the public keys that verify message signatures.
+- **[DMARC records](/articles/dmarc-record/)** define the policy for handling authentication failures.
+- **[MX records](/articles/mx-record/)** route email to the correct servers.
 
-### 2. Check and protect sender reputation {#improve-reputation}
+Incorrect, missing, or slow-to-propagate DNS records are behind a large share of deliverability problems. A common pattern: a domain owner adds a new email service but forgets to update the SPF record. Emails from that service fail authentication, deliverability drops, and the symptom is "my emails are going to spam."
 
-Use these free tools to assess your current standing:
-
-- [Google Postmaster Tools](https://postmaster.google.com/) - Gmail-specific reputation, spam rate, and authentication data.
-- [Microsoft SNDS](https://sendersupport.olc.protection.outlook.com/snds/) - Outlook/Hotmail IP reputation and complaint data.
-- [Sender Score](https://www.senderscore.org/) - General reputation score (0-100) across multiple providers.
-- [MXToolbox Blacklist Check](https://mxtoolbox.com/blacklists.aspx) - Scan your domain against dozens of blacklists.
-
-If your domain or IP is on a blacklist, fix the underlying issue (compromised account, spam complaints, poor list hygiene), then submit a removal request to the blacklist operator.
-
-### 3. Clean your email list {#improve-list}
-
-- Remove hard-bounce addresses immediately. These are permanent failures that will never succeed.
-- Use double opt-in for new subscribers to confirm valid addresses.
-- Sunset inactive subscribers who have not opened or clicked in 6 to 12 months.
-- Never use purchased or scraped email lists.
-
-### 4. Warm up new domains and IPs {#improve-warmup}
-
-New domains and IP addresses have no sending history. Mailbox providers treat unknown senders with caution. Ramp up sending volume gradually over several weeks:
-
-- Start with your most engaged recipients (people who regularly open and click).
-- Increase daily volume by 20-50% per week.
-- Monitor bounce rates and spam complaints at each stage. Pause if either spikes.
-- Ensure authentication is fully configured before sending the first message.
-
-### 5. Fix content and sending patterns {#improve-content}
-
-- Include a visible, functional unsubscribe link in every marketing email. Google and Yahoo require one-click unsubscribe for bulk senders.
-- Avoid sudden volume spikes. If you need to send a large campaign, spread it over multiple days.
-- Use a consistent `From:` name and address so recipients recognize your email.
-- Test emails with a tool like [Mail Tester](https://www.mail-tester.com/) to catch content-level issues before sending.
-
-For detailed, step-by-step implementation, see [Improving Email Deliverability](/articles/improving-email-deliverability/).
-
-## How to measure email deliverability {#measure}
-
-### Monitor authentication results {#measure-authentication}
-
-Publish a [DMARC record](/articles/dmarc-record/) with a `rua=` reporting address. Mailbox providers will send daily aggregate reports showing which IPs sent email as your domain and whether they passed SPF and DKIM.
-
-Raw DMARC reports are XML files. Services like [dmarcian](https://dmarcian.com/) and [Postmark DMARC Digests](https://dmarc.postmarkapp.com/) parse them into readable dashboards.
-
-### Track reputation over time {#measure-reputation}
-
-Check Google Postmaster Tools weekly for:
-
-- **Domain reputation** trending (High, Medium, Low, Bad)
-- **Spam rate** (keep below 0.1%)
-- **Authentication pass rates** for SPF, DKIM, and DMARC
-
-### Watch bounce and complaint rates {#measure-bounces}
-
-Your email service provider's dashboard shows bounce rates and complaint rates. A sudden increase in hard bounces usually means invalid addresses entered your list. A spike in complaints often follows a content or frequency change.
-
-For a full monitoring routine with schedules and tool recommendations, see [Monitoring Email Deliverability](/articles/monitoring-email-deliverability/).
+DNSimple manages these records alongside everything else your domain needs.
 
 ## Common email deliverability problems {#problems}
 
 ### Why are my emails going to spam even though authentication passes? {#problem-spam-despite-auth}
 
-Authentication is necessary but not sufficient. If SPF, DKIM, and DMARC all pass but email still lands in spam, check:
-
-1. Domain and IP reputation with [Google Postmaster Tools](https://postmaster.google.com/) and [MXToolbox](https://mxtoolbox.com/blacklists.aspx).
-2. Spam complaint rate. Anything above 0.1% is problematic.
-3. Email content for spam triggers (excessive images, misleading subjects, missing unsubscribe link).
-4. Whether your DMARC policy is still `p=none`. Some providers treat unenforced DMARC as a weaker trust signal.
+Authentication is necessary but not sufficient. If SPF, DKIM, and DMARC all pass but email still lands in spam, the cause is usually reputation or content. Check your domain reputation with [Google Postmaster Tools](https://postmaster.google.com/), scan for blacklisting with [MXToolbox](https://mxtoolbox.com/blacklists.aspx), and review your spam complaint rate.
 
 ### Why did my deliverability drop suddenly? {#problem-sudden-drop}
 
-Common causes of a sudden drop:
+Common causes:
 
-- A sending service was removed from or never added to your SPF record.
-- A DKIM key was rotated by your email provider but the DNS record was not updated.
-- Your domain or IP was added to a blacklist after a spam complaint spike.
-- A large send to a stale list caused a bounce rate spike.
+- A sending service was removed from or never added to your SPF record
+- A DKIM key was rotated by your email provider but the DNS record was not updated
+- Your domain or IP was added to a blacklist after a spam complaint spike
+- A large send to a stale list caused a bounce rate spike
 
-### Does email forwarding affect deliverability? {#problem-forwarding}
+### Do I need a dedicated IP address for good deliverability? {#problem-dedicated-ip}
 
-Yes. When email is forwarded, the forwarding server's IP replaces the original sender's IP. This causes SPF to fail because the forwarding server is not in the original sender's SPF record. DKIM signatures survive forwarding (they are part of the message itself), which is one reason DKIM is essential alongside SPF.
-
-For forwarding-specific issues, see [Email Forwarding Not Working](/articles/email-forwarding-not-working/).
-
-### Does DNS affect email deliverability? {#problem-dns}
-
-DNS is where email deliverability starts. SPF, DKIM, and DMARC are all DNS TXT records. MX records route email to the correct servers. Incorrect, missing, or slow-to-propagate DNS records are behind a large share of deliverability problems. DNSimple manages these records alongside everything else your domain needs.
+Not necessarily. Shared IPs from reputable email service providers carry the provider's collective reputation, which is usually good. Dedicated IPs make sense for high-volume senders (100,000+ emails per month) who want full control over their IP reputation, but they require proper warm-up.
 
 ## Frequently asked questions {#faq}
 
@@ -189,19 +125,21 @@ Email delivery is whether the message reached the recipient's mail server (not b
 
 ### How long does it take to fix deliverability problems? {#faq-how-long}
 
-DNS authentication changes (SPF, DKIM, DMARC) take effect within minutes to hours after the records propagate. Reputation recovery takes longer - typically two to four weeks of consistent, clean sending after fixing the underlying issue. Severe reputation damage or blacklisting can take longer.
-
-### Do I need a dedicated IP address for good deliverability? {#faq-dedicated-ip}
-
-Not necessarily. Shared IPs from reputable email service providers (Google Workspace, Postmark, SendGrid) carry the provider's collective reputation, which is usually good. Dedicated IPs make sense for high-volume senders (100,000+ emails per month) who want full control over their IP reputation, but they require proper warm-up.
+DNS authentication changes take effect within minutes to hours after the records propagate. Reputation recovery takes longer - typically two to four weeks of consistent, clean sending after fixing the underlying issue.
 
 ### Can email content alone cause deliverability problems? {#faq-content}
 
-Content is a factor, but it is rarely the primary cause. Authentication failures and poor sender reputation have a much larger impact than content. Fix authentication and reputation first, then address content triggers if problems persist.
+Content is a factor, but it is rarely the primary cause. Authentication failures and poor sender reputation have a much larger impact. Fix authentication and reputation first.
 
 ### Does DNSimple send email? {#faq-dnsimple}
 
-DNSimple does not provide email hosting or send email on your behalf. DNSimple manages the DNS records (SPF, DKIM, DMARC, MX) that email authentication and routing depend on. Your email service provider handles the actual sending.
+DNSimple does not provide email hosting or send email on your behalf. DNSimple manages the DNS records that email authentication and routing depend on. Your email service provider handles the actual sending.
+
+## Next steps {#next-steps}
+
+- [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/) - Configure SPF, DKIM, and DMARC
+- [Improve Email Deliverability](/articles/improving-email-deliverability/) - Step-by-step actions to improve inbox placement
+- [Monitor Email Deliverability](/articles/monitoring-email-deliverability/) - Tools and routines for tracking deliverability over time
 
 ## Have more questions?
 

--- a/content/articles/understanding-email-deliverability.md
+++ b/content/articles/understanding-email-deliverability.md
@@ -1,12 +1,12 @@
 ---
-title: Understanding Email Deliverability
-excerpt: What email deliverability is, why it matters, and how DNS-based authentication affects whether your emails reach recipients' inboxes.
-meta: Understand email deliverability and the DNS-based factors - SPF, DKIM, DMARC, and sender reputation - that determine whether your emails reach recipients' inboxes or end up in spam folders.
+title: "Email Deliverability: How to Get Your Emails to the Inbox"
+excerpt: What email deliverability is, why emails end up in spam, and how to fix it through DNS authentication, sender reputation, and list management.
+meta: Email deliverability is the ability to land emails in recipients' inboxes rather than spam folders. Learn how DNS authentication (SPF, DKIM, DMARC), sender reputation, list hygiene, and sending patterns determine inbox placement.
 categories:
 - Emails
 ---
 
-# Understanding Email Deliverability
+# Email Deliverability: How to Get Your Emails to the Inbox
 
 ### Table of Contents {#toc}
 
@@ -15,66 +15,194 @@ categories:
 
 ---
 
-Email deliverability is the measure of how successfully emails reach recipients' inboxes rather than being filtered as spam, rejected, or lost in transit. It depends on several DNS-backed signals that mailbox providers evaluate when deciding where to place incoming mail.
+Email deliverability is the ability to land emails in recipients' inboxes rather than spam folders. It is not the same as email delivery (whether the message reached the mail server at all). An email can be successfully delivered to a mail server and still end up in spam. Deliverability is determined by DNS authentication, sender reputation, list quality, and sending patterns.
 
-## Deliverability vs. delivery {#deliverability-vs-delivery}
+## What is email deliverability? {#what-is}
 
-These two terms are often confused:
+Email deliverability measures how consistently your emails reach the inbox instead of being filtered as spam, rejected, or lost. Mailbox providers like Gmail, Outlook, and Yahoo evaluate every incoming message against a set of signals before deciding where to place it.
 
-- **Email delivery** refers to whether an email reaches the recipient's mail server at all (i.e., it was not bounced).
-- **Email deliverability** refers to whether it reaches the inbox rather than the spam folder. Deliverability is the broader concept and includes reputation, authentication, and content factors.
+### Delivery vs. deliverability {#delivery-vs-deliverability}
 
-A high delivery rate (few bounces) does not guarantee good deliverability. Emails can be delivered to the mail server but still land in spam.
+These two terms describe different things:
 
-## Factors that affect deliverability {#factors}
+- **Email delivery** - Whether the email reached the recipient's mail server. A delivery failure is a [bounce](/articles/understanding-email-bounces/) (the server rejected the message entirely).
+- **Email deliverability** - Whether the email reached the inbox rather than the spam folder. A delivered email can still have poor deliverability if it lands in spam.
 
-### Email authentication {#authentication}
+A 99% delivery rate means almost no bounces. It says nothing about how many of those delivered emails actually reached the inbox.
 
-Mailbox providers check whether incoming email passes DNS-based authentication. Three protocols work together:
+### What is a good deliverability rate? {#good-rate}
 
-- **[SPF (Sender Policy Framework)](/articles/spf-record/)** - A TXT record that lists which servers are authorized to send email for your domain. Receiving servers compare the sending IP against this list.
-- **[DKIM (DomainKeys Identified Mail)](/articles/dkim-record/)** - A TXT record containing a public key. The sending server signs each message with the corresponding private key, and the receiving server verifies the signature.
-- **[DMARC (Domain-based Message Authentication, Reporting & Conformance)](/articles/dmarc-record/)** - A TXT record that tells receiving servers what to do when SPF or DKIM checks fail and where to send reports about authentication results.
+Industry benchmarks vary, but general thresholds are:
 
-When all three are configured correctly and [aligned](/articles/understanding-spf-dkim-dmarc-alignment/), mailbox providers have strong evidence that the email is legitimate.
+| Metric | Healthy | Needs attention |
+|---|---|---|
+| Inbox placement rate | Above 90% | Below 85% |
+| Spam complaint rate | Below 0.1% | 0.1% or higher |
+| Hard bounce rate | Below 0.5% | 0.5% or higher |
+| Total bounce rate | Below 2% | 2% or higher |
 
-> [!NOTE]
-> For a walkthrough of configuring all three protocols, see [Email Authentication Best Practices](/articles/email-authentication-best-practices/).
+Most email service providers show delivery and bounce rates in their dashboards. Inbox placement rate requires additional tools like [Google Postmaster Tools](https://postmaster.google.com/) or seed-list testing.
 
-### Sender reputation {#reputation}
+## Why emails end up in spam {#why-spam}
 
-Mailbox providers (Gmail, Outlook, Yahoo, etc.) assign a reputation score to your domain and sending IP based on historical behavior:
+Emails land in spam for specific, diagnosable reasons. The most common causes, in order of impact:
 
-- **Bounce rates** - A high rate of [hard bounces](/articles/understanding-email-bounces/) signals a poorly maintained list and lowers reputation.
-- **Spam complaints** - Recipients marking your email as spam directly hurts reputation. Most providers consider anything above 0.1% (1 per 1,000 emails) problematic.
-- **Engagement** - Whether recipients open, click, or reply to your messages also factors in. Low engagement can push future messages toward spam.
-- **Blacklists** - If your domain or sending IP appears on a public blacklist (e.g., Spamhaus, Barracuda), deliverability drops significantly.
+### Missing or broken email authentication {#spam-authentication}
 
-### Content and sending patterns {#content}
+If your domain does not have [SPF](/articles/spf-record/), [DKIM](/articles/dkim-record/), and [DMARC](/articles/dmarc-record/) records configured, or if they are misconfigured, mailbox providers have no way to verify that your email is legitimate. This is the single most common cause of deliverability problems for domains managed through DNS.
 
-These factors are outside the scope of DNS, but they interact with authentication and reputation:
+Since February 2024, Google and Yahoo require SPF, DKIM, and DMARC for bulk senders. Microsoft Outlook enforced similar requirements starting May 2025. Missing records can result in outright rejection, not just spam placement.
 
-- Spam-triggering words, excessive images, or broken HTML can hurt inbox placement even when authentication passes.
-- Sudden spikes in sending volume can trigger spam filters, especially from a new or low-volume domain.
-- Sending to invalid addresses inflates bounce rates, which damages reputation over time.
+See [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/) for the full setup process.
 
-## How DNSimple helps with deliverability {#dnsimple}
+### Poor sender reputation {#spam-reputation}
 
-DNSimple is not a mailbox provider and does not send email on your behalf, but deliverability depends heavily on DNS records that DNSimple manages:
+Mailbox providers assign a reputation score to your domain and sending IP based on historical behavior. Factors that damage reputation:
 
-- **SPF records** - Use the [Record Editor](/articles/record-editor/) to publish a TXT record listing your authorized senders. See [Set Up SPF Records](/articles/setting-up-spf/).
-- **DKIM records** - Add the public key your email provider gives you as a TXT record at the appropriate selector. See [Set Up DKIM](/articles/set-up-dkim/).
-- **DMARC records** - Publish a policy record at `_dmarc.yourdomain.com` to control how authentication failures are handled. See [Set Up DMARC](/articles/set-up-dmarc/).
-- **MX records** - Correct MX configuration ensures mail is routed to the right servers in the first place.
+- High bounce rates (sending to invalid addresses)
+- Spam complaints from recipients
+- Sending to spam trap addresses
+- Sudden volume spikes from a domain with little sending history
+- Appearing on a public blacklist (e.g., Spamhaus, Barracuda)
 
-> [!TIP]
-> If you use multiple services that send email on your behalf (e.g., Google Workspace for corporate mail and Postmark for transactional email), each one needs to be authorized in your SPF record and may require its own DKIM selector. See [Managing Multiple DKIM Selectors](/articles/managing-multiple-dkim-selectors/).
+### Dirty email lists {#spam-list}
 
-## Next steps {#next-steps}
+Sending to outdated, purchased, or unverified email lists inflates bounce rates and spam complaints, which directly damages reputation.
 
-- [Improving Email Deliverability](/articles/improving-email-deliverability/) - Actionable steps to configure authentication and improve sender reputation.
-- [Monitoring Email Deliverability](/articles/monitoring-email-deliverability/) - Tools and techniques for tracking authentication status and reputation.
+### Content triggers {#spam-content}
+
+Spam-triggering content is less impactful than authentication and reputation, but can still cause problems:
+
+- Excessive images with little text
+- Misleading subject lines
+- URL shorteners (often associated with phishing)
+- Broken HTML
+- Missing unsubscribe link
+
+## How to improve email deliverability {#improve}
+
+Address these areas in priority order. DNS authentication is the foundation - fix it first.
+
+### 1. Set up email authentication {#improve-authentication}
+
+Configure all three DNS-based authentication protocols:
+
+- **[Set Up SPF Records](/articles/setting-up-spf/)** - Authorize every service that sends email for your domain in a single TXT record.
+- **[Set Up DKIM](/articles/set-up-dkim/)** - Add a DKIM public key for each sending service at its designated selector subdomain.
+- **[Set Up DMARC](/articles/set-up-dmarc/)** - Publish a policy record and enable reporting. Start with `p=none` (monitoring), then move to enforcement.
+
+For a full walkthrough of the authentication setup process, see [How to Set Up Email Authentication for Your Domain](/articles/email-authentication/).
+
+### 2. Check and protect sender reputation {#improve-reputation}
+
+Use these free tools to assess your current standing:
+
+- [Google Postmaster Tools](https://postmaster.google.com/) - Gmail-specific reputation, spam rate, and authentication data.
+- [Microsoft SNDS](https://sendersupport.olc.protection.outlook.com/snds/) - Outlook/Hotmail IP reputation and complaint data.
+- [Sender Score](https://www.senderscore.org/) - General reputation score (0-100) across multiple providers.
+- [MXToolbox Blacklist Check](https://mxtoolbox.com/blacklists.aspx) - Scan your domain against dozens of blacklists.
+
+If your domain or IP is on a blacklist, fix the underlying issue (compromised account, spam complaints, poor list hygiene), then submit a removal request to the blacklist operator.
+
+### 3. Clean your email list {#improve-list}
+
+- Remove hard-bounce addresses immediately. These are permanent failures that will never succeed.
+- Use double opt-in for new subscribers to confirm valid addresses.
+- Sunset inactive subscribers who have not opened or clicked in 6 to 12 months.
+- Never use purchased or scraped email lists.
+
+### 4. Warm up new domains and IPs {#improve-warmup}
+
+New domains and IP addresses have no sending history. Mailbox providers treat unknown senders with caution. Ramp up sending volume gradually over several weeks:
+
+- Start with your most engaged recipients (people who regularly open and click).
+- Increase daily volume by 20-50% per week.
+- Monitor bounce rates and spam complaints at each stage. Pause if either spikes.
+- Ensure authentication is fully configured before sending the first message.
+
+### 5. Fix content and sending patterns {#improve-content}
+
+- Include a visible, functional unsubscribe link in every marketing email. Google and Yahoo require one-click unsubscribe for bulk senders.
+- Avoid sudden volume spikes. If you need to send a large campaign, spread it over multiple days.
+- Use a consistent `From:` name and address so recipients recognize your email.
+- Test emails with a tool like [Mail Tester](https://www.mail-tester.com/) to catch content-level issues before sending.
+
+For detailed, step-by-step implementation, see [Improving Email Deliverability](/articles/improving-email-deliverability/).
+
+## How to measure email deliverability {#measure}
+
+### Monitor authentication results {#measure-authentication}
+
+Publish a [DMARC record](/articles/dmarc-record/) with a `rua=` reporting address. Mailbox providers will send daily aggregate reports showing which IPs sent email as your domain and whether they passed SPF and DKIM.
+
+Raw DMARC reports are XML files. Services like [dmarcian](https://dmarcian.com/) and [Postmark DMARC Digests](https://dmarc.postmarkapp.com/) parse them into readable dashboards.
+
+### Track reputation over time {#measure-reputation}
+
+Check Google Postmaster Tools weekly for:
+
+- **Domain reputation** trending (High, Medium, Low, Bad)
+- **Spam rate** (keep below 0.1%)
+- **Authentication pass rates** for SPF, DKIM, and DMARC
+
+### Watch bounce and complaint rates {#measure-bounces}
+
+Your email service provider's dashboard shows bounce rates and complaint rates. A sudden increase in hard bounces usually means invalid addresses entered your list. A spike in complaints often follows a content or frequency change.
+
+For a full monitoring routine with schedules and tool recommendations, see [Monitoring Email Deliverability](/articles/monitoring-email-deliverability/).
+
+## Common email deliverability problems {#problems}
+
+### Why are my emails going to spam even though authentication passes? {#problem-spam-despite-auth}
+
+Authentication is necessary but not sufficient. If SPF, DKIM, and DMARC all pass but email still lands in spam, check:
+
+1. Domain and IP reputation with [Google Postmaster Tools](https://postmaster.google.com/) and [MXToolbox](https://mxtoolbox.com/blacklists.aspx).
+2. Spam complaint rate. Anything above 0.1% is problematic.
+3. Email content for spam triggers (excessive images, misleading subjects, missing unsubscribe link).
+4. Whether your DMARC policy is still `p=none`. Some providers treat unenforced DMARC as a weaker trust signal.
+
+### Why did my deliverability drop suddenly? {#problem-sudden-drop}
+
+Common causes of a sudden drop:
+
+- A sending service was removed from or never added to your SPF record.
+- A DKIM key was rotated by your email provider but the DNS record was not updated.
+- Your domain or IP was added to a blacklist after a spam complaint spike.
+- A large send to a stale list caused a bounce rate spike.
+
+### Does email forwarding affect deliverability? {#problem-forwarding}
+
+Yes. When email is forwarded, the forwarding server's IP replaces the original sender's IP. This causes SPF to fail because the forwarding server is not in the original sender's SPF record. DKIM signatures survive forwarding (they are part of the message itself), which is one reason DKIM is essential alongside SPF.
+
+For forwarding-specific issues, see [Email Forwarding Not Working](/articles/email-forwarding-not-working/).
+
+### Does DNS affect email deliverability? {#problem-dns}
+
+DNS is where email deliverability starts. SPF, DKIM, and DMARC are all DNS TXT records. MX records route email to the correct servers. Incorrect, missing, or slow-to-propagate DNS records are behind a large share of deliverability problems. DNSimple manages these records alongside everything else your domain needs.
+
+## Frequently asked questions {#faq}
+
+### What is the difference between email delivery and email deliverability? {#faq-delivery-vs}
+
+Email delivery is whether the message reached the recipient's mail server (not bounced). Email deliverability is whether it reached the inbox rather than the spam folder. You can have high delivery rates and poor deliverability at the same time.
+
+### How long does it take to fix deliverability problems? {#faq-how-long}
+
+DNS authentication changes (SPF, DKIM, DMARC) take effect within minutes to hours after the records propagate. Reputation recovery takes longer - typically two to four weeks of consistent, clean sending after fixing the underlying issue. Severe reputation damage or blacklisting can take longer.
+
+### Do I need a dedicated IP address for good deliverability? {#faq-dedicated-ip}
+
+Not necessarily. Shared IPs from reputable email service providers (Google Workspace, Postmark, SendGrid) carry the provider's collective reputation, which is usually good. Dedicated IPs make sense for high-volume senders (100,000+ emails per month) who want full control over their IP reputation, but they require proper warm-up.
+
+### Can email content alone cause deliverability problems? {#faq-content}
+
+Content is a factor, but it is rarely the primary cause. Authentication failures and poor sender reputation have a much larger impact than content. Fix authentication and reputation first, then address content triggers if problems persist.
+
+### Does DNSimple send email? {#faq-dnsimple}
+
+DNSimple does not provide email hosting or send email on your behalf. DNSimple manages the DNS records (SPF, DKIM, DMARC, MX) that email authentication and routing depend on. Your email service provider handles the actual sending.
 
 ## Have more questions?
 
-If you have additional questions or need assistance with email deliverability, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.
+If you have any questions about email deliverability, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/understanding-spf-dkim-dmarc-alignment.md
+++ b/content/articles/understanding-spf-dkim-dmarc-alignment.md
@@ -1,12 +1,12 @@
 ---
-title: Understanding SPF, DKIM, and DMARC Alignment
+title: SPF, DKIM, and DMARC Alignment
 excerpt: About alignment requirements for SPF, DKIM, and DMARC and how they affect email authentication.
 meta: Detailed explanation of SPF, DKIM, and DMARC alignment requirements and how they work together for email authentication.
 categories:
 - Emails
 ---
 
-# Understanding SPF, DKIM, and DMARC Alignment
+# SPF, DKIM, and DMARC Alignment
 
 ### Table of Contents {#toc}
 

--- a/content/articles/verify-dkim.md
+++ b/content/articles/verify-dkim.md
@@ -29,7 +29,7 @@ If no result is returned, verify the TXT record was added with the correct subdo
 ## Verifying your DKIM with an online tool {#verifying-your-dkim-with-an-online-tool}
 Verify your DKIM with an online tool like [this one from Treehouse](https://www.mail-tester.com/spf-dkim-check). This tool verifies that you have [SPF](/articles/spf-record/) and DKIM records. In the DKIM selector field, add the first part of the subdomain your DKIM is under. For example, if your DKIM is at `google._domainkey.example.com`, then the DKIM selector is `google`.
 
-If your DKIM record is published correctly but messages are still failing authentication, see [Troubleshooting Email Authentication](/articles/troubleshooting-email-authentication/) for common causes like selector mismatches and key issues.
+If your DKIM record is published correctly but messages are still failing authentication, see [Troubleshoot Email Authentication](/articles/troubleshooting-email-authentication/) for common causes like selector mismatches and key issues.
 
 ## Technical details {#technical-details}
 For more information about the technical details of DKIM, head over to [DKIM.org](http://dkim.org).

--- a/content/articles/verifying-dmarc.md
+++ b/content/articles/verifying-dmarc.md
@@ -31,7 +31,7 @@ Verify your DMARC with an online tool like [this one from MX Toolbox](https://mx
 ## Monitoring DMARC {#monitoring-dmarc}
 DMARC sends daily reports to the email specified in the RUA tag to provide an overview of email traffic. These reports are sent in XML format, and can be difficult to read &mdash; we recommend using a free tool, like [Postmark's reporting](https://dmarc.postmarkapp.com/), to provide a weekly, human-readable report.
 
-If your DMARC record is published correctly but messages are still failing, the problem is often an alignment issue. See [Troubleshooting Email Authentication](/articles/troubleshooting-email-authentication/) for how to diagnose alignment failures and other common causes.
+If your DMARC record is published correctly but messages are still failing, the problem is often an alignment issue. See [Troubleshoot Email Authentication](/articles/troubleshooting-email-authentication/) for how to diagnose alignment failures and other common causes.
 
 ## Technical details {#technical-details}
 To read more about the technical details of DMARC, head over to [DMARC.org](https://dmarc.org).

--- a/content/articles/verifying-spf.md
+++ b/content/articles/verifying-spf.md
@@ -78,7 +78,7 @@ When verifying your SPF record, you may see different results:
 
 **Missing mechanisms:** Ensure your SPF record includes all the email providers you use. Missing an authorized sender can cause legitimate emails to fail SPF checks.
 
-If your SPF record is published correctly but messages are still failing authentication, see [Troubleshooting Email Authentication](/articles/troubleshooting-email-authentication/) for common causes like missing senders and DNS lookup limits.
+If your SPF record is published correctly but messages are still failing authentication, see [Troubleshoot Email Authentication](/articles/troubleshooting-email-authentication/) for common causes like missing senders and DNS lookup limits.
 
 ## Technical details {#technical}
 


### PR DESCRIPTION
## Summary

- **New article: "How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)"** - Pillar page targeting the "email authentication" keyword. Covers what email authentication is (including "email validation" synonym), how SPF/DKIM/DMARC work together, step-by-step setup, common mistakes, and FAQ section for People Also Ask capture.
- **Rewritten: "Email Deliverability: How to Get Your Emails to the Inbox"** - Replaces the former "Understanding Email Deliverability" (740 words) with a comprehensive pillar page (~2,200 words) targeting the "email deliverability" keyword. Covers the problem definition, why emails land in spam, how to improve deliverability (DNS-first ordering), measurement, common problems, and FAQ. Same URL, no redirect needed.
- **Trimmed: "Email Authentication Best Practices"** - Removed sections that overlapped with the new authentication pillar (common mistakes, overview, duplicate setup/documentation advice). Now focused purely on ongoing maintenance and optimization, with a link to the new pillar for initial setup.
- **Updated hub page and category YAML** - Added both new articles to the emails hub page and category listings.

## SEO context

DNSimple does not rank for "email authentication" or "email deliverability" as head terms. These two pillar articles are designed to capture those keywords with:
- Direct-answer opening paragraphs (GEO/AI citation optimization)
- Question-format H2/H3 headings matching People Also Ask patterns
- FAQ sections (schema-eligible)
- "Email validation" synonym coverage (used by Wikipedia and Microsoft)
- Cross-links to the existing 25+ email articles (hub-and-spoke)

## Test plan

- [x] Verify both new articles render correctly in local nanoc build
- [x] Confirm all internal cross-links resolve (no broken `/articles/` paths)
- [x] Verify category YAML titles match frontmatter titles exactly
- [x] Review article voice and tone against DNSimple style guide
- [x] Check that the old `/articles/understanding-email-deliverability/` URL still works (same filename, no redirect needed)