### PR TITLE
Lengthen meta descriptions to 120-160 characters for SEO

### DIFF
--- a/content/articles/account-creation.md
+++ b/content/articles/account-creation.md
@@ -1,6 +1,7 @@
 ---
 title: Account Creation
 excerpt: How to sign up for a DNSimple account or create a new account for an existing DNSimple user.
+meta: Sign up for a DNSimple account, verify your email, choose a plan, and activate your subscription. Supports Google sign-in and multiple accounts.
 categories:
 - Account
 ---

--- a/content/articles/account-invoice-history.md
+++ b/content/articles/account-invoice-history.md
@@ -1,6 +1,7 @@
 ---
 title: Account Invoice History
 excerpt: Using the payment history on your account and understanding the states of the listed invoices.
+meta: View your DNSimple account invoice history, understand payment states like collected and failed, and retry failed invoice payments.
 categories:
 - Account
 ---

--- a/content/articles/account-multi.md
+++ b/content/articles/account-multi.md
@@ -1,6 +1,7 @@
 ---
 title: Multiple Accounts Per User
 excerpt: How to manage multiple accounts per DNSimple user and switch active accounts.
+meta: Manage multiple DNSimple accounts under one user profile. Create separate accounts for different projects and switch between them easily.
 categories:
 - Account
 ---

--- a/content/articles/activate-deactivate-dns-zone.md
+++ b/content/articles/activate-deactivate-dns-zone.md
@@ -1,7 +1,7 @@
 ---
 title: Activate and Deactivate a DNS Zone
 excerpt: How to activate or deactivate zones in your DNSimple account.
-meta: DNSimple provides a simple interface for activating and deactivating your DNS zones.
+meta: Activate or deactivate DNS zones in your DNSimple account to control DNS hosting for your domains. Inactive zones stop resolving and billing.
 categories:
 - DNS
 ---

--- a/content/articles/add-ns-records-for-subdomain.md
+++ b/content/articles/add-ns-records-for-subdomain.md
@@ -1,6 +1,7 @@
 ---
 title: Adding NS Records for a Subdomain
 excerpt: How to delegate a subdomain from a domain registered to custom name servers.
+meta: Add NS records for a subdomain in DNSimple to delegate DNS resolution to custom name servers, with verification steps using dig.
 categories:
 - Name Servers
 ---

--- a/content/articles/alias-record-reference.md
+++ b/content/articles/alias-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: ALIAS Record Reference
 excerpt: The formal structure, restrictions, and key technical details of an ALIAS record.
-meta: Learn more about the structure, restrictions, and technical details for ALIAS records.
+meta: ALIAS records are a proprietary DNSimple type providing CNAME-like functionality at the zone apex. Covers format, dynamic resolution, and key traits.
 categories:
 - DNS
 ---

--- a/content/articles/amazon-elasticbeanstalk-service.md
+++ b/content/articles/amazon-elasticbeanstalk-service.md
@@ -1,6 +1,7 @@
 ---
 title: AWS Elastic Beanstalk Service
 excerpt: How to set up AWS Elastic Beanstalk DNS using DNSimple's One-click Service.
+meta: Connect your domain to AWS Elastic Beanstalk using DNSimple One-click Services. Automatically configure the required DNS records.
 categories:
 - Services
 ---

--- a/content/articles/billing-settings.md
+++ b/content/articles/billing-settings.md
@@ -1,6 +1,7 @@
 ---
 title: Billing Settings
 excerpt: What you need to know about the billing information displayed on every invoice.
+meta: Customize billing information on invoices, including company name, tax ID, and address. Teams plans and higher can set a separate billing email.
 categories:
 - Account
 ---

--- a/content/articles/caa-record-format.md
+++ b/content/articles/caa-record-format.md
@@ -1,7 +1,7 @@
 ---
 title: CAA Record Format and Policy Tags
 excerpt: The structure and canonical representation of a CAA record
-meta: Learn more about the structure of CAA records and policy tags.
+meta: CAA records control which Certificate Authorities can issue certificates for your domain. Reference covers format, flags, tags, and examples.
 categories:
 - DNS
 ---

--- a/content/articles/changing-domain-contact.md
+++ b/content/articles/changing-domain-contact.md
@@ -1,6 +1,7 @@
 ---
 title: Changing Domain Contacts
 excerpt: How to change or update the contact assigned to a domain or part of its data.
+meta: Change or update the contact assigned to a domain registered with DNSimple. Assign new contacts, edit details, and monitor registrant changes.
 categories:
 - Contacts
 ---

--- a/content/articles/cname-record-reference.md
+++ b/content/articles/cname-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: CNAME Record Reference
 excerpt: The formal structure, restrictions, and key technical details of a CNAME record.
-meta: Learn more about the structure, restrictions, and technical details for CNAME records.
+meta: CNAME records map one domain name to another as an alias. Reference covers format, DNSimple configuration, and critical restrictions for proper use.
 categories:
 - DNS
 ---

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -1,6 +1,7 @@
 ---
 title: Managing Your Contacts
 excerpt: This article explains how to manage your contacts for your domains and SSL certificates.
+meta: Create, update, and delete domain contacts in your DNSimple account. Keep contact information accurate to avoid ICANN verification issues.
 categories:
 - Contacts
 ---

--- a/content/articles/create-record-deletion-note.md
+++ b/content/articles/create-record-deletion-note.md
@@ -1,7 +1,7 @@
 ---
 title: Create a Record Deletion Note
 excerpt: Make notes to remember why you deleted a specific record.
-meta: Easily add notes to your DNS records in DNSimple to keep track of record deletions.
+meta: Add a deletion note when removing a DNS record in DNSimple to document why the record was deleted and maintain a clear audit trail.
 categories:
 - DNS
 ---

--- a/content/articles/create-record-note.md
+++ b/content/articles/create-record-note.md
@@ -1,7 +1,7 @@
 ---
 title: Create a Record Note
 excerpt: How to create a record note
-meta: Learn how to create a record note to remember why you made changes to a given DNS record.
+meta: Add notes to DNS records in DNSimple when creating or editing them. Record notes help your team track why changes were made.
 categories:
 - DNS
 ---

--- a/content/articles/delegating-dnsimple-hosted.md
+++ b/content/articles/delegating-dnsimple-hosted.md
@@ -1,6 +1,7 @@
 ---
 title: Delegating a Domain registered with another Registrar to DNSimple
 excerpt: How to delegate a domain registered with a different registrar to DNSimple's name servers.
+meta: Delegate a domain registered with another registrar to DNSimple name servers by updating your name server settings at your current provider.
 categories:
 - Name Servers
 ---

--- a/content/articles/delegating-dnsimple-registered.md
+++ b/content/articles/delegating-dnsimple-registered.md
@@ -1,6 +1,7 @@
 ---
 title: Delegating a Domain registered with DNSimple to DNSimple
 excerpt: How to delegate a domain registered with DNSimple to DNSimple's name servers.
+meta: Point your DNSimple-registered domain to DNSimple name servers to resolve DNS records configured in your DNSimple account.
 categories:
 - Name Servers
 ---

--- a/content/articles/dkim-record-reference.md
+++ b/content/articles/dkim-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: DKIM Record Reference
 excerpt: The formal structure, behavior, and key technical details of a DKIM record.
-meta: Learn more about the structure, behavior, and technical details for DKIM records.
+meta: DKIM records store public keys used to verify email signatures. Reference covers TXT record format, selector naming, tags, and DNSimple setup.
 categories:
 - DNS
 - Emails

--- a/content/articles/dmarc-record-reference.md
+++ b/content/articles/dmarc-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: DMARC Record Reference
 excerpt: The formal structure, behavior, and key technical details of a DMARC record.
-meta: Learn more about the structure, behavior, and technical details for DMARC records.
+meta: DMARC records set email authentication policies and reporting for your domain. Reference covers TXT record format, policy tags, and DNSimple setup.
 categories:
 - DNS
 - Emails

--- a/content/articles/domain-registration-reference.md
+++ b/content/articles/domain-registration-reference.md
@@ -1,7 +1,7 @@
 ---
 title: Domain Registration Reference
 excerpt: The formal requirements, restrictions, and key technical details of domain registration.
-meta: Learn more about the requirements, restrictions, and technical details for domain registration.
+meta: Domain registration requirements, character restrictions, pricing, WHOIS privacy, and auto-renewal options for registering domains with DNSimple.
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/domains-au.md
+++ b/content/articles/domains-au.md
@@ -1,6 +1,7 @@
 ---
 title: .AU Domains
 excerpt: This article explains the requirements and special procedures for .AU domain names.
+meta: Register .AU domains with DNSimple. Australian presence and a valid eligibility ID are required for second-level and third-level .AU domain registrations.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-bank.md
+++ b/content/articles/domains-bank.md
@@ -1,6 +1,7 @@
 ---
 title: .BANK Domains
 excerpt: This article explains the requirements and special procedures for .BANK domain names.
+meta: Register .BANK domains on DNSimple Enterprise plans with eligibility verification, DNSSEC, HTTPS security, and annual re-verification required.
 categories:
 - TLDs
 - Enterprise

--- a/content/articles/domains-be.md
+++ b/content/articles/domains-be.md
@@ -1,6 +1,7 @@
 ---
 title: .BE Domains
 excerpt: This article explains the requirements and special procedures for .BE names.
+meta: Register .BE domains with DNSimple. DNS Belgium sends a confirmation email to complete registration. Contact changes and transfers have specific requirements.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-berlin.md
+++ b/content/articles/domains-berlin.md
@@ -1,6 +1,7 @@
 ---
 title: .BERLIN Domains
 excerpt: This article explains the requirements and special procedures for .BERLIN names.
+meta: Register .BERLIN domains through DNSimple. The registrant address must be located in Berlin, and the city is verified during the registration process.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-ca.md
+++ b/content/articles/domains-ca.md
@@ -1,6 +1,7 @@
 ---
 title: .CA Domains
 excerpt: This article explains the requirements and special procedures for .ca domain names.
+meta: Register .CA domains with DNSimple. New registrants must agree to the CIRA registrant agreement within five days to complete registration.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-ch.md
+++ b/content/articles/domains-ch.md
@@ -1,6 +1,7 @@
 ---
 title: .CH Domains
 excerpt: This article explains the requirements and special procedures for .CH domain names.
+meta: .CH domains only support auto-renewal through DNSimple. Manual renewals are not available, and domains without auto-renewal are removed before expiration.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-cm.md
+++ b/content/articles/domains-cm.md
@@ -1,6 +1,7 @@
 ---
 title: .CM Domains
 excerpt: This article explains the requirements and special procedures for .CM domain names.
+meta: Register .CM domains with DNSimple. Name server changes are limited to 3-4 per 30 days, and expired .CM domains have no grace or redemption period.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-co-nz.md
+++ b/content/articles/domains-co-nz.md
@@ -1,6 +1,7 @@
 ---
 title: .CO.NZ Domains
 excerpt: This article explains the requirements and special procedures for .CO.NZ domain names.
+meta: Register .CO.NZ domains with DNSimple. This third-level .NZ domain is intended for commercial organizations, open to registrants worldwide.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-co-uk.md
+++ b/content/articles/domains-co-uk.md
@@ -1,6 +1,7 @@
 ---
 title: .CO.UK Domains
 excerpt: This article explains the requirements and special procedures for .CO.UK domain names.
+meta: Register .CO.UK domains with DNSimple. Open worldwide with no eligibility restrictions. Transfers may include a 2-year extension based on time remaining.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-co.md
+++ b/content/articles/domains-co.md
@@ -1,6 +1,7 @@
 ---
 title: .CO Domains
 excerpt: This article explains the requirements and special procedures for .CO domain names.
+meta: Register .CO domains with DNSimple. Open worldwide for individuals and organizations, .CO is a popular alternative to .COM in the tech industry.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-com-au.md
+++ b/content/articles/domains-com-au.md
@@ -1,6 +1,7 @@
 ---
 title: .COM.AU Domains
 excerpt: This article explains the requirements and special procedures for .COM.AU domain names.
+meta: Register .COM.AU domains with DNSimple. Requires an Australian business presence, a valid eligibility ID like an ABN or ACN, and an Australian address.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-com-co.md
+++ b/content/articles/domains-com-co.md
@@ -1,6 +1,7 @@
 ---
 title: .COM.CO Domains
 excerpt: This article explains the requirements and special procedures for .COM.CO domain names.
+meta: Register .COM.CO domains with DNSimple. This commercial third-level .CO domain is open worldwide for individuals and organizations.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-day.md
+++ b/content/articles/domains-day.md
@@ -1,6 +1,7 @@
 ---
 title: .DAY Domains
 excerpt: This article explains the requirements and special procedures for .DAY domain names.
+meta: .DAY is a secured namespace requiring HTTPS. Register .DAY domains through DNSimple and obtain an SSL certificate for browser-based access.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-eco.md
+++ b/content/articles/domains-eco.md
@@ -1,6 +1,7 @@
 ---
 title: .ECO Domains
 excerpt: This article explains the requirements and special procedures for .ECO domain names.
+meta: Register .ECO domains through DNSimple. Activate your domain by creating a .ECO profile with the registry to enable DNS resolution.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-es.md
+++ b/content/articles/domains-es.md
@@ -1,6 +1,7 @@
 ---
 title: .ES Domains
 excerpt: This article explains the requirements and special procedures for .ES domain names.
+meta: Register and transfer .ES domains through DNSimple. Registration requires a Spanish legal form and ID type. Transfers need explicit acknowledgment.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-eu.md
+++ b/content/articles/domains-eu.md
@@ -1,6 +1,7 @@
 ---
 title: .EU Domains
 excerpt: This article explains the requirements and special procedures for .EU domain names.
+meta: Register .EU domains through DNSimple. EU citizenship, residency, or an EU-established organization is required. Agree to the registry data transfer policy.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-fi.md
+++ b/content/articles/domains-fi.md
@@ -1,6 +1,7 @@
 ---
 title: .FI Domains
 excerpt: This article explains the requirements and special procedures for .FI domain names.
+meta: Register .FI domains with DNSimple. Open worldwide for individuals and organizations. Finnish companies may need to provide a Y-tunnus business ID.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-fr.md
+++ b/content/articles/domains-fr.md
@@ -1,6 +1,7 @@
 ---
 title: .FR Domains
 excerpt: This article explains the requirements and special procedures for .FR domain names.
+meta: Register .FR domains with DNSimple. Open worldwide for individuals and organizations. French companies may need to provide a SIRET business number.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-gay.md
+++ b/content/articles/domains-gay.md
@@ -1,6 +1,7 @@
 ---
 title: .GAY Domains
 excerpt: This article explains the requirements and special procedures for .GAY domain names.
+meta: Register .GAY domains through DNSimple. Anti-LGBTQ content is strictly prohibited, and 20% of each registration is donated to GLAAD and CenterLink.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-gen-nz.md
+++ b/content/articles/domains-gen-nz.md
@@ -1,6 +1,7 @@
 ---
 title: .GEN.NZ Domains
 excerpt: This article explains the requirements and special procedures for .GEN.NZ domain names.
+meta: Register .GEN.NZ domains with DNSimple. This general-purpose third-level .NZ domain is open to individuals and organizations worldwide.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-insurance.md
+++ b/content/articles/domains-insurance.md
@@ -1,6 +1,7 @@
 ---
 title: .INSURANCE Domains
 excerpt: This article explains the requirements and special procedures for .INSURANCE domain names.
+meta: Register .INSURANCE domains on a DNSimple Enterprise plan. Eligibility verification, DNSSEC, HTTPS, and annual re-verification are required by the registry.
 categories:
 - TLDs
 - Enterprise

--- a/content/articles/domains-io.md
+++ b/content/articles/domains-io.md
@@ -1,6 +1,7 @@
 ---
 title: .IO Domains
 excerpt: This article explains the requirements and special procedures for .IO domain names.
+meta: Register .IO domains with DNSimple. Open worldwide, .IO is popular with technology companies, startups, and developer tool projects.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-is.md
+++ b/content/articles/domains-is.md
@@ -1,6 +1,7 @@
 ---
 title: .IS Domains
 excerpt: This article explains the requirements and special procedures for .IS domain names.
+meta: Transfer .IS domains to DNSimple using contact handle BDB2-IS instead of an auth code. Point name servers to DNSimple before starting the transfer.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-it.md
+++ b/content/articles/domains-it.md
@@ -1,6 +1,7 @@
 ---
 title: .IT Domains
 excerpt: This article explains the requirements and special procedures for .it domain names.
+meta: Register .IT domains through DNSimple. EU citizenship or residency is required, along with a taxpayer number and acceptance of Italian registry terms.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-jobs.md
+++ b/content/articles/domains-jobs.md
@@ -1,6 +1,7 @@
 ---
 title: .JOBS Domains
 excerpt: This article explains the requirements and special procedures for .JOBS domain names.
+meta: Register .JOBS domains through DNSimple. Provide your company URL and industry details for registry review and approval before activation.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-jp.md
+++ b/content/articles/domains-jp.md
@@ -1,6 +1,7 @@
 ---
 title: .JP Domains
 excerpt: This article explains the requirements and special procedures for .JP domain names.
+meta: .JP domains registered with DNSimple require auto-renewal enabled. Manual renewal is not supported, and transfers are blocked within 30 days of expiry.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-li.md
+++ b/content/articles/domains-li.md
@@ -1,6 +1,7 @@
 ---
 title: .LI Domains
 excerpt: This article explains the requirements and special procedures for .LI domain names.
+meta: .LI domains only support auto-renewal through DNSimple. Manual renewals are not available, and domains without auto-renewal are removed before expiration.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-mx.md
+++ b/content/articles/domains-mx.md
@@ -1,6 +1,7 @@
 ---
 title: .MX Domains
 excerpt: This article explains the requirements and special procedures for .MX domain names.
+meta: Transfer .MX domains to DNSimple using the registry-approved process. The current registrar must approve the request, which can take up to 10 days.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-net-au.md
+++ b/content/articles/domains-net-au.md
@@ -1,6 +1,7 @@
 ---
 title: .NET.AU Domains
 excerpt: This article explains the requirements and special procedures for .NET.AU domain names.
+meta: Register .NET.AU domains with DNSimple. Requires an Australian business presence, a valid eligibility ID like an ABN or ACN, and an Australian address.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-net-co.md
+++ b/content/articles/domains-net-co.md
@@ -1,6 +1,7 @@
 ---
 title: .NET.CO Domains
 excerpt: This article explains the requirements and special procedures for .NET.CO domain names.
+meta: Register .NET.CO domains with DNSimple. This third-level .CO domain is open worldwide and primarily used by network infrastructure providers.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-net-nz.md
+++ b/content/articles/domains-net-nz.md
@@ -1,6 +1,7 @@
 ---
 title: .NET.NZ Domains
 excerpt: This article explains the requirements and special procedures for .NET.NZ domain names.
+meta: Register .NET.NZ domains with DNSimple. This third-level .NZ domain is open worldwide and intended for network infrastructure providers.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-nl.md
+++ b/content/articles/domains-nl.md
@@ -1,6 +1,7 @@
 ---
 title: .NL Domains
 excerpt: This article explains the requirements and special procedures for .NL domain names.
+meta: Register .NL domains with DNSimple. Open worldwide for individuals and organizations. Dutch companies may need a KVK Chamber of Commerce number.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-nom-co.md
+++ b/content/articles/domains-nom-co.md
@@ -1,6 +1,7 @@
 ---
 title: .NOM.CO Domains
 excerpt: This article explains the requirements and special procedures for .NOM.CO domain names.
+meta: Register .NOM.CO personal domains with DNSimple. This third-level .CO domain is open worldwide for individuals seeking a nom de plume domain name.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-nz.md
+++ b/content/articles/domains-nz.md
@@ -1,6 +1,7 @@
 ---
 title: .NZ Domains
 excerpt: This article explains the requirements and special procedures for .NZ domain names.
+meta: Register .NZ domains and third-level extensions like .CO.NZ, .NET.NZ, .ORG.NZ, and .GEN.NZ through DNSimple. Open to individuals and organizations.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-org-au.md
+++ b/content/articles/domains-org-au.md
@@ -1,6 +1,7 @@
 ---
 title: .ORG.AU Domains
 excerpt: This article explains the requirements and special procedures for .ORG.AU domain names.
+meta: Register .ORG.AU domains with DNSimple. Restricted to Australian non-profits, charities, and associations. Requires a valid ABN and an Australian address.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-org-nz.md
+++ b/content/articles/domains-org-nz.md
@@ -1,6 +1,7 @@
 ---
 title: .ORG.NZ Domains
 excerpt: This article explains the requirements and special procedures for .ORG.NZ domain names.
+meta: Register .ORG.NZ domains with DNSimple. This third-level .NZ domain is designed for non-profit organizations, charities, and community groups.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-org-uk.md
+++ b/content/articles/domains-org-uk.md
@@ -1,6 +1,7 @@
 ---
 title: .ORG.UK Domains
 excerpt: This article explains the requirements and special procedures for .ORG.UK domain names.
+meta: Register .ORG.UK domains with DNSimple for non-profit organizations and charities. Transfers may include a 2-year extension based on time remaining.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-pl.md
+++ b/content/articles/domains-pl.md
@@ -1,6 +1,7 @@
 ---
 title: .PL Domains
 excerpt: This article explains the requirements and special procedures for .PL domain names.
+meta: Register .PL domains through DNSimple. You must specify whether the contact personal data can be published, as required by the .PL registry since 2025.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-se.md
+++ b/content/articles/domains-se.md
@@ -1,6 +1,7 @@
 ---
 title: .SE Domains
 excerpt: This article explains the requirements and special procedures for .SE domain names.
+meta: Register .SE domains through DNSimple. An ID number is required by NIC-SE, and EU companies outside Sweden must provide a VAT ID.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-sg.md
+++ b/content/articles/domains-sg.md
@@ -1,6 +1,7 @@
 ---
 title: .SG Domains
 excerpt: This article explains the requirements and special procedures for .sg domain names.
+meta: Register .SG and .COM.SG domains with DNSimple. Companies need a registration number or RCBID, and individuals require a Singpass ID.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-uk.md
+++ b/content/articles/domains-uk.md
@@ -1,6 +1,7 @@
 ---
 title: .UK Domains
 excerpt: This article explains the requirements and special procedures for .UK domain names.
+meta: Register and transfer .UK domains with DNSimple. Reservation rules apply for existing .CO.UK holders, and transfers require an IPS tag change.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-us.md
+++ b/content/articles/domains-us.md
@@ -1,6 +1,7 @@
 ---
 title: .US Domains
 excerpt: This article explains the requirements and special procedures for .US domain names.
+meta: Transfer .US domains to DNSimple with explicit email acknowledgment. Unacknowledged transfers are automatically canceled after 14 days.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-xxx.md
+++ b/content/articles/domains-xxx.md
@@ -1,6 +1,7 @@
 ---
 title: .XXX Domains
 excerpt: This article explains the requirements and special procedures for .XXX domain names.
+meta: Register .XXX domains through DNSimple. A Member Auth Token from the ICM Registry is required to activate domain resolution for adult entertainment sites.
 categories:
 - TLDs
 ---

--- a/content/articles/domains-za.md
+++ b/content/articles/domains-za.md
@@ -1,6 +1,7 @@
 ---
 title: .ZA Domains
 excerpt: This article explains the requirements and special procedures for .ZA domain names.
+meta: Transfer .ZA domains to DNSimple with explicit email acknowledgment. Unacknowledged .ZA transfers are canceled after 14 days.
 categories:
 - TLDs
 ---

--- a/content/articles/forgot-password.md
+++ b/content/articles/forgot-password.md
@@ -1,6 +1,7 @@
 ---
 title: Forgot Password
 excerpt: Forgot your password? Use this guide to reset your password so you can log in.
+meta: Reset your DNSimple password with a secure email link. Includes troubleshooting steps for missing reset emails and alternative sign-in methods.
 categories:
 - Account
 ---

--- a/content/articles/github-pages.md
+++ b/content/articles/github-pages.md
@@ -1,6 +1,7 @@
 ---
 title: GitHub Pages
 excerpt: How to point your root or apex domain to host your site with GitHub Pages using DNSimple.
+meta: Point your apex domain to GitHub Pages using DNSimple One-click Services or a manual ALIAS record. Includes GitHub setup steps.
 categories:
 - Services
 - Integrations

--- a/content/articles/heroku-connector.md
+++ b/content/articles/heroku-connector.md
@@ -1,6 +1,7 @@
 ---
 title: Heroku Connector
 excerpt: How to connect a Heroku app to your domain using DNSimple's Heroku Connector
+meta: Connect your domain to a Heroku app with the DNSimple Heroku Connector. Authorize both accounts and configure DNS records automatically.
 categories:
 - Connectors
 - Integrations

--- a/content/articles/hinfo-record-reference.md
+++ b/content/articles/hinfo-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: HINFO Record Reference
 excerpt: The formal structure, restrictions, and key technical details of HINFO records.
-meta: Learn more about the structure, security considerations, and technical details for HINFO records.
+meta: HINFO records describe a host's hardware and operating system. Reference covers format, CPU and OS fields, examples, and security considerations.
 categories:
 - DNS
 ---

--- a/content/articles/hinfo-records.md
+++ b/content/articles/hinfo-records.md
@@ -1,7 +1,7 @@
 ---
 title: What Are HINFO Records?
 excerpt: HINFO records indicate the hardware type and operating system of the host.
-meta: Learn how HINFO records work and why they have largely been superseded.
+meta: HINFO records store hardware and operating system details for a host in DNS. Rarely used in modern deployments due to security concerns.
 categories:
 - DNS
 ---

--- a/content/articles/how-to-add-dns-records.md
+++ b/content/articles/how-to-add-dns-records.md
@@ -1,7 +1,7 @@
 ---
 title: How To Add Common DNS Records
 excerpt: How to add common DNS records to your domains.
-meta: Learn more about how to add common DNS records in DNSimple.
+meta: Add A, AAAA, CNAME, ALIAS, TXT, URL, and NS records to your domain in DNSimple using the record editor with step-by-step instructions.
 categories:
 - DNS
 ---

--- a/content/articles/mx-record-reference.md
+++ b/content/articles/mx-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: MX Record Reference
 excerpt: The formal structure, behavior, and key technical details of an MX record.
-meta: Learn more about the structure, behavior, and technical details for MX records.
+meta: MX records direct email to the correct mail servers for a domain. Reference covers format, priority behavior, redundancy, and DNSimple configuration.
 categories:
 - DNS
 - Emails

--- a/content/articles/netlify-connector.md
+++ b/content/articles/netlify-connector.md
@@ -1,6 +1,7 @@
 ---
 title: Netlify Connector
 excerpt: How to connect a Netlify app to your domain using DNSimple's Netlify Connector
+meta: Connect your domain to a Netlify site with the DNSimple Netlify Connector. Set up DNS records and Netlify configuration automatically.
 categories:
 - Connectors
 ---

--- a/content/articles/oauth-applications.md
+++ b/content/articles/oauth-applications.md
@@ -1,6 +1,7 @@
 ---
 title: OAuth Applications
 excerpt: Explains how to create a new OAuth application for access to the API version 2.
+meta: Register and manage OAuth applications in DNSimple to authorize third-party access to the API without sharing account passwords.
 categories:
 - API
 - Enterprise

--- a/content/articles/product-expiring-tomorrow-notification.md
+++ b/content/articles/product-expiring-tomorrow-notification.md
@@ -1,6 +1,7 @@
 ---
 title: Product Expiring Tomorrow Notification
 excerpt: The Product Expiring Tomorrow email contains a list of domains expiring within 24 hours.
+meta: The Product Expiring Tomorrow email alerts you when domains, certificates, or WHOIS privacies are set to expire within 24 hours.
 categories:
 - DNSimple
 ---

--- a/content/articles/ptr-record-reference.md
+++ b/content/articles/ptr-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: PTR Record Reference
 excerpt: The formal structure, restrictions, and key technical details of a PTR record.
-meta: Learn more about the structure, restrictions, and technical details for PTR records.
+meta: PTR records map IP addresses to domain names for reverse DNS lookups. Reference covers format, IPv4 and IPv6 syntax, use cases, and management.
 categories:
 - DNS
 ---

--- a/content/articles/resolving-with-us.html
+++ b/content/articles/resolving-with-us.html
@@ -1,7 +1,7 @@
 ---
 title: Resolving with DNSimple
 excerpt: Show off a DNSimple badge on your website.
-meta: Enhance your online presence by showcasing a DNSimple badge on your website for credibility.
+meta: Display a Resolving with DNSimple badge on your website. Choose from light and dark themes, with code snippets ready to copy and paste.
 categories:
 - DNS
 ---

--- a/content/articles/secondary-dns-provider-dyn.md
+++ b/content/articles/secondary-dns-provider-dyn.md
@@ -1,6 +1,7 @@
 ---
 title: Adding Dyn as a Secondary DNS Server
 excerpt: Secondary DNS can be complicated to set up. We simplify it with provider specific settings for Dyn.
+meta: Set up Dyn Standard or Dyn Managed as a secondary DNS provider with DNSimple using preconfigured AXFR zone transfer settings.
 categories:
 - Secondary DNS
 - Enterprise

--- a/content/articles/secondary-dns.md
+++ b/content/articles/secondary-dns.md
@@ -1,6 +1,7 @@
 ---
 title: Add a secondary DNS server to DNSimple
 excerpt: This page provides information about secondary DNS configuration with DNSimple.
+meta: Configure secondary DNS with DNSimple using AXFR zone transfers for DNS redundancy. Supports Dyn, DNSMadeEasy, EasyDNS, and custom providers.
 categories:
 - Secondary DNS
 - Enterprise

--- a/content/articles/set-up-dkim.md
+++ b/content/articles/set-up-dkim.md
@@ -1,7 +1,7 @@
 ---
 title: Set Up DKIM
 excerpt: How to set up DKIM on your domains.
-meta: Learn how to set up DKIM by using a specially formatted DNS text record storing a public key.
+meta: Configure DKIM for your domain in DNSimple by adding a TXT or CNAME record with the public key from your email service provider.
 categories:
 - DNS
 - Emails

--- a/content/articles/set-up-dmarc.md
+++ b/content/articles/set-up-dmarc.md
@@ -1,7 +1,7 @@
 ---
 title: Set Up DMARC
 excerpt: How to set up DMARC in your DNSimple account.
-meta: Learn how to set up DMARC and what to expect from your email provider.
+meta: Set up a DMARC record in DNSimple by adding a TXT record with your policy, then verify and monitor aggregate email reports.
 categories:
 - DNS
 - Emails

--- a/content/articles/soa-record-reference.md
+++ b/content/articles/soa-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: SOA Record Reference
 excerpt: The structure and canonical representation of an SOA record
-meta: Learn more about the structure of SOA records, their components, and key technical details.
+meta: SOA records define administrative details for a DNS zone. Reference covers format, components like serial, refresh, retry, expire, and behavior.
 categories:
 - DNS
 ---

--- a/content/articles/spf-syntax-validation-reference.md
+++ b/content/articles/spf-syntax-validation-reference.md
@@ -1,7 +1,7 @@
 ---
 title: SPF Record Syntax and Validation Reference
 excerpt: The syntax, mechanisms, modifiers, and validation rules that govern SPF records.
-meta: Learn more about the syntax, mechanisms, modifiers, and validation rules for SPF records.
+meta: SPF records authorize which servers can send email for your domain. Reference covers syntax, mechanisms, qualifiers, modifiers, and validation rules.
 categories:
 - DNS
 - Emails

--- a/content/articles/sshfp-record-reference.md
+++ b/content/articles/sshfp-record-reference.md
@@ -1,7 +1,7 @@
 ---
 title: SSHFP Record Reference
 excerpt: The structure and canonical representation of an SSHFP record
-meta: Learn more about the structure, format, and key technical details of SSHFP records.
+meta: SSHFP records store SSH server fingerprints in DNS for host key verification. Reference covers format, algorithm types, fingerprint types, and examples.
 categories:
 - DNS
 ---

--- a/content/articles/sshfp-records.md
+++ b/content/articles/sshfp-records.md
@@ -1,7 +1,7 @@
 ---
 title: What Are SSHFP Records?
 excerpt: SSHFP records securely publish SSH host key fingerprints in DNS.
-meta: Learn how SSHFP records enhance the security and user experience of SSH connections.
+meta: SSHFP records publish SSH host key fingerprints in DNS for secure, automated server verification. Requires DNSSEC for full protection.
 categories:
 - DNS
 ---

--- a/content/articles/system-records.md
+++ b/content/articles/system-records.md
@@ -1,7 +1,7 @@
 ---
 title: What Are System Records?
 excerpt: What system records are, and how they work in DNSimple.
-meta: Learn what system records are, their importance in DNS management, and why you cannot edit them.
+meta: System records are SOA and NS records that DNSimple automatically creates and manages for your domain. Covers their purpose and why they cannot be edited.
 categories:
   - DNS
 ---

--- a/content/articles/understanding-email-bounces.md
+++ b/content/articles/understanding-email-bounces.md
@@ -1,7 +1,7 @@
 ---
 title: Email Bounces
 excerpt: About email bounces, the different types of bounces, and what causes them.
-meta: Learn about email bounces, including hard bounces, soft bounces, DSN codes, and how to handle them.
+meta: Understand hard bounces, soft bounces, and DSN codes. Identify causes of email delivery failures and reduce bounce rates effectively.
 categories:
 - Emails
 ---

--- a/content/articles/url-record-format-details.md
+++ b/content/articles/url-record-format-details.md
@@ -1,7 +1,7 @@
 ---
 title: URL Record Format and Technical Details
 excerpt: The formal structure, restrictions, and technical details of a URL record.
-meta: Learn more about the structure, restrictions, and technical details for URL records.
+meta: URL records are a proprietary DNSimple record type that handle HTTP redirects. Reference covers format, configuration, and technical implementation.
 categories:
   - DNS
 ---

--- a/content/articles/verify-dkim.md
+++ b/content/articles/verify-dkim.md
@@ -1,7 +1,7 @@
 ---
 title: Verify DKIM with dig and Online Tools
 excerpt: How to verify your DKIM record is being returned correctly.
-meta: Learn how to verify your DKIM record is working and find online tools to help monitor.
+meta: Verify your DKIM record with dig and online tools to confirm correct DNS configuration and troubleshoot authentication failures.
 categories:
 - DNS
 - Emails

--- a/content/articles/verifying-dmarc.md
+++ b/content/articles/verifying-dmarc.md
@@ -1,7 +1,7 @@
 ---
 title: Verify DMARC with dig and Online Tools
 excerpt: How to verify your DMARC record is being returned correctly.
-meta: Learn how to verify your DMARC record is working and find online tools to help monitor.
+meta: Verify your DMARC record with dig or online tools like MX Toolbox, and set up aggregate report monitoring with DNSimple.
 categories:
 - DNS
 - Emails

--- a/content/articles/verifying-spf.md
+++ b/content/articles/verifying-spf.md
@@ -1,7 +1,7 @@
 ---
 title: Verify SPF with dig and Online Tools
 excerpt: How to verify your SPF record is being returned correctly.
-meta: Learn how to verify your SPF record is working and find online tools to help monitor.
+meta: Verify your SPF record with dig or online tools, understand validation results, and fix common issues like syntax errors.
 categories:
 - DNS
 - Emails

--- a/content/articles/what-are-glue-records.md
+++ b/content/articles/what-are-glue-records.md
@@ -1,7 +1,7 @@
 ---
 title: What Are Glue Records?
 excerpt: Learn what glue records are and why they matter.
-meta: Discover the importance of glue records and how they solve a fundamental problem in DNS.
+meta: Glue records provide IP addresses for name servers within their own domain, solving the circular dependency problem in DNS delegation.
 categories:
   - DNS
   - Name Servers

--- a/content/articles/what-is-a-nameserver.md
+++ b/content/articles/what-is-a-nameserver.md
@@ -1,6 +1,7 @@
 ---
 title: What is a name server?
 excerpt: An explanation of what name servers are, why they're important, and how to set them up.
+meta: Name servers translate domain names into IP addresses for internet navigation. Change your name servers in DNSimple with a few steps.
 categories:
 - Name Servers
 ---

--- a/content/articles/what-is-zone-file.md
+++ b/content/articles/what-is-zone-file.md
@@ -1,7 +1,7 @@
 ---
 title: What Is a Zone File?
 excerpt: What a zone file is and their key benefits and uses.
-meta: Learn what zone files are, their importance in DNS management, and what's inside them.
+meta: A zone file is a text-based blueprint of your domain DNS configuration, containing all resource records. Export and import zone files with DNSimple.
 categories:
 - DNS
 - Enterprise


### PR DESCRIPTION
## Summary

- Ahrefs flagged 95 articles with meta descriptions under 100 characters. Two were false positives (SSL troubleshooting articles whose metas were truncated at quote marks in the CSV export), leaving 93 articles to update.
- Updated the `meta:` frontmatter field in 92 files (93 articles, one is an `.html` file) to the 120-160 character range recommended for optimal SERP display and AI answer engine extraction.
- Individualized every meta description based on each article's unique content -- particularly the 44 TLD domain articles that previously all shared the same generic template.

## Test plan

- [x] Verify meta descriptions render correctly on the site (spot-check a few articles in staging)
- [x] Confirm frontmatter YAML parses without errors (site builds successfully)
- [x] Spot-check a sample of TLD articles to confirm metas reflect each TLD's unique registration requirements