### PR TITLE
Fix Domain Trustee category listings (exact title match)

### DIFF
--- a/categories/contacts.yaml
+++ b/categories/contacts.yaml
@@ -1,6 +1,7 @@
 Managing contacts:
 - "Changing Domain Contacts"
 - "Managing Your Contacts"
+- "What is Domain Trustee?"
 
 Troubleshooting:
 - "ICANN 60-Day Lock After Change of Registrant"

--- a/categories/contacts.yaml
+++ b/categories/contacts.yaml
@@ -1,7 +1,7 @@
 Managing contacts:
 - "Changing Domain Contacts"
 - "Managing Your Contacts"
-- "What is Domain Trustee?"
+- "What Is Domain Trustee?"
 
 Troubleshooting:
 - "ICANN 60-Day Lock After Change of Registrant"

--- a/categories/domains_and_transfers.yaml
+++ b/categories/domains_and_transfers.yaml
@@ -7,7 +7,7 @@ Explanation:
     - "What Is a Domain?"
     - "What Is WHOIS?"
     - "What is a TLD?"
-    - "What Is Domain Trustee?"
+    - "What is Domain Trustee?"
     - "What Is Domain Transfer?"
     - "What Are Domain Contacts?"
     - "What Is Domain Lock?"

--- a/categories/domains_and_transfers.yaml
+++ b/categories/domains_and_transfers.yaml
@@ -7,7 +7,7 @@ Explanation:
     - "What Is a Domain?"
     - "What Is WHOIS?"
     - "What is a TLD?"
-    - "What is Domain Trustee?"
+    - "What Is Domain Trustee?"
     - "What Is Domain Transfer?"
     - "What Are Domain Contacts?"
     - "What Is Domain Lock?"

--- a/content/articles/what-is-domain-trustee.md
+++ b/content/articles/what-is-domain-trustee.md
@@ -1,5 +1,5 @@
 ---
-title: What is Domain Trustee?
+title: What Is Domain Trustee?
 excerpt: Domain trustee service helps you register or transfer TLDs when the registry requires local presence or other rules you cannot meet alone; you stay the beneficiary.
 meta: "What domain trustee is in DNSimple: trustee partner vs beneficiary, optional vs required trustee by TLD, registration and transfer availability, extended attributes, billing, and using trustee with the API."
 categories:
@@ -7,7 +7,7 @@ categories:
 - Domains and Transfers
 ---
 
-# What is Domain Trustee?
+# What Is Domain Trustee?
 
 ### Table of Contents {#toc}
 
@@ -18,7 +18,7 @@ categories:
 
 Some top-level domains (TLDs) require local presence, a designated registrant type, or other eligibility you may not be able to provide directly. **Domain trustee** service bridges that gap: DNSimple arranges trustee coverage so you can register or transfer eligible domains while you continue to manage the domain from your account.
 
-## What is a Domain Trustee? {#what-is-a-domain-trustee}
+## What Is a Domain Trustee? {#what-is-a-domain-trustee}
 
 A **domain trustee** is the party that meets the registry's eligibility role on paper—often a local partner or designated registrant—when rules say the domain cannot be held under your personal or company details alone. **You remain the beneficiary**: you keep operational control through DNSimple (DNS, renewal, transfers, and account billing). The trustee fulfills the registry's legal or administrative requirement so the registration or transfer can complete.
 


### PR DESCRIPTION
## Summary

The Domain Trustee article appeared under **Other** on the Domains and Transfers category page because `lib/sub_categories.rb` matches YAML entries to the article frontmatter `title` with exact string equality. The YAML used `What Is Domain Trustee?` while the article title is `What is Domain Trustee?`.

## Changes

- `categories/domains_and_transfers.yaml` — use `What is Domain Trustee?` under Explanation → Core Domain Concepts so it resolves correctly.
- `categories/contacts.yaml` — list the same title under Managing contacts (the article is tagged with both Contacts and Domains and Transfers).

## Test plan

- `nanoc build`
- Confirm Domains and Transfers shows the article under Explanation → Core Domain Concepts, not Other
- Confirm Contacts category lists it under Managing contacts