### PR TITLE
Add Domain Trustee explanation article

### DIFF
--- a/categories/domains_and_transfers.yaml
+++ b/categories/domains_and_transfers.yaml
@@ -7,6 +7,7 @@ Explanation:
     - "What Is a Domain?"
     - "What Is WHOIS?"
     - "What is a TLD?"
+    - "What is Domain Trustee?"
     - "What Is Domain Transfer?"
     - "What Are Domain Contacts?"
     - "What Is Domain Lock?"

--- a/categories/domains_and_transfers.yaml
+++ b/categories/domains_and_transfers.yaml
@@ -7,7 +7,7 @@ Explanation:
     - "What Is a Domain?"
     - "What Is WHOIS?"
     - "What is a TLD?"
-    - "What is Domain Trustee?"
+    - "What Is Domain Trustee?"
     - "What Is Domain Transfer?"
     - "What Are Domain Contacts?"
     - "What Is Domain Lock?"

--- a/content/articles/changing-domain-contact.md
+++ b/content/articles/changing-domain-contact.md
@@ -17,6 +17,8 @@ categories:
 
 For domains registered with DNSimple, [Domain Managers](https://support.dnsimple.com/articles/domain-access-control/#domain-manager) and anyone with [Full Access](https://support.dnsimple.com/articles/domain-access-control/#full-access) can change the contact associated with a domain at any time.
 
+Domains that use [domain trustee](/articles/what-is-domain-trustee/) may show only the extended attributes that still apply for that trustee configuration when you update contacts.
+
 > [!NOTE] Domains not registered with DNSimple
 > These instructions apply only to domains registered with DNSimple. If you are hosting the domain with us, and the domain is registered elsewhere, you will have to update the contact information at your current registrar, or transfer the domain to DNSimple.
 

--- a/content/articles/domain-registration-reference.md
+++ b/content/articles/domain-registration-reference.md
@@ -31,7 +31,7 @@ When registering a domain, you must provide accurate registrant contact informat
 
 ### Extended attributes
 
-**TLD-specific requirements:** Depending on the TLD, you may need to fill out extended attributes that are required for registration. These attributes vary by TLD and may include:
+**TLD-specific requirements:** Depending on the TLD, you may need to fill out extended attributes that are required for registration. Some TLDs support [domain trustee](/articles/what-is-domain-trustee/) service, which can change which attributes the registry collects when you register or transfer. These attributes vary by TLD and may include:
 
 - Additional contact information
 - Business registration numbers

--- a/content/articles/domain-transfer.md
+++ b/content/articles/domain-transfer.md
@@ -49,7 +49,7 @@ At DNSimple:
 3. Enter the name of the domain that is being transferred and click **Start Transfer**.
 4. Enter the authorization code.
 5. Select a registrant if a contact has already been made. If not, fill in the information needed to create a contact.
-6. Depending on the TLD, you may have to fill out extended attributes that are required. 
+6. Depending on the TLD, you may have to fill out extended attributes that are required. Some TLDs support [domain trustee](/articles/what-is-domain-trustee/) service during transfer when local presence or similar registry rules apply.
 7. WHOIS Privacy Protection can be enabled by checking the **Hide my contact information in WHOIS** box, so it is enabled immediately upon completion of the transfer.
 8. Auto renewal for the domain is automatically checked to be enabled. This can be disabled if desired by unchecking the box. If auto renewal is disabled, check out [how to renew a domain](/articles/renewing-domain/).
 9. Click <label>Transfer [Domain name]</label>. The card on file will be charged.

--- a/content/articles/domains-com-br.md
+++ b/content/articles/domains-com-br.md
@@ -16,7 +16,7 @@ This article explains how .COM.BR registration works with DNSimple, including tr
 
 ## Registering a .COM.BR domain {#registering}
 
-Registration of .COM.BR domains requires **trustee service**. The registry applies eligibility rules for who may hold a .COM.BR name; trustee service satisfies those rules by using a local partner as the legal registrant so you can register and manage the domain without your own Brazilian entity. 
+Registration of .COM.BR domains requires [**domain trustee** service](/articles/what-is-domain-trustee/). The registry applies eligibility rules for who may hold a .COM.BR name; trustee service satisfies those rules by using a local partner as the legal registrant so you can register and manage the domain without your own Brazilian entity. 
 
 Through DNSimple, trustee service is **included** and applied when you register the domain; you do not need to request it or purchase it separately.
 

--- a/content/articles/transferring-domain-between-accounts.md
+++ b/content/articles/transferring-domain-between-accounts.md
@@ -20,6 +20,8 @@ categories:
 
 You can transfer a domain between DNSimple accounts any time via the DNSimple interface. Billing responsibility will be transferred to the new domain account once the move is accepted. Transferring a domain to another account will transfer all associated resources, like DNS records, SSL certificates, and email forwards.
 
+If the domain uses [domain trustee](/articles/what-is-domain-trustee/), the push flow may only prompt for extended attributes that still apply under that trustee configuration.
+
 Working with a Reseller? Follow the steps outlined [here](#accepting-a-transfer) to gain access to your account. If you cannot find a domain in your account, see [I Can't Find My Domain](/articles/finding-missing-domain/).
 
 > [!WARNING]

--- a/content/articles/what-is-domain-trustee.md
+++ b/content/articles/what-is-domain-trustee.md
@@ -3,6 +3,7 @@ title: What is Domain Trustee?
 excerpt: Domain trustee service helps you register or transfer TLDs when the registry requires local presence or other rules you cannot meet alone; you stay the beneficiary.
 meta: "What domain trustee is in DNSimple: trustee partner vs beneficiary, optional vs required trustee by TLD, registration and transfer availability, extended attributes, billing, and using trustee with the API."
 categories:
+- Contacts
 - Domains and Transfers
 ---
 

--- a/content/articles/what-is-domain-trustee.md
+++ b/content/articles/what-is-domain-trustee.md
@@ -1,7 +1,7 @@
 ---
 title: What is Domain Trustee?
 excerpt: Domain trustee service helps you register or transfer TLDs when the registry requires local presence or other rules you cannot meet alone; you stay the beneficiary.
-meta: What domain trustee is in DNSimple: trustee partner vs beneficiary, optional vs required trustee by TLD, registration and transfer availability, extended attributes, billing, and using trustee with the API.
+meta: "What domain trustee is in DNSimple: trustee partner vs beneficiary, optional vs required trustee by TLD, registration and transfer availability, extended attributes, billing, and using trustee with the API."
 categories:
 - Domains and Transfers
 ---

--- a/content/articles/what-is-domain-trustee.md
+++ b/content/articles/what-is-domain-trustee.md
@@ -1,0 +1,54 @@
+---
+title: What is Domain Trustee?
+excerpt: Domain trustee service helps you register or transfer TLDs when the registry requires local presence or other rules you cannot meet alone; you stay the beneficiary.
+meta: What domain trustee is in DNSimple: trustee partner vs beneficiary, optional vs required trustee by TLD, registration and transfer availability, extended attributes, billing, and using trustee with the API.
+categories:
+- Domains and Transfers
+---
+
+# What is Domain Trustee?
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+Some top-level domains (TLDs) require local presence, a designated registrant type, or other eligibility you may not be able to provide directly. **Domain trustee** service bridges that gap: DNSimple arranges trustee coverage so you can register or transfer eligible domains while you continue to manage the domain from your account.
+
+## What is a Domain Trustee? {#what-is-a-domain-trustee}
+
+A **domain trustee** is the party that meets the registry's eligibility role on paper—often a local partner or designated registrant—when rules say the domain cannot be held under your personal or company details alone. **You remain the beneficiary**: you keep operational control through DNSimple (DNS, renewal, transfers, and account billing). The trustee fulfills the registry's legal or administrative requirement so the registration or transfer can complete.
+
+## How do optional and required trustee differ? {#optional-vs-required}
+
+**Optional trustee** — The TLD supports trustee, but registration or transfer may still be possible without it if you supply every registry requirement yourself (for example, all [extended attributes](/articles/domain-registration-reference/#extended-attributes)). When you choose trustee, the flow may ask for fewer registry fields than when trustee is off.
+
+**Required trustee** — The registry mandates trustee for that TLD. You cannot opt out; trustee is part of standard eligibility. How it appears in checkout (included in the price versus a separate fee) depends on the TLD. See [.COM.BR domains](/articles/domains-com-br/) for an example where trustee is required.
+
+Trustee is not universal: many TLDs do not offer it. Whether a suffix supports optional trustee, requires trustee, or offers no trustee depends on the registry.
+
+## When is domain trustee available? {#when-available}
+
+Trustee service applies only during [domain registration](/articles/registering-domain/) and [domain transfers into DNSimple](/articles/domain-transfer/). You make the choice in that flow for eligible TLDs, alongside options such as [WHOIS privacy](/articles/what-is-whois-privacy/) or [auto-renewal](/articles/domain-auto-renewal/). You cannot turn trustee on later as a standalone domain setting like an integration or DNS template.
+
+## How does domain trustee affect extended attributes? {#extended-attributes}
+
+Many TLDs collect extended attributes—extra registry fields beyond standard contact data—during registration or transfer.
+
+When trustee applies, you may still need to provide some attributes, or none, depending on the TLD and whether trustee is optional or required. If trustee is optional and you disable it, you normally must complete the full attribute set the registry requests.
+
+After registration, updates follow trustee rules: when you [change domain contacts](/articles/changing-domain-contact/) or [push the domain to another DNSimple account](/articles/transferring-domain-between-accounts/), you may only see extended attributes that still apply for domains using trustee service.
+
+## How is domain trustee billed? {#billing}
+
+When trustee is optional and you add it, DNSimple lists trustee as its own invoice line item next to registration or transfer. When trustee is required or bundled for a TLD, pricing is shown in the purchase flow for that extension. Account-level discounts can apply to trustee service where DNSimple has configured them, similar to other registration products.
+
+## Can you use domain trustee through the API? {#api}
+
+Yes. If you register or transfer domains using the [DNSimple API](/articles/api-documentation/), the same optional-or-required trustee rules apply as in the dashboard. Use the [developer documentation](https://developer.dnsimple.com/) for the exact requests and responses for your integration.
+
+## Have more questions?
+
+If you have any questions about domain trustee service, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.


### PR DESCRIPTION
## Summary

Adds a new Explanation article for Domain Trustee, covering:
- What the service is (trustee vs beneficiary)
- When it applies (registration and transfer only)
- Optional vs required trustee behavior by TLD
- How trustee affects extended attributes
- Billing behavior and a brief API overview

## Changes

- `content/articles/what-is-domain-trustee.md` — new article
- `categories/domains_and_transfers.yaml` — added under Explanation → Core Domain Concepts
- Added cross-links from:
  - `.COM.BR domains`
  - Domain registration reference
  - Domain transfer
  - Changing domain contacts
  - Transfer to another account

## Test plan

- [ ] `nanoc build` renders the new article and category entry
- [ ] Internal links resolve correctly
- [ ] Article appears in Domains and Transfers → Explanation