### PR TITLE
Shorten meta descriptions to 160 characters or fewer

### DIFF
--- a/categories/meta.yaml
+++ b/categories/meta.yaml
@@ -1,19 +1,19 @@
 api: Explore our comprehensive API documentation and resources at DNSimple. Find guides, tutorials, and support to seamlessly integrate and manage your DNS services.
 account: Explore our comprehensive account support articles to manage your DNSimple account effectively. Find answers, tips, and resources to enhance your experience.
-domains_and_transfers: Discover comprehensive guides and resources on managing your domains and transfers with DNSimple. Get expert tips and troubleshooting advice to optimize your domain and transfer experience.
+domains_and_transfers: Guides on managing domains and transfers at DNSimple, including registration, renewal, transferring to and from DNSimple, and troubleshooting.
 tlds: Explore documentation for top-level domains (TLDs) supported by DNSimple, including country-code and generic TLDs, requirements, and registration details.
 templates: Explore our comprehensive collection of templates designed to simplify your DNS management. Find articles and guides to enhance your experience with DNSimple.
-dns: Explore our comprehensive DNS support articles to enhance your understanding and management of DNS settings, troubleshooting, and best practices for optimal performance.
-dnsimple: Explore our comprehensive DNSimple support articles to help you manage your DNS settings, troubleshoot issues, and optimize your domain configurations effortlessly.
+dns: Articles on DNS management at DNSimple, covering DNS settings, record types, troubleshooting, and best practices for your domains.
+dnsimple: DNSimple support articles covering DNS settings, troubleshooting, and domain configuration to help you manage your domains.
 dnssec: Explore our comprehensive DNSSEC support articles to understand how to enhance your domain's security, protect against spoofing, and ensure data integrity.
 emails: Explore our comprehensive guide on email services with DNSimple. Find articles, tips, and solutions to optimize your email experience effortlessly.
 contacts: Explore our comprehensive guide on managing contacts in DNSimple. Find articles, tips, and best practices to effectively handle your domain contacts.
-connectors: Explore our comprehensive guides on connectors to seamlessly integrate your DNS with various services, enhancing connectivity and efficiency. Find the support you need!
+connectors: Guides on DNSimple connectors to integrate your DNS with external services, improving connectivity and multi-provider management.
 services: Explore our one-click services, designed to help you effectively utilize and manage DNSimple's powerful features and tools.
-name_servers: Explore our comprehensive guide on name servers, featuring articles that cover setup, management, and troubleshooting to enhance your DNS experience with DNSimple.
-whois_privacy: Explore our comprehensive guide on our free Whois Privacy, featuring articles that explain benefits, setup, and management to protect your personal information online.
+name_servers: Articles on name server setup, management, and troubleshooting at DNSimple, including vanity name servers and delegation configuration.
+whois_privacy: Articles on DNSimple's free WHOIS Privacy service, covering setup, management, and how it protects your personal information from public view.
 secondary_dns: Explore our comprehensive guide on Secondary DNS at DNSimple. Find articles, tutorials, and resources to enhance your domain's reliability and performance.
-integrations: Explore our comprehensive guide to integrations at DNSimple. Discover articles, tutorials, and resources to seamlessly connect your domains with various services.
+integrations: Articles on DNSimple integrations, with guides and resources for connecting your domains with external DNS providers and services.
 guides: Master DNS management and domain registration with our expert guides, tips, and step-by-step instructions to enhance your online presence.
 ssl_certificates: Discover in-depth guides on SSL certificates, including installation, management, and best practices to enhance your website's security and safeguard user data.
-enterprise: Explore comprehensive Enterprise features and resources at DNSimple, including enterprise-exclusive features, security options, infrastructure capabilities, and general enterprise tools to support your organization's DNS and domain management needs.
+enterprise: DNSimple Enterprise features including security options, infrastructure capabilities, and tools for your organization's DNS and domain management.

--- a/content/articles/account-suspended.md
+++ b/content/articles/account-suspended.md
@@ -1,7 +1,7 @@
 ---
 title: Suspended Account
 excerpt: Reasons your DNSimple account may be suspended.
-meta: Discover the common reasons for DNSimple account suspension and learn how to resolve issues quickly to regain access to your services. Stay informed and proactive!
+meta: Common reasons for DNSimple account suspension and how to resolve issues to regain access to your domains and services.
 categories:
 - Account
 ---

--- a/content/articles/alias-record.md
+++ b/content/articles/alias-record.md
@@ -1,7 +1,7 @@
 ---
 title: What Is an ALIAS Record?
 excerpt: What an ALIAS record is, and how to add an ALIAS record in DNSimple.
-meta: What an ALIAS record is, and how to add an ALIAS record in DNSimple. Discover how to easily add to enhance your domain's DNS management and improve website performance.
+meta: What an ALIAS record is and how to add one in DNSimple. ALIAS records let you point your root domain to another hostname using DNS resolution.
 categories:
 - DNS
 ---

--- a/content/articles/amazon-route-53-integration-demo.md
+++ b/content/articles/amazon-route-53-integration-demo.md
@@ -1,7 +1,7 @@
 ---
 title: How to Use Route 53 as an Integrated DNS Provider
 excerpt: An introductory tutorial to integrating Amazon Route 53 with DNSimple.
-meta: Discover how to seamlessly integrate Amazon Route 53 with DNSimple in this comprehensive tutorial, enhancing your domain management and DNS capabilities effortlessly.
+meta: Tutorial on integrating Amazon Route 53 with DNSimple. Manage Route 53 zones and DNS records alongside your DNSimple domains in one dashboard.
 categories:
 - DNS
 - Integrations

--- a/content/articles/amazon-s3-service.md
+++ b/content/articles/amazon-s3-service.md
@@ -1,7 +1,7 @@
 ---
 title: AWS S3 Service
 excerpt: How to set up AWS S3 DNS using DNSimple's One-click Service.
-meta: Learn how to effortlessly configure AWS S3 DNS with DNSimple's One-click Service, ensuring seamless integration and optimal performance for your web applications.
+meta: Configure AWS S3 DNS with DNSimple's one-click service. Point your domain to an S3 bucket for static website hosting with the required DNS records.
 categories:
 - Services
 ---

--- a/content/articles/announcement-change-ent-behavior.md
+++ b/content/articles/announcement-change-ent-behavior.md
@@ -1,7 +1,7 @@
 ---
 title: Change of Non-Compliant ENT Behavior
 excerpt: We are updating our name server behavior to properly handle Empty Non-Terminal (ENT) records.
-meta: Learn about DNSimple's update to RFC 4592-compliant ENT behavior. Understand how Empty Non-Terminal records will be handled and what action you may need to take.
+meta: DNSimple's update to RFC 4592-compliant ENT behavior. How Empty Non-Terminal records will be handled and what action you may need to take.
 categories:
   - DNS
 ---

--- a/content/articles/announcement-ns1-ns3-ip-addresses.md
+++ b/content/articles/announcement-ns1-ns3-ip-addresses.md
@@ -1,7 +1,7 @@
 ---
 title: Discontinuation of Legacy NS1 and NS3 IP Addresses
 excerpt: DNSimple is migrating NS1 and NS3 to new edge infrastructure. Legacy Cloudflare IP addresses will be fully retired on July 6, 2026.
-meta: Learn about DNSimple's migration of NS1 and NS3 to new edge infrastructure. Find the replacement IPs, the migration timeline, and what action you need to take before July 6, 2026.
+meta: DNSimple is migrating NS1 and NS3 to new edge infrastructure. Find replacement IPs, the migration timeline, and what to do before July 6, 2026.
 categories:
   - DNS
 ---

--- a/content/articles/api-documentation.md
+++ b/content/articles/api-documentation.md
@@ -1,7 +1,7 @@
 ---
 title: API Documentation
 excerpt: You can find our API documentation at the developer site.
-meta: Explore comprehensive API documentation at DNSimple, designed to help developers seamlessly integrate and utilize our services for domain management and automation.
+meta: DNSimple API documentation for developers. Integrate and automate domain registration, DNS management, and SSL certificate operations.
 categories:
 - API
 - Enterprise

--- a/content/articles/api-errors.md
+++ b/content/articles/api-errors.md
@@ -1,7 +1,7 @@
 ---
 title: API Errors
 excerpt: You can find more information about API errors in our developer site.
-meta: Discover detailed insights into API errors on our developer site, including common issues, troubleshooting tips, and solutions to enhance your integration experience.
+meta: API error reference on the DNSimple developer site. Common error codes, troubleshooting tips, and solutions for API integration issues.
 categories:
 - API
 - Enterprise

--- a/content/articles/auto-import-dns.md
+++ b/content/articles/auto-import-dns.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-Import DNS Records
 excerpt: Auto-import your DNS records to avoid downtime when transferring or hosting your domain with us.
-meta: Learn how to auto-import DNS records when transferring or hosting your domain with DNSimple. Reduce downtime and simplify DNS migration with automatic record detection.
+meta: Auto-import DNS records when transferring or hosting your domain with DNSimple. Reduce downtime and simplify migration with automatic record detection.
 categories:
 - DNS
 ---

--- a/content/articles/before-transferring-domain.md
+++ b/content/articles/before-transferring-domain.md
@@ -1,7 +1,7 @@
 ---
 title: Prepare a Domain Transfer to Avoid Downtime
 excerpt: How to prepare your DNS in DNSimple to avoid downtime before transferring your domain registration.
-meta: Set up DNS records in DNSimple before transferring your domain registration to avoid downtime. Covers adding the domain, copying records, verifying with dig, and switching name servers.
+meta: Set up DNS in DNSimple before transferring your domain to avoid downtime. Add the domain, copy records, verify with dig, and switch name servers.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/blogger-service.md
+++ b/content/articles/blogger-service.md
@@ -1,7 +1,7 @@
 ---
 title: Blogger Service
 excerpt: How to set up Blogger DNS using DNSimple's One-click Service.
-meta: Easily set up Blogger DNS with DNSimple's One-click Service. Follow our step-by-step guide to streamline your blogging experience and enhance your online presence.
+meta: Set up Blogger DNS with DNSimple's one-click service. Apply the required DNS records for your Blogger site to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/buy-wildcard-ssl-certificate.md
+++ b/content/articles/buy-wildcard-ssl-certificate.md
@@ -1,7 +1,7 @@
 ---
 title: How to Buy a Wildcard SSL Certificate
 excerpt: How to buy a wildcard SSL certificate with DNSimple.
-meta: How to buy a wildcard SSL certificate with DNSimple to secure all subdomains under your domain, with step-by-step instructions for both Let's Encrypt and Sectigo.
+meta: Buy a wildcard SSL certificate with DNSimple to secure all subdomains under your domain. Step-by-step instructions for Let's Encrypt and Sectigo.
 categories:
 - SSL Certificates
 - Enterprise

--- a/content/articles/caa-records-ssl-certificates.md
+++ b/content/articles/caa-records-ssl-certificates.md
@@ -1,7 +1,7 @@
 ---
 title: CAA Records and SSL Certificates
 excerpt: CAA records control which Certificate Authorities can issue SSL certificates for your domain. Misconfigured or missing CAA records are a common cause of certificate issuance failures.
-meta: Learn how CAA records affect SSL certificate issuance at DNSimple, what values to use for Sectigo and Let's Encrypt, and how to troubleshoot CAA-related failures.
+meta: How CAA records affect SSL certificate issuance at DNSimple. Values to use for Sectigo and Let's Encrypt, and how to troubleshoot CAA failures.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/can-elliptic-curve-key-ssl-certificates.md
+++ b/content/articles/can-elliptic-curve-key-ssl-certificates.md
@@ -1,7 +1,7 @@
 ---
 title: Do You Support Elliptic Curve Cryptography (ECC) SSL Certificates?
 excerpt: All DNSimple SSL certificates use ECDSA keys by default. RSA is available as an alternative for all certificate products.
-meta: DNSimple issues all SSL certificates with ECDSA (ECC) keys using prime256v1 by default. RSA is available for all products via the signature algorithm selector. Sectigo certificates also support custom CSRs with ECDSA secp384r1 or RSA keys.
+meta: DNSimple issues SSL certificates with ECDSA (ECC) keys by default. RSA is available via the signature algorithm selector. Sectigo also supports custom CSRs.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/can-ev-ssl-certificates.md
+++ b/content/articles/can-ev-ssl-certificates.md
@@ -1,7 +1,7 @@
 ---
 title: Do You Support Extended Validation (EV) SSL Certificates?
 excerpt: DNSimple does not offer EV or OV SSL certificates. All DNSimple certificates are domain-validated (DV).
-meta: DNSimple does not provide Extended Validation (EV) or Organization Validated (OV) SSL certificates. All certificates are domain-validated (DV) with the same cryptographic security.
+meta: DNSimple does not offer EV or OV SSL certificates. All certificates are domain-validated (DV) and provide the same cryptographic security as EV and OV.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/can-upgrade-single-hostname-ssl-certificate-to-wildcard.md
+++ b/content/articles/can-upgrade-single-hostname-ssl-certificate-to-wildcard.md
@@ -1,7 +1,7 @@
 ---
 title: Can I Upgrade a Single-Hostname SSL Certificate to a Wildcard SSL Certificate?
 excerpt: You cannot upgrade a single-name SSL certificate to a wildcard. You must purchase a new wildcard certificate separately.
-meta: DNSimple does not support upgrading a single-name SSL certificate to a wildcard certificate. Learn about the refund policy and how to order a wildcard certificate instead.
+meta: DNSimple does not support upgrading a single-name SSL certificate to a wildcard. Learn the refund policy and how to order a wildcard certificate.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/changing-account-information.md
+++ b/content/articles/changing-account-information.md
@@ -1,7 +1,7 @@
 ---
 title: Changing Account Information
 excerpt: How to change the information associated with a DNSimple account.
-meta: Learn how to easily update your DNSimple account information, including email, password, and billing details, to ensure your account stays secure and up-to-date.
+meta: Update your DNSimple account information, including email, password, and billing details. Keep your account secure and current.
 categories:
 - Account
 ---

--- a/content/articles/changing-whois-contact.md
+++ b/content/articles/changing-whois-contact.md
@@ -1,7 +1,7 @@
 ---
 title: Change WHOIS Information
 excerpt: How to change the contact information displayed in the WHOIS for a domain.
-meta: Update the public WHOIS contact information for a domain registered with DNSimple. Covers registrant, administrative, and technical contacts, plus the ICANN 60-day transfer lock.
+meta: Update WHOIS contact information for a domain at DNSimple. Covers registrant, admin, and technical contacts, plus the ICANN 60-day transfer lock.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/common-dns-records.md
+++ b/content/articles/common-dns-records.md
@@ -1,7 +1,7 @@
 ---
 title: Common DNS Records
 excerpt: The most common DNS record types are A, AAAA, CNAME, MX, and TXT. Each serves a specific function in directing traffic, routing email, or verifying domain ownership.
-meta: Common DNS record types explained: A, AAAA, CNAME, MX, TXT, NS, and SOA. Learn what each record does, when to use it, and how to configure it.
+meta: "Common DNS record types explained: A, AAAA, CNAME, MX, TXT, NS, and SOA. Learn what each record does, when to use it, and how to configure it."
 categories:
 - DNS
 ---

--- a/content/articles/common-dns-records.md
+++ b/content/articles/common-dns-records.md
@@ -1,7 +1,7 @@
 ---
 title: Common DNS Records
 excerpt: The most common DNS record types are A, AAAA, CNAME, MX, and TXT. Each serves a specific function in directing traffic, routing email, or verifying domain ownership.
-meta: Common DNS record types explained - A, AAAA, CNAME, MX, TXT, NS, and SOA records. Learn what each DNS record does, when to use it, and how to configure it for your domain.
+meta: Common DNS record types explained: A, AAAA, CNAME, MX, TXT, NS, and SOA. Learn what each record does, when to use it, and how to configure it.
 categories:
 - DNS
 ---

--- a/content/articles/dashboard.md
+++ b/content/articles/dashboard.md
@@ -1,7 +1,7 @@
 ---
 title: Getting to Know Your DNSimple Dashboard
 excerpt: How to use the DNSimple Dashboard to manage your domains.
-meta: Explore the DNSimple dashboard with our comprehensive guide. Learn to navigate your domain list, manage settings, and optimize your domain management experience.
+meta: Guide to the DNSimple dashboard. Navigate your domain list, manage account settings, and access key domain management features.
 categories:
 - DNSimple
 ---

--- a/content/articles/dns-redundancy.md
+++ b/content/articles/dns-redundancy.md
@@ -1,7 +1,7 @@
 ---
 title: DNS Redundancy Options at DNSimple
 excerpt: How to add DNS redundancy to your domains using secondary DNS or multi-provider setups.
-meta: Learn when and how to add DNS redundancy at DNSimple. Compare secondary DNS via zone transfer (AXFR) with multi-provider DNS sync to protect your domains from outages.
+meta: When and how to add DNS redundancy at DNSimple. Compare secondary DNS via AXFR with multi-provider DNS sync to protect your domains from outages.
 categories:
 - Secondary DNS
 ---

--- a/content/articles/dns.md
+++ b/content/articles/dns.md
@@ -1,7 +1,7 @@
 ---
 title: DNS at DNSimple
 excerpt: Learn about DNS, manage your DNS records, and configure DNS hosting with DNSimple
-meta: Comprehensive guide to DNS management at DNSimple, including DNS records, zone management, troubleshooting, and advanced DNS features like Anycast and secondary DNS.
+meta: Guide to DNS management at DNSimple, covering DNS records, zone management, troubleshooting, and features like Anycast and secondary DNS.
 categories:
 - DNS
 ---

--- a/content/articles/dnsimple-nameservers.md
+++ b/content/articles/dnsimple-nameservers.md
@@ -1,7 +1,7 @@
 ---
 title: DNSimple Name Servers
 excerpt: How to change your domain's name servers to DNSimple's name servers.
-meta: Learn how to easily update your domain's name servers to DNSimple's for improved performance and reliability. Follow our step-by-step guide for seamless changes.
+meta: How to update your domain's name servers to DNSimple for improved DNS performance and reliability. Step-by-step name server change guide.
 categories:
 - Name Servers
 ---

--- a/content/articles/dnsimple-services.md
+++ b/content/articles/dnsimple-services.md
@@ -1,7 +1,7 @@
 ---
 title: DNSimple Services
 excerpt: "DNSimple provides essential services for every Internet-connected system: hosted DNS, domain registration, a powerful automation API, One Click DNS Services, and SSL certificates."
-meta: Discover DNSimple's comprehensive services including DNS hosting, domain registration, automation API, one-click DNS services, and SSL certificates for your domains.
+meta: DNSimple services overview. DNS hosting, domain registration, automation API, one-click DNS services, and SSL certificates for your domains.
 categories:
 - DNSimple
 ---

--- a/content/articles/dnsimple-status.md
+++ b/content/articles/dnsimple-status.md
@@ -1,7 +1,7 @@
 ---
 title: DNSimple Status Page
 excerpt: We make our current system status, as well as our uptime history, available at dnsimplestatus.com.
-meta: Check DNSimple's system status and uptime history. Monitor our name server availability and service status in real-time. Subscribe to incident notifications via email, SMS, or webhook.
+meta: Check DNSimple system status and uptime history. Monitor name server availability and subscribe to incident notifications via email, SMS, or webhook.
 categories:
 - DNSimple
 ---

--- a/content/articles/dnskey-records-explained.md
+++ b/content/articles/dnskey-records-explained.md
@@ -1,7 +1,7 @@
 ---
 title: DNSKEY Records Explained
 excerpt: The DNSKEY record is the DNS record type that holds the DNSSEC public signing key used to verify digital signatures on DNS data.
-meta: The DNSKEY record holds the DNSSEC public signing key. Learn what type of DNS record stores the public key, how DNSKEY records work, and their role in DNSSEC validation.
+meta: The DNSKEY record holds the DNSSEC public signing key. Learn how DNSKEY records work and their role in DNSSEC validation and the chain of trust.
 categories:
 - DNSSEC
 ---

--- a/content/articles/dnssec-chain-of-trust.md
+++ b/content/articles/dnssec-chain-of-trust.md
@@ -1,7 +1,7 @@
 ---
 title: The DNSSEC Chain of Trust
 excerpt: The DNSSEC chain of trust is a series of cryptographic signatures linking the DNS root zone down to your domain, allowing resolvers to validate every response.
-meta: How DNSSEC validation works through the chain of trust. Learn how DS records, DNSKEY records, and trust anchors link the DNS root to your domain for end-to-end verification.
+meta: How DNSSEC validation works through the chain of trust. DS records, DNSKEY records, and trust anchors link the DNS root to your domain.
 categories:
 - DNSSEC
 ---

--- a/content/articles/dnssec-management-in-dnsimple.md
+++ b/content/articles/dnssec-management-in-dnsimple.md
@@ -1,7 +1,7 @@
 ---
 title: DNSSEC Management in DNSimple
 excerpt: Reference for the DNSSEC management interface in DNSimple, including how to enable, disable, and configure DS records for your domain.
-meta: Reference guide for the DNSSEC management interface in DNSimple. See how to enable and disable DNSSEC, add DS records, and manage fully managed DNSSEC for your domains.
+meta: Reference for the DNSSEC management interface in DNSimple. Enable and disable DNSSEC, add DS records, and manage fully managed DNSSEC for your domains.
 categories:
 - DNSSEC
 ---

--- a/content/articles/dnssec.md
+++ b/content/articles/dnssec.md
@@ -1,7 +1,7 @@
 ---
 title: DNSSEC at DNSimple
 excerpt: Enable, manage, and troubleshoot DNSSEC for your domains at DNSimple, with automatic key rotation and DS-data and KEY-data interface support.
-meta: DNSSEC at DNSimple. Enable, manage, and troubleshoot DNSSEC with automatic key rotation, DS record provisioning, and full key lifecycle management for your domains.
+meta: DNSSEC at DNSimple. Enable, manage, and troubleshoot DNSSEC with automatic key rotation, DS record provisioning, and key lifecycle management.
 categories:
 - DNSSEC
 ---

--- a/content/articles/domain-masking.md
+++ b/content/articles/domain-masking.md
@@ -1,7 +1,7 @@
 ---
 title: Domain Masking
 excerpt: Information on Domain Masking and URL Masking.
-meta: Learn about domain masking and URL masking, their benefits, and how to implement them effectively to enhance your online presence and protect your brand identity.
+meta: What domain masking and URL masking are, how they work, and how to implement them to display one URL while serving content from another.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/domain-resolution-issues.md
+++ b/content/articles/domain-resolution-issues.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot Domain Resolution Issues
 excerpt: How to diagnose and fix domain resolution issues, including DNS server not responding errors, NXDOMAIN, SERVFAIL, and delegation problems.
-meta: Fix domain resolution issues including DNS server not responding, NXDOMAIN, SERVFAIL, and name server delegation problems. Step-by-step DNS troubleshooting guide.
+meta: Fix domain resolution issues: DNS server not responding, NXDOMAIN, SERVFAIL, and delegation problems. Step-by-step DNS troubleshooting guide.
 categories:
 - DNS
 ---

--- a/content/articles/domain-resolution-issues.md
+++ b/content/articles/domain-resolution-issues.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot Domain Resolution Issues
 excerpt: How to diagnose and fix domain resolution issues, including DNS server not responding errors, NXDOMAIN, SERVFAIL, and delegation problems.
-meta: Fix domain resolution issues: DNS server not responding, NXDOMAIN, SERVFAIL, and delegation problems. Step-by-step DNS troubleshooting guide.
+meta: "Fix domain resolution issues: DNS server not responding, NXDOMAIN, SERVFAIL, and delegation problems. Step-by-step DNS troubleshooting guide."
 categories:
 - DNS
 ---

--- a/content/articles/domain-transfer-pricing.md
+++ b/content/articles/domain-transfer-pricing.md
@@ -1,7 +1,7 @@
 ---
 title: Domain Transfer Pricing
 excerpt: Domain transfer pricing at DNSimple varies by TLD and includes a 1-year registration extension from the current expiration date.
-meta: Domain transfer fees at DNSimple vary by TLD and include a 1-year registration extension. Check supported TLDs, transfer costs, and how expiration dates are extended after transfer.
+meta: Domain transfer fees at DNSimple vary by TLD and include a 1-year registration extension. Check supported TLDs, costs, and how expiration dates change.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/domains-and-transfers.md
+++ b/content/articles/domains-and-transfers.md
@@ -1,7 +1,7 @@
 ---
 title: Domains and Transfers at DNSimple
 excerpt: Learn about domain registration, renewal, and transfers at DNSimple.
-meta: Comprehensive guide to domains and transfers at DNSimple, including registering and adding domains, renewals, transferring domains to or from DNSimple, and managing domain settings.
+meta: Guide to domains and transfers at DNSimple, including registration, renewals, transferring to or from DNSimple, and managing domain settings.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/domains-de.md
+++ b/content/articles/domains-de.md
@@ -1,7 +1,7 @@
 ---
 title: .DE Domains
 excerpt: Requirements and special procedures for .DE domains, including DENIC contact-data rules, verification, and transfers.
-meta: Learn how .DE domains work at DNSimple, including DENIC contact accuracy requirements under NIS2, risk checks, verification timelines, and unique transfer rules.
+meta: How .DE domains work at DNSimple, including DENIC contact accuracy requirements under NIS2, risk checks, verification timelines, and transfer rules.
 categories:
 - TLDs
 ---

--- a/content/articles/edns-client-subnet.md
+++ b/content/articles/edns-client-subnet.md
@@ -1,7 +1,7 @@
 ---
 title: What Is EDNS Client Subnet Support?
 excerpt: What ECS is and how it works.
-meta: This article explains what EDNS Client Subnet (ECS) support is, how it is an option in the Extension Mechanisms for DNS, and how it's configured with an ALIAS record
+meta: EDNS Client Subnet (ECS) is an Extension Mechanisms for DNS option that improves geolocation accuracy. Learn how ECS works with ALIAS records at DNSimple.
 categories:
 - DNS
 ---

--- a/content/articles/email-authentication.md
+++ b/content/articles/email-authentication.md
@@ -1,7 +1,7 @@
 ---
 title: How to Set Up Email Authentication for Your Domain (SPF, DKIM & DMARC)
 excerpt: How to set up SPF, DKIM, and DMARC for your domain to authenticate your email and protect against spoofing.
-meta: Set up email authentication (also called email validation) for your domain using SPF, DKIM, and DMARC DNS records. Step-by-step instructions for configuring all three protocols.
+meta: Set up email authentication for your domain using SPF, DKIM, and DMARC DNS records. Step-by-step instructions for configuring all three protocols.
 categories:
 - Emails
 ---

--- a/content/articles/email-hosting.md
+++ b/content/articles/email-hosting.md
@@ -1,7 +1,7 @@
 ---
 title: Email Hosting Support
 excerpt: DNSimple does not provide email hosting, but you can use a third-party email hosting provider and manage your DNS records through DNSimple.
-meta: DNSimple does not provide email hosting. Learn how to use third-party email hosting providers like Google Workspace, Microsoft 365, and FastMail with DNSimple DNS management.
+meta: DNSimple does not provide email hosting. Use providers like Google Workspace, Microsoft 365, and FastMail with DNSimple DNS management.
 categories:
 - DNSimple
 - Emails

--- a/content/articles/emails.md
+++ b/content/articles/emails.md
@@ -1,7 +1,7 @@
 ---
 title: Email Services at DNSimple
 excerpt: Email forwarding, authentication records (SPF, DKIM, DMARC), and third-party email hosting configuration at DNSimple.
-meta: Guide to email services at DNSimple, including email forwarding, SPF, DKIM, and DMARC authentication records, and integration with third-party email hosting providers.
+meta: Email services at DNSimple, including email forwarding, SPF, DKIM, and DMARC authentication records, and integration with third-party email hosting.
 categories:
 - Emails
 ---

--- a/content/articles/external-dns-diagnostic-tools.md
+++ b/content/articles/external-dns-diagnostic-tools.md
@@ -1,7 +1,7 @@
 ---
 title: External DNS Diagnostic Tools
 excerpt: Reference guide to third-party DNS diagnostic tools used for troubleshooting and verifying DNS resolution.
-meta: External DNS diagnostic tools: Google Admin Toolbox Dig, IntoDNS, ViewDNS, and WhatsMyDNS for troubleshooting and verifying DNS resolution.
+meta: "External DNS diagnostic tools: Google Admin Toolbox Dig, IntoDNS, ViewDNS, and WhatsMyDNS for troubleshooting and verifying DNS resolution."
 categories:
 - DNS
 ---

--- a/content/articles/external-dns-diagnostic-tools.md
+++ b/content/articles/external-dns-diagnostic-tools.md
@@ -1,7 +1,7 @@
 ---
 title: External DNS Diagnostic Tools
 excerpt: Reference guide to third-party DNS diagnostic tools used for troubleshooting and verifying DNS resolution.
-meta: Reference guide to external DNS diagnostic tools including Google Admin Toolbox Dig, IntoDNS, ViewDNS, and WhatsMyDNS for troubleshooting and verifying DNS resolution.
+meta: External DNS diagnostic tools: Google Admin Toolbox Dig, IntoDNS, ViewDNS, and WhatsMyDNS for troubleshooting and verifying DNS resolution.
 categories:
 - DNS
 ---

--- a/content/articles/external-dnssec-diagnostic-tools.md
+++ b/content/articles/external-dnssec-diagnostic-tools.md
@@ -1,7 +1,7 @@
 ---
 title: External DNSSEC Diagnostic Tools
 excerpt: Test and check your DNSSEC configuration with external diagnostic tools like DNSSEC Analyzer, DNSViz, and dig.
-meta: Test and check your DNSSEC configuration with these diagnostic tools. Use DNSSEC Analyzer, DNSViz, and dig to validate your chain of trust and identify common DNSSEC issues.
+meta: Test your DNSSEC configuration with DNSSEC Analyzer, DNSViz, and dig. Validate your chain of trust and identify common DNSSEC issues.
 categories:
 - DNSSEC
 ---

--- a/content/articles/faq-ssl-certificates.md
+++ b/content/articles/faq-ssl-certificates.md
@@ -1,7 +1,7 @@
 ---
 title: SSL Certificates Frequently Asked Questions
 excerpt: A collection of frequently asked questions about the SSL certificates offered by DNSimple.
-meta: Frequently asked questions about SSL certificates at DNSimple, covering pricing, domain requirements, certificate types, validity periods, and common procedures.
+meta: FAQ about SSL certificates at DNSimple, covering pricing, domain requirements, certificate types, validity periods, and common procedures.
 categories:
 - SSL Certificates
 structured_data: true

--- a/content/articles/finding-missing-domain.md
+++ b/content/articles/finding-missing-domain.md
@@ -1,7 +1,7 @@
 ---
 title: I Can't Find My Domain
 excerpt: How to locate a domain that is not showing up in your DNSimple account.
-meta: Troubleshoot a missing domain in your DNSimple account. Common causes include domains registered through integrations like ClickFunnels or a second account you forgot about.
+meta: Troubleshoot a missing domain in your DNSimple account. Common causes include domains registered through ClickFunnels or a second account.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/getting-started-clickfunnels.md
+++ b/content/articles/getting-started-clickfunnels.md
@@ -1,7 +1,7 @@
 ---
 title: DNSimple and ClickFunnels
 excerpt: Get started with your new DNSimple account quickly.
-meta: Move your domain from ClickFunnels to your own DNSimple account. Step-by-step guide for requesting the domain push, accepting it, and managing your domain and certificates.
+meta: Move your domain from ClickFunnels to your own DNSimple account. Request the domain push, accept it, and manage your domain and certificates.
 categories:
 - DNSimple
 ---

--- a/content/articles/getting-started-ssl-certificates.md
+++ b/content/articles/getting-started-ssl-certificates.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with SSL Certificates
 excerpt: Everything you need to choose, order, validate, and install an SSL certificate with DNSimple.
-meta: Complete guide to buying SSL certificates at DNSimple. Learn how to choose between Sectigo and Let's Encrypt, purchase and validate your certificate, install it on your server, and manage renewals.
+meta: Guide to SSL certificates at DNSimple. Choose between Sectigo and Let's Encrypt, purchase, validate, install on your server, and manage renewals.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/getting-started.md
+++ b/content/articles/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
 excerpt: A comprehensive guide to help you get started with DNSimple.
-meta: Explore our comprehensive guide to getting started with DNSimple, featuring essential articles and resources to help you configure and manage your domain effortlessly.
+meta: Get started with DNSimple. Essential articles and resources to help you register domains, configure DNS, and manage your account.
 categories:
 - DNSimple
 ---

--- a/content/articles/google-workspace-service.md
+++ b/content/articles/google-workspace-service.md
@@ -1,7 +1,7 @@
 ---
 title: Google Workspace (formerly G Suite) Service
 excerpt: How to set up Google Workspace DNS using DNSimple's one-click service or manual configuration.
-meta: Set up Google Workspace email with DNSimple using the one-click service or manual DNS configuration, including MX records, domain verification, and email authentication.
+meta: Set up Google Workspace email with DNSimple using the one-click service or manual DNS, including MX records, domain verification, and authentication.
 categories:
 - Services
 - Emails

--- a/content/articles/guide-dashboard.md
+++ b/content/articles/guide-dashboard.md
@@ -1,7 +1,7 @@
 ---
 title: First Steps With Your DNSimple Account
 excerpt: A Quick Tour of Your Dashboard and Domain List
-meta: Explore the DNSimple dashboard with our comprehensive guide. Learn to navigate your domain list, manage settings, and optimize your online presence effortlessly.
+meta: First steps with your DNSimple account. A quick tour of the dashboard, domain list, and key settings to get you started.
 categories:
 - DNSimple
 - Guides

--- a/content/articles/heroku-service.md
+++ b/content/articles/heroku-service.md
@@ -1,7 +1,7 @@
 ---
 title: Heroku Service
 excerpt: How to set up Heroku DNS using DNSimple's one-click service.
-meta: Easily point your domain to your Heroku application using DNSimple's one-click service. Follow our step-by-step guide to streamline your setup and enhance performance.
+meta: Point your domain to Heroku using DNSimple's one-click service. Apply the required DNS records for your Heroku application in one click.
 categories:
 - Services
 ---

--- a/content/articles/how-dnsimple-handles-incidents.md
+++ b/content/articles/how-dnsimple-handles-incidents.md
@@ -1,7 +1,7 @@
 ---
 title: How DNSimple Handles Incidents
 excerpt: How DNSimple communicates during service incidents and where to find status updates.
-meta: Learn how DNSimple communicates during service incidents, where to check system status, how to subscribe to status notifications, and what to expect from postmortems.
+meta: How DNSimple communicates during service incidents. Where to check system status, subscribe to notifications, and what to expect from postmortems.
 categories:
 - DNSimple
 ---

--- a/content/articles/how-long-does-it-take-for-a-new-record-to-resolve-for-my-domain.md
+++ b/content/articles/how-long-does-it-take-for-a-new-record-to-resolve-for-my-domain.md
@@ -1,7 +1,7 @@
 ---
 title: How Long Does a New DNS Record Take to Resolve?
 excerpt: New DNS records are live on DNSimple name servers within seconds. Full DNS propagation to all resolvers worldwide depends on TTL and caching.
-meta: DNS propagation typically takes minutes to 48 hours depending on TTL and resolver caching. Learn how long new DNS records take to resolve and why propagation delays happen.
+meta: DNS propagation takes minutes to 48 hours depending on TTL and resolver caching. Learn how long new records take to resolve and why delays happen.
 categories:
 - DNS
 ---

--- a/content/articles/how-to-different-ssl-domain-validation-email.md
+++ b/content/articles/how-to-different-ssl-domain-validation-email.md
@@ -1,7 +1,7 @@
 ---
 title: How to Select a Different SSL Certificate Domain Validation Email
 excerpt: How to use a different email address for SSL certificate domain validation when the default addresses do not work.
-meta: Learn how to select an alternative email address for SSL certificate domain validation when your preferred email is not in the list provided by the Certificate Authority.
+meta: How to select an alternative email for SSL certificate domain validation when your preferred address is not in the Certificate Authority's list.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/i-got-an-ecc-certificate-but-i-want-a-rsa-one.md
+++ b/content/articles/i-got-an-ecc-certificate-but-i-want-a-rsa-one.md
@@ -1,7 +1,7 @@
 ---
 title: How to Switch From an ECC-Signed Certificate to RSA
 excerpt: What to do when you need your SSL certificate to be signed with an RSA key.
-meta: Learn how to get an RSA-signed SSL certificate in DNSimple if you received an ECC-signed certificate, with steps for both Let's Encrypt and Sectigo certificates.
+meta: How to get an RSA-signed SSL certificate in DNSimple if you received an ECC-signed certificate. Steps for both Let's Encrypt and Sectigo.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/improving-email-deliverability.md
+++ b/content/articles/improving-email-deliverability.md
@@ -1,7 +1,7 @@
 ---
 title: Improve Email Deliverability
 excerpt: How to improve email deliverability by configuring DNS-based authentication and managing sender reputation.
-meta: Step-by-step guide to improving email deliverability through SPF, DKIM, and DMARC configuration, sender reputation management, list hygiene, domain warm-up, and content fixes.
+meta: Improve email deliverability with SPF, DKIM, and DMARC configuration, sender reputation management, list hygiene, domain warm-up, and content fixes.
 categories:
 - Emails
 ---

--- a/content/articles/jimdo-service.md
+++ b/content/articles/jimdo-service.md
@@ -1,7 +1,7 @@
 ---
 title: Jimdo Service
 excerpt: How to set up Jimdo DNS using DNSimple's One-click Service.
-meta: Easily point your domain to Jimdo using DNSimple's One-click Service. Follow our step-by-step guide to streamline your website management and enhance your online presence.
+meta: Point your domain to Jimdo using DNSimple's one-click service. Apply the required DNS records for Jimdo to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/kickofflabs-service.md
+++ b/content/articles/kickofflabs-service.md
@@ -1,7 +1,7 @@
 ---
 title: KickoffLabs Service
 excerpt: How to set up KickoffLabs DNS using DNSimple's One-click Service.
-meta: Easily set up KickoffLabs DNS with DNSimple's One-click Service. Follow our step-by-step guide to streamline your domain management and enhance your online presence.
+meta: Set up KickoffLabs DNS with DNSimple's one-click service. Apply the required DNS records for KickoffLabs to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/labeling-domains.md
+++ b/content/articles/labeling-domains.md
@@ -1,7 +1,7 @@
 ---
 title: Organize and Label Domains
 excerpt: How to add, filter, edit, and remove labels on domains in your DNSimple account.
-meta: Use labels in DNSimple to organize and filter your domain portfolio. Add labels to multiple domains at once, filter by label, and edit or remove labels from the domain list.
+meta: Use labels in DNSimple to organize and filter your domains. Add labels to multiple domains at once, filter by label, and edit or remove labels.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/letsencrypt.md
+++ b/content/articles/letsencrypt.md
@@ -1,7 +1,7 @@
 ---
 title: "Let's Encrypt: Free SSL Certificates with DNSimple"
 excerpt: Let's Encrypt provides free SSL certificates through DNSimple, with automated issuance and renewal via DNS-based validation.
-meta: Let's Encrypt provides free SSL certificates through DNSimple. Learn how DNSimple automates Let's Encrypt certificate issuance, renewal, and DNS validation for your domains.
+meta: Let's Encrypt provides free SSL certificates through DNSimple with automated issuance, renewal, and DNS validation for your domains.
 categories:
 - SSL Certificates
 - Integrations

--- a/content/articles/manage-a-record.md
+++ b/content/articles/manage-a-record.md
@@ -1,7 +1,7 @@
 ---
 title: Manage A Records
 excerpt: Instructions to add, update, and remove an A record in DNSimple.
-meta: Learn how to efficiently manage your A records in DNSimple with our step-by-step guide. Add, update, or remove DNS records effortlessly for optimal domain performance.
+meta: Manage A records in DNSimple. Add, update, or remove A records that point your domain or subdomain to an IPv4 address, with step-by-step instructions.
 categories:
 - DNS
 ---

--- a/content/articles/manage-service-binding-records.md
+++ b/content/articles/manage-service-binding-records.md
@@ -1,7 +1,7 @@
 ---
 title: Manage Service Binding Records (SVCB and HTTPS)
 excerpt: Instructions to add, update, and remove SVCB and HTTPS records in DNSimple.
-meta: Learn how to effectively manage SVCB and HTTPS records in DNSimple with our step-by-step guide. Add, update, or remove records to optimize your domain's service binding configuration.
+meta: Manage SVCB and HTTPS records in DNSimple. Add, update, or remove service binding records to optimize your domain's performance and protocol configuration.
 categories:
 - DNS
 ---

--- a/content/articles/managing-integrated-domains.md
+++ b/content/articles/managing-integrated-domains.md
@@ -1,7 +1,7 @@
 ---
 title: Manage Integrated Domains
 excerpt: How to view and manage domains registered at other providers (GoDaddy, Namecheap, PorkBun) from your DNSimple account.
-meta: Manage domains registered at other providers (GoDaddy, Namecheap, PorkBun) from your DNSimple dashboard. View registration details, sync records, and control DNS in one place.
+meta: Manage domains from other providers (GoDaddy, Namecheap, PorkBun) in your DNSimple dashboard. View registration details, sync records, and control DNS.
 categories:
 - Domains and Transfers
 - Integrations

--- a/content/articles/managing-integrated-zones.md
+++ b/content/articles/managing-integrated-zones.md
@@ -1,7 +1,7 @@
 ---
 title: Refresh and Import Integrated Zones
 excerpt: How to view your DNSimple zones and zones from Integrated DNS Providers.
-meta: Easily view your zones from DNSimple and Integrated DNS Providers. Streamline your DNS management across multiple authoritative providers such as Route53 and CoreDNS.
+meta: View and manage zones from DNSimple and integrated DNS providers. Refresh and import zones across providers like Route 53 and CoreDNS.
 categories:
 - DNS
 ---

--- a/content/articles/netlify-service.md
+++ b/content/articles/netlify-service.md
@@ -1,7 +1,7 @@
 ---
 title: Netlify Service
 excerpt: How to set up Netlify DNS using DNSimple's One-click Service.
-meta: Easily point your domain to Netlify using DNSimple's One-click DNS Service. Follow our step-by-step guide to streamline your domain management and enhance your website's performance.
+meta: Point your domain to Netlify using DNSimple's one-click service. Apply the required DNS records for Netlify to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/office-365-service.md
+++ b/content/articles/office-365-service.md
@@ -1,7 +1,7 @@
 ---
 title: Microsoft 365 (formerly Office 365) Service
 excerpt: How to set up Microsoft 365 DNS using DNSimple's one-click service or manual configuration.
-meta: Set up Microsoft 365 email with DNSimple using the one-click service or manual DNS configuration, including MX records, domain verification, and email authentication.
+meta: Set up Microsoft 365 email with DNSimple using the one-click service or manual DNS, including MX records, verification, and email authentication.
 categories:
 - Services
 - Emails

--- a/content/articles/payment-methods.md
+++ b/content/articles/payment-methods.md
@@ -1,7 +1,7 @@
 ---
 title: Payment methods
 excerpt: Payment methods supported by DNSimple.
-meta: Article on all the different payment methods that are supported by DNSimple. See how we use a PCI-compliant billing provider to process and store all payment data.
+meta: Payment methods supported by DNSimple. We use a PCI-compliant billing provider to process and store all payment data securely.
 categories:
 - DNSimple
 ---

--- a/content/articles/rackspace-email-service.md
+++ b/content/articles/rackspace-email-service.md
@@ -1,7 +1,7 @@
 ---
 title: Rackspace Email Service
 excerpt: How to set up Rackspace Email DNS using DNSimple's One-click Service.
-meta: Easily set up Rackspace Email with DNSimple's One-click Service. Follow our comprehensive guide to configure your DNS settings and ensure seamless email functionality.
+meta: Set up Rackspace Email DNS with DNSimple's one-click service. Apply all required DNS records for Rackspace Email to your domain in one click.
 categories:
 - Services
 - Emails

--- a/content/articles/reasons-hosting-dns.md
+++ b/content/articles/reasons-hosting-dns.md
@@ -1,7 +1,7 @@
 ---
 title: Why Should I Host My DNS with DNSimple?
 excerpt: You should consider DNSimple for easy DNS management and expert support.
-meta: Discover the top reasons to host your DNS with DNSimple, where seamless management, expert support, and reliable performance come together for your online success.
+meta: Why host your DNS with DNSimple. Straightforward management, expert support, reliable Anycast performance, and a powerful automation API.
 categories:
 - DNSimple
 ---

--- a/content/articles/reasons-registering-domain.md
+++ b/content/articles/reasons-registering-domain.md
@@ -1,8 +1,7 @@
 ---
 title: Why Should I Register My Domain Name with DNSimple?
 excerpt: We won't try to upsell you when you register your domain.
-meta: Discover the top reasons to choose DNSimple for your DNS hosting needs, including seamless management, reliable performance, and exceptional expert support.
-meta: Discover the top reasons to choose DNSimple as an alternative to GoDaddy for your DNS hosting needs, including seamless management, reliable performance, and exceptional expert support.
+meta: Why register your domain with DNSimple. Straightforward management, reliable DNS performance, expert support, and no upsells or hidden fees.
 categories:
 - DNSimple
 ---

--- a/content/articles/record-notes.md
+++ b/content/articles/record-notes.md
@@ -1,7 +1,7 @@
 ---
 title: Record Notes
 excerpt: Make notes on your records to remember the purpose of the change.
-meta: Easily add notes to your DNS records in DNSimple to keep track of changes and their purposes, ensuring better management and organization of your domain settings.
+meta: Add notes to your DNS records in DNSimple to track changes and their purposes for better management and organization of your domain settings.
 categories:
 - DNS
 ---

--- a/content/articles/redirect-heroku.md
+++ b/content/articles/redirect-heroku.md
@@ -1,7 +1,7 @@
 ---
 title: Redirect www to Non-www Domain at Heroku
 excerpt: How to redirect www to a non-www domain (or vice versa) for a Heroku-hosted app using DNSimple, with and without HTTPS.
-meta: Set up www to non-www redirects for Heroku apps using DNSimple. Covers HTTP and HTTPS scenarios, including SSL certificate configuration and Rack::SslEnforcer setup.
+meta: Set up www to non-www redirects for Heroku apps using DNSimple. Covers HTTP and HTTPS scenarios, SSL configuration, and Rack::SslEnforcer setup.
 categories:
 - Domains and Transfers
 - Integrations

--- a/content/articles/redirect-heroku.md
+++ b/content/articles/redirect-heroku.md
@@ -1,7 +1,7 @@
 ---
 title: Redirect www to Non-www Domain at Heroku
 excerpt: How to redirect www to a non-www domain (or vice versa) for a Heroku-hosted app using DNSimple, with and without HTTPS.
-meta: Set up www to non-www redirects for Heroku apps using DNSimple. Covers HTTP and HTTPS scenarios, SSL configuration, and Rack::SslEnforcer setup.
+meta: "Set up www to non-www redirects for Heroku apps using DNSimple. Covers HTTP and HTTPS scenarios, SSL configuration, and Rack::SslEnforcer setup."
 categories:
 - Domains and Transfers
 - Integrations

--- a/content/articles/redirector.md
+++ b/content/articles/redirector.md
@@ -1,7 +1,7 @@
 ---
 title: DNSimple Redirector
 excerpt: How to redirect HTTP and HTTPS requests from one host name to another URL using the DNSimple URL record.
-meta: Redirect HTTP and HTTPS requests to a different URL using DNSimple URL records. Supports 301 redirects, HTTPS with SSL certificates, wildcard redirects, and path forwarding.
+meta: Redirect HTTP and HTTPS requests using DNSimple URL records. Supports 301 redirects, HTTPS with SSL certificates, wildcard redirects, and path forwarding.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/restoring-domain.md
+++ b/content/articles/restoring-domain.md
@@ -1,7 +1,7 @@
 ---
 title: Restore a Domain
 excerpt: How to restore a domain with a DNSimple account.
-meta: How to restore an expired domain that has entered the redemption period through DNSimple. Covers restoration fees, timelines, and the steps to recover your domain.
+meta: Restore an expired domain in the redemption period through DNSimple. Covers restoration fees, timelines, and steps to recover your domain.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/reverse-dns.md
+++ b/content/articles/reverse-dns.md
@@ -1,7 +1,7 @@
 ---
 title: Reverse DNS Zones
 excerpt: We support reverse DNS zones.
-meta: Article on how to set up Reverse DNS zone. Reverse lookup zone is an authoritative DNS zone that is used primarily to resolve IP addresses to network resource names.
+meta: How to set up a reverse DNS zone. A reverse lookup zone resolves IP addresses to network resource names for email verification and diagnostics.
 categories:
 - DNS
 ---

--- a/content/articles/sandbox-pitfalls.md
+++ b/content/articles/sandbox-pitfalls.md
@@ -1,7 +1,7 @@
 ---
 title: Sandbox Common Pitfalls
 excerpt: Common pitfalls and things to keep in mind when working in the DNSimple Sandbox environment.
-meta: Avoid common mistakes when using the DNSimple Sandbox. Learn about domain registration behavior, DNS resolution limits, certificate testing, data persistence, and shared system considerations.
+meta: Common pitfalls when using the DNSimple Sandbox. Domain registration behavior, DNS resolution limits, certificate testing, and data persistence.
 categories:
 - API
 ---

--- a/content/articles/sandbox.md
+++ b/content/articles/sandbox.md
@@ -1,7 +1,7 @@
 ---
 title: What Is the DNSimple Sandbox?
 excerpt: An explanation of the DNSimple Sandbox environment for testing domains, DNS, integrations, and workflows without affecting production data.
-meta: Learn what the DNSimple Sandbox is, how it mirrors the full production environment, and how to use it for evaluating DNSimple, testing domain workflows, and developing API integrations safely.
+meta: The DNSimple Sandbox mirrors production for evaluating DNSimple, testing domain workflows, and developing API integrations without affecting live data.
 categories:
 - DNSimple
 - API

--- a/content/articles/service-binding-records.md
+++ b/content/articles/service-binding-records.md
@@ -1,7 +1,7 @@
 ---
 title: What Are Service Binding Records (SVCB and HTTPS)?
 excerpt: SVCB and HTTPS records are DNS record types that provide service binding information, enabling performance improvements, protocol optimization, and apex domain aliasing.
-meta: Learn about SVCB and HTTPS records, DNS record types that provide service binding information for network services, enabling better performance and protocol optimization.
+meta: SVCB and HTTPS are DNS record types that provide service binding information for network services, enabling better performance and protocol optimization.
 categories:
 - DNS
 ---

--- a/content/articles/services.md
+++ b/content/articles/services.md
@@ -1,7 +1,7 @@
 ---
 title: One-click Services
 excerpt: Services are DNS snippets ready for you to use in one click.
-meta: Discover DNSimple's services—ready-to-use DNS snippets that simplify domain management. Streamline your DNS setup with just one click and enhance your online presence.
+meta: DNSimple one-click services are ready-to-use DNS snippets that simplify domain management. Apply DNS configurations for popular providers in one click.
 categories:
 - Services
 ---

--- a/content/articles/set-up-email-forwarding.md
+++ b/content/articles/set-up-email-forwarding.md
@@ -1,7 +1,7 @@
 ---
 title: How to Set Up Email Forwarding
 excerpt: Set up email forwarding for your domain with this step-by-step guide covering prerequisites, configuration, and what to expect.
-meta: Step-by-step guide to setting up email forwarding for your domain in DNSimple. Learn how to configure email forwarding, what prerequisites you need, and what to expect after activation.
+meta: Set up email forwarding for your domain in DNSimple. Configure forwarding addresses, prerequisites, and what to expect after activation.
 categories:
 - Emails
 ---

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -1,6 +1,7 @@
 ---
 title: Setting the Name Servers for a Domain
 excerpt: To set the name servers, your domain must be registered with DNSimple. If it's not, use the control panel of your current domain registrar to update the name servers.
+meta: How to set name servers for your domain. Your domain must be registered with DNSimple, or use your current registrar's control panel.
 categories:
   - Name Servers
 ---

--- a/content/articles/squarespace-service.md
+++ b/content/articles/squarespace-service.md
@@ -1,7 +1,7 @@
 ---
 title: Squarespace Service
 excerpt: How to set up Squarespace DNS using DNSimple's One-click Service.
-meta: Easily point your domain to Squarespace using DNSimple's One-click DNS Service. Follow our step-by-step guide for a seamless setup and enhance your website's performance.
+meta: Point your domain to Squarespace using DNSimple's one-click service. Apply the required DNS records for Squarespace to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/ssl-certificate-authorities.md
+++ b/content/articles/ssl-certificate-authorities.md
@@ -1,7 +1,7 @@
 ---
 title: SSL Certificate Authorities Used by DNSimple
 excerpt: The list of certificate authorities used by DNSimple to sign SSL certificates, with product details and trust information.
-meta: DNSimple uses Sectigo and Let's Encrypt as certificate authorities. See which products each CA signs, validation methods, pricing, and trust store compatibility.
+meta: DNSimple uses Sectigo and Let's Encrypt as certificate authorities. See which products each CA signs, validation methods, pricing, and trust compatibility.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/ssl-certificate-product-specs.md
+++ b/content/articles/ssl-certificate-product-specs.md
@@ -1,7 +1,7 @@
 ---
 title: SSL Certificate Product Specifications
 excerpt: A side-by-side comparison of all DNSimple SSL certificate products, including pricing, validity, validation methods, and features.
-meta: Compare DNSimple SSL certificate products side by side. Covers Sectigo single-name, Sectigo wildcard, Let's Encrypt SAN, and Let's Encrypt wildcard certificates with pricing, validity, and features.
+meta: Compare DNSimple SSL certificate products. Sectigo single-name, Sectigo wildcard, Let's Encrypt SAN, and Let's Encrypt wildcard with pricing and features.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/ssl-certificate-with-windows.md
+++ b/content/articles/ssl-certificate-with-windows.md
@@ -1,7 +1,7 @@
 ---
 title: How to Install an SSL Certificate on Windows
 excerpt: How to identify your web server on Windows and follow the appropriate SSL certificate installation guide.
-meta: Learn how to install an SSL certificate on a Windows server by identifying your web server software and following the appropriate installation guide from DNSimple.
+meta: Install an SSL certificate on a Windows server. Identify your web server software and follow the appropriate installation guide from DNSimple.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/ssl-certificates-email-validation.md
+++ b/content/articles/ssl-certificates-email-validation.md
@@ -1,7 +1,7 @@
 ---
 title: SSL Certificate Email-Based Domain Validation
 excerpt: The email-based domain validation is the most common domain ownership validation method for a certificate and it is required for domain-validated certificates.
-meta: Understand how email-based domain validation works for SSL certificates, including approved email addresses, the validation process, and how to select or change your validation email.
+meta: How email-based domain validation works for SSL certificates, including approved email addresses, the validation process, and changing your validation email.
 categories:
 - SSL Certificates
 redirect_from:

--- a/content/articles/ssl-certificates-glossary.md
+++ b/content/articles/ssl-certificates-glossary.md
@@ -1,7 +1,7 @@
 ---
 title: SSL Certificate Glossary
 excerpt: Definitions of key terms related to SSL/TLS certificates, encryption, and certificate management.
-meta: Definitions of SSL certificate terms including CA, CSR, private key, TLS handshake, ECDSA, PEM, wildcard certificates, and more. Quick reference for DNSimple users.
+meta: SSL certificate glossary covering CA, CSR, private key, TLS handshake, ECDSA, PEM, wildcard certificates, and more. Quick reference for DNSimple users.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/ssl-certificates.md
+++ b/content/articles/ssl-certificates.md
@@ -1,7 +1,7 @@
 ---
 title: SSL/TLS Certificates
 excerpt: Information about purchasing and managing an SSL/TLS certificate with DNSimple.
-meta: Learn about DNSimple SSL certificate products, including Sectigo and Let's Encrypt options, pricing, validation methods, and how to manage certificates for your domains.
+meta: DNSimple SSL certificate products, including Sectigo and Let's Encrypt options, pricing, validation methods, and certificate management for your domains.
 categories:
 - SSL Certificates
 - Enterprise

--- a/content/articles/standard-vs-letsencrypt.md
+++ b/content/articles/standard-vs-letsencrypt.md
@@ -1,7 +1,7 @@
 ---
 title: Sectigo vs Let's Encrypt SSL Certificates
 excerpt: Explains the key differences between Sectigo and Let's Encrypt SSL certificates to help you choose the right certificate type.
-meta: Compare Sectigo and Let's Encrypt SSL certificates to find the best option for your site. Understand the differences in cost, expiration, validation, and features — including free and low-cost options.
+meta: Compare Sectigo and Let's Encrypt SSL certificates. Understand differences in cost, expiration, validation, and features to choose the right certificate.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/surge-service.md
+++ b/content/articles/surge-service.md
@@ -1,7 +1,7 @@
 ---
 title: Surge Service
 excerpt: How to set up Surge DNS using DNSimple's one-click service.
-meta: Easily point your domain to Surge using DNSimple's one-click service. Follow our step-by-step guide to streamline your DNS management and enhance your online presence.
+meta: Point your domain to Surge using DNSimple's one-click service. Apply the required DNS records for Surge to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/tender-service.md
+++ b/content/articles/tender-service.md
@@ -1,7 +1,7 @@
 ---
 title: Tender Service
 excerpt: How to set up Tender DNS using DNSimple's One-click Service.
-meta: Easily point your domain to Tender using DNSimple's One-click Service. Streamline your DNS management and enhance your online presence with our comprehensive guide.
+meta: Point your domain to Tender using DNSimple's one-click service. Apply the required DNS records for Tender to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/terraform-provider.md
+++ b/content/articles/terraform-provider.md
@@ -1,7 +1,7 @@
 ---
 title: Terraform Provider
 excerpt: How to use DNSimple's Terraform provider to manage your DNS
-meta: Discover how to efficiently manage your DNS using DNSimple's Terraform provider. Learn setup, configuration, and best practices to streamline your DNS management.
+meta: Manage your DNS with DNSimple's Terraform provider. Setup, configuration, and best practices for infrastructure-as-code DNS management.
 categories:
 - Integrations
 - Enterprise

--- a/content/articles/tlds-regulated.md
+++ b/content/articles/tlds-regulated.md
@@ -1,7 +1,7 @@
 ---
 title: Regulated Top-Level Domains
 excerpt: Information about regulated and highly-regulated TLDs.
-meta: Discover essential information about regulated and highly-regulated top-level domains (TLDs), including their requirements and implications for domain registration.
+meta: Regulated and highly-regulated top-level domains (TLDs), their requirements, restrictions, and implications for domain registration at DNSimple.
 categories:
 - TLDs
 - Domains and Transfers

--- a/content/articles/transfer-account-ownership.md
+++ b/content/articles/transfer-account-ownership.md
@@ -1,7 +1,7 @@
 ---
 title: Transfer Account Ownership
 excerpt: How to transfer ownership of the account to another DNSimple user.
-meta: Learn how to seamlessly transfer ownership of your DNSimple account to another user with our step-by-step guide, ensuring a smooth transition and secure management.
+meta: How to transfer ownership of your DNSimple account to another user. Step-by-step guide for a smooth and secure account transition.
 categories:
 - Account
 ---

--- a/content/articles/transferring-domain-away.md
+++ b/content/articles/transferring-domain-away.md
@@ -1,7 +1,7 @@
 ---
 title: Transfer a Domain Away from DNSimple
 excerpt: How to request a transfer code and transfer a domain from DNSimple to a different registrar.
-meta: How to transfer a domain away from DNSimple to another registrar. Covers unlocking the domain, requesting your authorization code, and initiating the transfer at the gaining registrar.
+meta: Transfer a domain from DNSimple to another registrar. Covers unlocking the domain, requesting your authorization code, and initiating the transfer.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/troubleshooting-dnssec-configurations.md
+++ b/content/articles/troubleshooting-dnssec-configurations.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot DNSSEC
 excerpt: Diagnose and resolve common DNSSEC issues for your domain, including checks for DS records, DNSKEYs, RRSIGs, and NSEC/NSEC3 records.
-meta: Troubleshoot DNSSEC with our detailed guide. Test and check your DS records, DNSKEYs, RRSIGs, and NSEC/NSEC3 to ensure your domain's DNSSEC validation is working.
+meta: Troubleshoot DNSSEC issues. Test and check DS records, DNSKEYs, RRSIGs, and NSEC/NSEC3 to ensure your domain's DNSSEC validation is working.
 categories:
   - DNSSEC
 ---

--- a/content/articles/troubleshooting-domain-transfer-issues.md
+++ b/content/articles/troubleshooting-domain-transfer-issues.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot Domain Transfer Issues
 excerpt: Solutions for common domain transfer problems, including denied transfers, missing authorization codes, and email delivery issues.
-meta: Fix common domain transfer problems at DNSimple, including denied transfers, missing or expired authorization codes, WHOIS email delivery issues, and 60-day transfer locks.
+meta: Fix domain transfer problems at DNSimple: denied transfers, missing or expired authorization codes, WHOIS email issues, and 60-day transfer locks.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/troubleshooting-domain-transfer-issues.md
+++ b/content/articles/troubleshooting-domain-transfer-issues.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot Domain Transfer Issues
 excerpt: Solutions for common domain transfer problems, including denied transfers, missing authorization codes, and email delivery issues.
-meta: Fix domain transfer problems at DNSimple: denied transfers, missing or expired authorization codes, WHOIS email issues, and 60-day transfer locks.
+meta: "Fix domain transfer problems at DNSimple: denied transfers, missing or expired authorization codes, WHOIS email issues, and 60-day transfer locks."
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/troubleshooting-email-authentication.md
+++ b/content/articles/troubleshooting-email-authentication.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot Email Authentication
 excerpt: How to diagnose SPF, DKIM, and DMARC failures using email headers and DNS verification.
-meta: Diagnose email authentication failures by reading email headers, identifying SPF, DKIM, and DMARC issues, and resolving common problems like alignment failures and missing records.
+meta: Diagnose email authentication failures by reading headers, identifying SPF, DKIM, and DMARC issues, and fixing alignment failures and missing records.
 categories:
 - Emails
 ---

--- a/content/articles/troubleshooting-lets-encrypt-failures.md
+++ b/content/articles/troubleshooting-lets-encrypt-failures.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting Let's Encrypt Certificate Failures
 excerpt: Your Let's Encrypt certificate is not issuing or renewing. Learn the common causes and how to fix them.
-meta: Fix Let's Encrypt SSL certificate failures in DNSimple. Covers DNS delegation issues, CAA record blocks, rate limits, DNSSEC misconfigurations, and Empty Non-Terminal problems.
+meta: Fix Let's Encrypt certificate failures in DNSimple. Covers DNS delegation issues, CAA record blocks, rate limits, DNSSEC errors, and ENT problems.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/troubleshooting-ssl-email-validation.md
+++ b/content/articles/troubleshooting-ssl-email-validation.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting Email Validation for SSL Certificates
 excerpt: Not receiving the domain validation email for your Sectigo SSL certificate? Learn the common causes and how to fix them.
-meta: Fix issues with SSL certificate email validation. Covers wrong email address, spam filters, WHOIS email deprecation, missing MX records, and how to resend the validation email.
+meta: Fix SSL certificate email validation issues. Covers wrong email address, spam filters, WHOIS email deprecation, missing MX records, and resending validation.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/understanding-email-deliverability.md
+++ b/content/articles/understanding-email-deliverability.md
@@ -1,7 +1,7 @@
 ---
 title: "Email Deliverability: How to Get Your Emails to the Inbox"
 excerpt: What email deliverability is, why emails end up in spam, and the factors that determine inbox placement.
-meta: Email deliverability is the ability to land emails in recipients' inboxes rather than spam folders. Learn how DNS authentication (SPF, DKIM, DMARC), sender reputation, list hygiene, and sending patterns determine inbox placement.
+meta: Email deliverability is the ability to land emails in inboxes, not spam. Learn how SPF, DKIM, DMARC, sender reputation, and list hygiene affect inbox placement.
 categories:
 - Emails
 ---

--- a/content/articles/validate-domain-ssl-certificate.md
+++ b/content/articles/validate-domain-ssl-certificate.md
@@ -1,7 +1,7 @@
 ---
 title: How to Validate Your Domain for an SSL Certificate
 excerpt: Learn how to complete domain validation for your SSL certificate using email-based or DNS-based validation methods in DNSimple.
-meta: Understand the domain validation methods available for SSL certificates in DNSimple, with step-by-step instructions for email-based (Sectigo) and DNS-based (Let's Encrypt) validation.
+meta: Domain validation methods for SSL certificates in DNSimple. Step-by-step instructions for email-based (Sectigo) and DNS-based (Let's Encrypt) validation.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/vanity-nameservers.md
+++ b/content/articles/vanity-nameservers.md
@@ -1,7 +1,7 @@
 ---
 title: Manage Vanity Name Servers
 excerpt: How to enable and disable vanity name servers in DNSimple.
-meta: How to enable and disable vanity name servers in DNSimple. Use your own domain as the name server authority (e.g., ns1.example.com) instead of the default DNSimple name servers.
+meta: Enable and disable vanity name servers in DNSimple. Use your own domain as the name server authority (e.g., ns1.example.com) instead of defaults.
 categories:
 - Name Servers
 - Domains and Transfers

--- a/content/articles/verifying-domain-resolution.md
+++ b/content/articles/verifying-domain-resolution.md
@@ -1,6 +1,6 @@
 ---
 title: Verify Domain Resolution
-meta: How to verify that your domain is resolving correctly using dig, nslookup, and online tools. Check DNS propagation and confirm your records are returning expected results.
+meta: Verify your domain is resolving correctly using dig, nslookup, and online tools. Check DNS propagation and confirm records return expected results.
 excerpt: How to verify that your domain is resolving correctly using dig, nslookup, and online tools.
 categories:
 - Domains and Transfers

--- a/content/articles/view-notes-audit-history.md
+++ b/content/articles/view-notes-audit-history.md
@@ -1,7 +1,7 @@
 ---
 title: View Record Notes and Audit History
 excerpt: How to view record notes you made and where to find record notes in your audit history.
-meta: Easily add notes to your DNS records in DNSimple to keep track of changes and their purposes, ensuring better management and organization of your domain settings.
+meta: View record notes and audit history in DNSimple. Track DNS record changes, see who made them, and review the notes attached to each change.
 categories:
 - DNS
 ---

--- a/content/articles/web-hosting.md
+++ b/content/articles/web-hosting.md
@@ -1,6 +1,6 @@
 ---
 title: Web Hosting Support
-meta: We focus primarily on domain management services. We don't provide web hosting allthough connecting to hosting providers is made easy with our one-click services.
+meta: DNSimple does not provide web hosting. We focus on domain management, and connecting to hosting providers is easy with our one-click services.
 excerpt: We focus primarily on domain management services. We don't provide web hosting.
 categories:
 - DNSimple

--- a/content/articles/webflow-service.md
+++ b/content/articles/webflow-service.md
@@ -1,6 +1,6 @@
 ---
 title: Webflow Service
-meta: Easily point your domain to Webflow using DNSimple's one-click service. Follow our step-by-step guide to streamline your website setup and enhanced DNS performance.
+meta: Point your domain to Webflow using DNSimple's one-click service. Apply the required DNS records for Webflow to your domain in one click.
 excerpt: How to set up Webflow DNS using DNSimple's one-click service.
 categories:
 - Services

--- a/content/articles/weebly-service.md
+++ b/content/articles/weebly-service.md
@@ -1,7 +1,7 @@
 ---
 title: Weebly Service
 excerpt: How to set up Weebly DNS using DNSimple's one-click service.
-meta: Easily point your domain to Weebly with DNSimple's one-click service. Follow our step-by-step guide for a seamless setup experience and enhance your website today!
+meta: Point your domain to Weebly using DNSimple's one-click service. Apply the required DNS records for Weebly to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/what-are-domain-contacts.md
+++ b/content/articles/what-are-domain-contacts.md
@@ -1,7 +1,7 @@
 ---
 title: What Are Domain Contacts?
 excerpt: Learn about domain contacts, the different contact types, and their roles in domain management.
-meta: Discover what domain contacts are, the different types of contacts (registrant, administrative, technical), and how contact information is used in domain management.
+meta: What domain contacts are, the types (registrant, administrative, technical), and how contact information is used in domain registration and management.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/what-happens-when-domain-expires.md
+++ b/content/articles/what-happens-when-domain-expires.md
@@ -1,7 +1,7 @@
 ---
 title: What Happens When a Domain Expires?
 excerpt: What happens when a domain expires, how to recover it, and understanding the associated fees.
-meta: Learn what happens when a domain expires, including grace periods, redemption periods, and deletion. Understand how to recover expired domains and the associated fees.
+meta: What happens when a domain expires, including grace periods, redemption periods, and deletion. How to recover expired domains and the associated fees.
 categories:
  - Domains and Transfers
 ---

--- a/content/articles/what-is-dane.md
+++ b/content/articles/what-is-dane.md
@@ -1,7 +1,7 @@
 ---
 title: What Is DANE (DNS-based Authentication of Named Entities)?
 excerpt: DANE is a security protocol that uses DNSSEC to publish and validate TLS certificate information in DNS records, enhancing the security of TLS connections.
-meta: Learn about DANE and how it uses DNSSEC to authenticate TLS certificates through DNS records, providing an additional layer of security for encrypted connections.
+meta: DANE uses DNSSEC to authenticate TLS certificates through DNS records, providing an additional layer of security for encrypted connections.
 categories:
 - DNS
 - DNSSEC

--- a/content/articles/what-is-dns.md
+++ b/content/articles/what-is-dns.md
@@ -1,7 +1,7 @@
 ---
 title: What Is DNS?
 excerpt: DNS stands for Domain Name System. It resolves human-readable domain names to machine-readable IP addresses so browsers can load websites.
-meta: DNS stands for Domain Name System - the protocol that translates domain names into IP addresses. Learn what DNS means, how DNS resolution works, and the role of DNS records, resolvers, and name servers.
+meta: DNS (Domain Name System) translates domain names into IP addresses. Learn how DNS resolution works and the role of DNS records, resolvers, and name servers.
 categories:
 - DNS
 ---

--- a/content/articles/what-is-dnssec.md
+++ b/content/articles/what-is-dnssec.md
@@ -1,7 +1,7 @@
 ---
 title: What Is DNSSEC (Domain Name System Security Extensions)?
 excerpt: DNSSEC adds cryptographic signatures to DNS, letting resolvers verify that responses are authentic and have not been tampered with.
-meta: What is DNSSEC? DNSSEC (Domain Name System Security Extensions) adds cryptographic signatures to DNS responses. Learn the meaning of DNSSEC, how it works, and whether you should enable it.
+meta: DNSSEC (Domain Name System Security Extensions) adds cryptographic signatures to DNS responses. Learn how DNSSEC works and whether to enable it.
 categories:
   - DNSSEC
   - Enterprise

--- a/content/articles/what-is-ssl-certificate.md
+++ b/content/articles/what-is-ssl-certificate.md
@@ -1,7 +1,7 @@
 ---
 title: What Is an SSL Certificate?
 excerpt: An SSL certificate is a digital credential that enables HTTPS encryption between a browser and a server, protecting data in transit and verifying the server's identity.
-meta: What is an SSL certificate and how does it work? Learn how SSL certificates encrypt web traffic, authenticate servers, and protect sensitive data — plus the difference between free and paid certificates.
+meta: An SSL certificate encrypts web traffic and authenticates servers. Learn how SSL works, what it protects, and the difference between free and paid certificates.
 categories:
 - SSL Certificates
 ---

--- a/content/articles/what-is-tld.md
+++ b/content/articles/what-is-tld.md
@@ -1,7 +1,7 @@
 ---
 title: What is a TLD?
 excerpt: The term top-level domain, or TLD, refers to the first part of every domain name.
-meta: Discover what a top-level domain (TLD) is and how it plays a crucial role in domain names. Learn about different TLD types and their significance in web addressing.
+meta: A top-level domain (TLD) is the last segment of a domain name, like .com or .org. Learn about TLD types and their role in the domain name system.
 categories:
 - TLDs
 - Domains and Transfers

--- a/content/articles/what-is-whois.md
+++ b/content/articles/what-is-whois.md
@@ -1,7 +1,7 @@
 ---
 title: What Is WHOIS?
 excerpt: Learn what WHOIS is, how it works, and why domain contact information is publicly accessible.
-meta: Discover what WHOIS is and how it provides public access to domain registration information. Learn about WHOIS databases, contact information, and privacy options.
+meta: What WHOIS is and how it provides public access to domain registration information. Covers WHOIS databases, contact details, and privacy options.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/where-are-your-servers-located.md
+++ b/content/articles/where-are-your-servers-located.md
@@ -1,7 +1,7 @@
 ---
 title: Where are your servers located?
 excerpt: Our Anycast network consists of multiple points-of-presence around the world.
-meta: Discover the global locations of our Anycast network servers, providing fast and reliable DNS services with multiple points-of-presence for enhanced performance.
+meta: DNSimple Anycast network server locations. Multiple global points-of-presence providing fast and reliable DNS resolution for your domains.
 categories:
 - DNSimple
 - Enterprise

--- a/content/articles/whois-privacy-blocks-transfer-email.md
+++ b/content/articles/whois-privacy-blocks-transfer-email.md
@@ -1,7 +1,7 @@
 ---
 title: Whois Privacy may cause transfer approval emails to not be delivered
 excerpt: Whois Privacy services often do not properly deliver transfer approval emails, and thus should be disabled before requesting a transfer.
-meta: WHOIS privacy can block domain transfer verification emails. Disable WHOIS privacy at your current registrar before starting a transfer to DNSimple to avoid email delivery failures.
+meta: WHOIS privacy can block domain transfer verification emails. Disable it at your current registrar before transferring to DNSimple to avoid failures.
 categories:
  - Whois Privacy
  - Domains and Transfers

--- a/content/articles/whois-privacy.md
+++ b/content/articles/whois-privacy.md
@@ -1,7 +1,7 @@
 ---
 title: WHOIS Privacy Protection
 excerpt: How to enable and disable WHOIS Privacy for a domain.
-meta: Learn how to easily enable and disable free WHOIS Privacy for your domain, protecting your personal information from public view and enhancing your online security.
+meta: Enable and disable free WHOIS Privacy for your domain at DNSimple to protect your personal information from public view in WHOIS lookups.
 categories:
 - Whois Privacy
 ---

--- a/content/articles/windows-azure-service.md
+++ b/content/articles/windows-azure-service.md
@@ -1,7 +1,7 @@
 ---
 title: Windows Azure Service
 excerpt: How to set up Windows Azure DNS using DNSimple's One-click Service.
-meta: Easily set up Windows Azure DNS with DNSimple's One-click Service. Follow our step-by-step guide to streamline your DNS management and enhance your cloud experience.
+meta: Set up Windows Azure DNS with DNSimple's one-click service. Apply the required DNS records for Azure to your domain in one click.
 categories:
 - Services
 ---

--- a/content/articles/zone-ns-records.md
+++ b/content/articles/zone-ns-records.md
@@ -1,7 +1,7 @@
 ---
 title: Zone NS Records
 excerpt: How to update zone NS records for a hosted domain.
-meta: Learn how to efficiently update Name Server records for your hosted domain in DNSimple, ensuring seamless domain management and optimal performance for your website.
+meta: How to update Name Server (NS) records for a hosted domain in DNSimple. Add, edit, or remove zone NS records to control DNS delegation.
 categories:
 - DNS
 ---


### PR DESCRIPTION
## Summary

- Shortened 127 meta descriptions flagged by Ahrefs as exceeding the recommended SEO limit (~155-160 characters)
- 8 category descriptions in `categories/meta.yaml` and 118 article `meta:` frontmatter fields across `content/articles/`
- Removed filler words ("comprehensive", "seamlessly", "effortlessly", "discover", "explore") and marketing phrases while preserving primary keywords and direct-answer phrasing for AI citation (GEO)
- Fixed a duplicate `meta:` field in `reasons-registering-domain.md` and added a missing `meta:` field to `setting-name-servers.md`

## Test plan

- [x] Verify meta descriptions render correctly on the built site (spot-check a few pages)
- [x] Confirm no frontmatter parsing errors from the changes
- [x] Spot-check that primary keywords are still present in shortened descriptions