### PR TITLE
Mention contact email verification in contact management article

### DIFF
--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -36,6 +36,9 @@ You can also create a new contact at any time through the **Contacts** page.
 
 ![creating a new contact](/files/change-contact-1.png)
 
+> [!NOTE]
+> If the email address on the contact has not been verified, you will receive a verification email. Follow the link in the email to complete the verification.
+
 ## Updating contacts
 
 If a contact is associated with multiple domains, updating that contact also updates all the contact information associated with these domains. You don't need to individually update these domains if they're associated with the same contact.
@@ -44,6 +47,9 @@ To update the contact for a specific domain, you will need to [replace the domai
 
 > [!NOTE]
 > When a domain contact has been changed, you will receive a confirmation email from no-reply@ispapi.net. You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
+
+> [!NOTE]
+> If you update a contact's email address and it has not been verified, you will receive a verification email. Follow the link in the email to complete the verification.
 
 ### Deleting a contact
 

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -47,9 +47,9 @@ To update the contact for a specific domain, you will need to [replace the domai
 
 > [!NOTE]
 > When you update a domain contact:
-- You will receive a confirmation email from no-reply@ispapi.net.
-- You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
-- If you update the contact's email address you may also receive an specific email to verify the new email address.
+> - You will receive a confirmation email from no-reply@ispapi.net.
+> - You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
+> - If you update the contact's email address you may also receive an specific email to verify the new email address.
 
 ### Deleting a contact
 

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -37,7 +37,7 @@ You can also create a new contact at any time through the **Contacts** page.
 ![creating a new contact](/files/change-contact-1.png)
 
 > [!NOTE]
-> If the email address on the contact has not been verified, you will receive a verification email. Follow the link in the email to complete the verification.
+> If the email address on the contact has not been verified to comply with [NIS2 regulations](https://nis2directive.eu/what-is-nis2/), you will receive a verification email. Follow the link in the email to complete the verification.
 
 ## Updating contacts
 
@@ -46,10 +46,10 @@ If a contact is associated with multiple domains, updating that contact also upd
 To update the contact for a specific domain, you will need to [replace the domain contact](/articles/changing-domain-contact/#replacing-a-domain-contact) with a new one.
 
 > [!NOTE]
-> When a domain contact has been changed, you will receive a confirmation email from no-reply@ispapi.net. You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
-
-> [!NOTE]
-> If you update a contact's email address and it has not been verified, you will receive a verification email. Follow the link in the email to complete the verification.
+> When you update a domain contact:
+- You will receive a confirmation email from no-reply@ispapi.net.
+- You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
+- If you update the contact's email address you may also receive an specific email to verify the new email address.
 
 ### Deleting a contact
 


### PR DESCRIPTION
## Summary

Updating the [Contact Management article](https://support.dnsimple.com/articles/contact-management) to mention that email verification may be required.

## Files changed

- `content/articles/contact-management.md`

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [x] Cross-links added on first mention of related concepts
- [x] Existing articles updated to link back (if applicable)
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`
- [x] Tested locally with `rake run`

## Review

- [x] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)
