### PR TITLE
Add NO support page

### DIFF
--- a/categories/tlds.yaml
+++ b/categories/tlds.yaml
@@ -46,6 +46,7 @@ TLDs:
   - ".NET.CO Domains"
   - ".NET.NZ Domains"
   - ".NL Domains"
+  - ".NO Domains"
   - ".NOM.CO Domains"
   - ".NZ Domains"
   - ".ORG.AU Domains"

--- a/content/articles/domains-no.md
+++ b/content/articles/domains-no.md
@@ -1,0 +1,39 @@
+---
+title: .NO Domains
+excerpt: This article explains the requirements and special procedures for .NO domain names.
+meta: Register and transfer .NO domains with DNSimple. Norwegian address and organization or person identifier, renewal window, transfers, and optional trustee service.
+categories:
+- TLDs
+---
+
+# .NO Domain Names
+
+* TOC
+{:toc}
+
+---
+
+This article explains the requirements and special procedures for .NO domain names.
+
+## Eligibility and restrictions {#eligibility}
+
+The registrant must have a valid postal address in Norway.
+
+- Organizations must be registered in Norway in the Brønnøysund Register Centre ([Enhetsregisteret](https://www.brreg.no/en/)) as an [approved organization type](https://www.norid.no/regelverk/vedlegg-e.en.html) and use a Norwegian postal address. An organization may register up to 100 domain names under .no per owner record, subject to registry limits.
+
+- Individuals must be 18 or older, registered in the National Registry with a Norwegian national identity number, and have a Norwegian postal address. Private individuals may hold a limited number of .no names per registry policy; see the [registry site for individuals](https://www.norid.no/en/nytt/privatpersoner-2014/) for current limits and geographical categories.
+
+The registry may verify registrations (for example by phone or documented proof) to confirm the request is legitimate.
+
+Depending on whether the registrant is a natural person or an organization, you provide one of the following with the registration or registrant change:
+
+- Person identifier - Format `N.PRI.XXXXXXXX`, issued by the registry. Request a person identifier through [Norid's person ID service](https://pid.norid.no/personid/personid). The national identity number itself is not used as the person identifier in the registration extension.
+- Organization number - The organization's number as registered in Enhetsregisteret (verify at [brreg.no](https://www.brreg.no/en/)).
+
+## Phone verification {#phone-verification}
+
+The [registrar](https://www.centralnicreseller.com/) requires phone verification for new registrations. The registrar will call the registrant to confirm their details, and the registrant has 48 hours to answer and complete verification. If verification is not completed within 48 hours, the domain will be suspended. The registrant can then contact the registrar to complete verification and restore the domain.
+
+## Have more questions?
+
+If you have questions about .NO domains, [contact our support team](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/tlds.md
+++ b/content/articles/tlds.md
@@ -68,6 +68,7 @@ Requirements, eligibility, registration and transfer rules, and any special step
 - [.NET.CO Domains](/articles/domains-net-co/) - Requirements and procedures for .NET.CO domain names.
 - [.NET.NZ Domains](/articles/domains-net-nz/) - Requirements and procedures for .NET.NZ domain names.
 - [.NL Domains](/articles/domains-nl/) - Open worldwide; KVK number for Dutch organizations, standard contact for individuals.
+- [.NO Domains](/articles/domains-no/) - Norwegian postal address; person identifier or organization number.
 - [.NOM.CO Domains](/articles/domains-nom-co/) - Requirements and procedures for .NOM.CO domain names.
 - [.NZ Domains](/articles/domains-nz/) - Requirements and procedures for .NZ domain names.
 - [.ORG.AU Domains](/articles/domains-org-au/) - Requirements and procedures for .ORG.AU domain names.


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2711

This PR adds the new support pages for:
- https://support.dnsimple.com/articles/domains-no/


## :mag: QA

- None needed.


## :clipboard: Deployment Pre/Post tasks


## :shipit: Deployment Verification

- [x] SHA is deployed