### PR TITLE
Add Troubleshoot DNSimple Name Servers to Name Servers category

### DIFF
--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -18,3 +18,7 @@ How-to:
   Name server sets and vanity name servers:
     - "Name Server Sets"
     - "Manage Vanity Name Servers"
+
+Troubleshooting:
+  DNSimple name servers:
+    - "Troubleshoot DNSimple Name Servers"

--- a/content/articles/troubleshoot-dnsimple-name-servers.md
+++ b/content/articles/troubleshoot-dnsimple-name-servers.md
@@ -4,6 +4,7 @@ excerpt: This article contains instructions to check and debug domain resolution
 meta: Explore this comprehensive guide to troubleshoot common issues with name servers, ensuring your website is accessible and functioning properly.
 categories:
 - DNS
+- Name Servers
 ---
 
 # Troubleshoot DNSimple Name Servers


### PR DESCRIPTION
## Summary

P3 IA row from [gaps analysis](docs/name-servers-gaps-analysis.md): surface **Troubleshoot DNSimple Name Servers** on the Name Servers category index.

## Depends on

- Merge https://github.com/dnsimple/dnsimple-support/pull/1920 (chain through earlier gap PRs) first so `categories/name_servers.yaml` already contains the new sections.

## Changes

- Add **Name Servers** to frontmatter on `troubleshoot-dnsimple-name-servers.md`
- Append `Troubleshooting DNSimple name servers` section in `categories/name_servers.yaml`.