### PR TITLE
Rewrite delegation how-to (setting-name-servers)

### DIFF
--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -13,7 +13,7 @@ How-to:
     - "Delegating a Domain registered with another Registrar to DNSimple"
     - "Delegating a Domain registered with DNSimple to DNSimple"
   Delegation settings and child zones:
-    - "Change delegation to another DNS provider (DNSimple registration)"
+    - "Change delegation to another DNS provider"
     - "Adding NS Records for a Subdomain"
   Name server sets and vanity name servers:
     - "Name Server Sets"

--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -13,7 +13,7 @@ How-to:
     - "Delegating a Domain registered with another Registrar to DNSimple"
     - "Delegating a Domain registered with DNSimple to DNSimple"
   Delegation settings and child zones:
-    - "Change Name Servers to another DNS provider
+    - "Change delegation to another DNS provider (DNSimple registration)"
     - "Adding NS Records for a Subdomain"
   Name server sets and vanity name servers:
     - "Name Server Sets"

--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -13,7 +13,7 @@ How-to:
     - "Delegating a Domain registered with another Registrar to DNSimple"
     - "Delegating a Domain registered with DNSimple to DNSimple"
   Delegation settings and child zones:
-    - "Change delegation to another DNS provider (DNSimple registration)"
+    - "Change Name Servers to another DNS provider
     - "Adding NS Records for a Subdomain"
   Name server sets and vanity name servers:
     - "Name Server Sets"

--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -13,7 +13,7 @@ How-to:
     - "Delegating a Domain registered with another Registrar to DNSimple"
     - "Delegating a Domain registered with DNSimple to DNSimple"
   Delegation settings and child zones:
-    - "Setting the Name Servers for a Domain"
+    - "Change delegation to another DNS provider (DNSimple registration)"
     - "Adding NS Records for a Subdomain"
   Name server sets and vanity name servers:
     - "Name Server Sets"

--- a/content/articles/cloudflare-ds-record.md
+++ b/content/articles/cloudflare-ds-record.md
@@ -25,7 +25,7 @@ If you want to use Cloudflare's DNSSEC with a domain registered through DNSimple
 
 ## Enable DNSSEC at Cloudflare
 
-To use Cloudflare's DNSSEC, you will need to [delegate your registered domain to Cloudflare's name servers in DNSimple](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider). To prevent downtime, make sure to set up all of the appropriate DNS records at Cloudflare before delegating the domain to them.
+To use Cloudflare's DNSSEC, you will need to [change delegation to Cloudflare's name servers in DNSimple](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider). To prevent downtime, make sure to set up all of the appropriate DNS records at Cloudflare before delegating the domain to them.
 
 Once the delegation is changed, you can start the process of enabling DNSSEC at Cloudflare.
 

--- a/content/articles/cloudflare-service.md
+++ b/content/articles/cloudflare-service.md
@@ -27,7 +27,7 @@ You can use Cloudflare services with DNSimple via [direct integraiton](#direct-i
 
 Direct integration requires to change the name servers for your domain to point to Cloudflare name servers.
 
-If your domain is registered with DNSimple, follow these instructions to [configure the name servers for a domain](/articles/setting-name-servers/). If the domain is registered elsewhere, you will need to follow the instructions of your existing domain registrar to point the domain to Cloudflare. In both cases, once the domain is pointing to Cloudflare, you will need to manage the DNS records in Cloudflare. Any DNS change in your DNSimple account for that domain will no longer have any effect, including changing DNS records, enabling/disabling one-click services and enabling/disabling email forwards.
+If your domain is registered with DNSimple, follow these instructions to [change delegation to another DNS provider](/articles/setting-name-servers/). If the domain is registered elsewhere, you will need to follow the instructions of your existing domain registrar to point the domain to Cloudflare. In both cases, once the domain is pointing to Cloudflare, you will need to manage the DNS records in Cloudflare. Any DNS change in your DNSimple account for that domain will no longer have any effect, including changing DNS records, enabling/disabling one-click services and enabling/disabling email forwards.
 
 Furthermore, the direct integration doesn't allow selectively delegating only certain DNS records to Cloudflare. If you want to use Cloudflare only for a specific DNS record (e.g. for the main website) and use DNSimple for all the other records (e.g. MX email configurations), then use the one-click DNSimple integration.
 

--- a/content/articles/domain-transfer.md
+++ b/content/articles/domain-transfer.md
@@ -98,7 +98,7 @@ When the transfer is completed, you will receive a confirmation email from DNSim
 
 To avoid unexpected downtime and confusion, we do not change the domain name servers upon a successful transfer. When the domain is transferred to us, we will keep using the same name servers previously configured for the domain.
 
-You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered/) in one click or [manually configure the name servers](/articles/setting-name-servers/).
+You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered/) in one click or [change the name server delegation](/articles/setting-name-servers/).
 
 > [!WARNING]
 > We suggest pointing [your domain to our name servers before the transfer](/articles/before-transferring-domain/) to avoid downtime during the transfer. Some DNS providers will stop serving the DNS for the domain as soon as the transfer is completed.

--- a/content/articles/domains-uk.md
+++ b/content/articles/domains-uk.md
@@ -103,7 +103,7 @@ When the transfer has completed, you will receive an email from DNSimple confirm
 > [!WARNING]
 > We don't automatically point your domain to our name servers when the transfer completes. We suggest pointing [your domain to our name servers before the transfer](/articles/before-transferring-domain/) to avoid downtime during the transfer. Some DNS providers will stop serving the DNS for the domain as soon as the transfer has completed.
 
-You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered/) in one click, or [manually configure the name servers](/articles/setting-name-servers/).
+You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered/) in one click, or [change the name server delegation](/articles/setting-name-servers/).
 
 ### Expiration extension
 

--- a/content/articles/integrated-domain-provider-transfer-domain.md
+++ b/content/articles/integrated-domain-provider-transfer-domain.md
@@ -72,7 +72,7 @@ When the transfer is completed, you will receive a confirmation email from DNSim
 
 To avoid unexpected downtime and confusion, we do not change the domain name servers upon a successful transfer. When the domain is transferred to us, we will keep using the same name servers previously configured for the domain.
 
-You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered/) in one click, or [manually configure the name servers](/articles/setting-name-servers/).
+You can now decide to [point the domain to DNSimple name servers](/articles/delegating-dnsimple-registered/) in one click, or [change the name server delegation](/articles/setting-name-servers/).
 
 > [!WARNING]
 > We suggest pointing [your domain to our name servers before the transfer](/articles/before-transferring-domain/) to avoid downtime during the transfer. Some DNS providers will stop serving the DNS for the domain as soon as the transfer is completed.

--- a/content/articles/secondary-dnsimple.md
+++ b/content/articles/secondary-dnsimple.md
@@ -30,7 +30,7 @@ To set up zone redundancy with another DNS provider on your zone, follow the ste
 
 ## Configuring DNSimple alongside another DNS provider (registered domain)
 
-To set up zone redundancy with another DNS provider on your domain, follow the steps in [Change delegation to another DNS provider (DNSimple registration)](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider).
+To set up zone redundancy with another DNS provider on your domain, follow the steps in [Change delegation to another DNS provider](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider).
 
 ## Have more questions?
 

--- a/content/articles/secondary-dnsimple.md
+++ b/content/articles/secondary-dnsimple.md
@@ -30,7 +30,7 @@ To set up zone redundancy with another DNS provider on your zone, follow the ste
 
 ## Configuring DNSimple alongside another DNS provider (registered domain)
 
-To set up zone redundancy with another DNS provider on your domain, follow the steps detailed in [Setting the Name Servers for a Domain Name](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider).
+To set up zone redundancy with another DNS provider on your domain, follow the steps in [Change delegation to another DNS provider (DNSimple registration)](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider).
 
 ## Have more questions?
 

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -28,7 +28,7 @@ For vocabulary (delegation versus records in your zone), see [What Is Domain Del
 After delegation points to another provider, the domain resolves using **that** provider's DNS. Records in your DNSimple account are **not** used for public DNS until delegation points back to DNSimple.
 
 <div class="section-steps" markdown="1">
-##### To change delegation to another provider
+### To change delegation to another provider
 
 1. If you have more than one account, select the relevant one.
 1. On the header, click the <label>Domain Names</label> tab, locate the relevant domain, and click on the name to access the domain page.

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -19,7 +19,7 @@ Use this guide when **DNSimple is your registrar** and you want DNS hosted **som
 
 If your domain is **not** registered at DNSimple, update name servers at your **current registrar**.
 
-If you want DNS hosted **by DNSimple**, follow [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/) instead of this article.
+If you want DNS hosted **by DNSimple**, follow [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) so you follow the right steps for your registration setup.
 
 For vocabulary (delegation versus records in your zone), see [What Is Domain Delegation?](/articles/what-is-domain-delegation/). For what authoritative name servers do, see [What is a name server?](/articles/what-is-a-nameserver/). For an overview when you are moving **to** DNSimple DNS, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/).
 
@@ -56,11 +56,7 @@ After delegation points to another provider, the domain resolves using **that** 
 > DNSimple's listing of NS records for the domain will be updated to match the name server changes.
 
 > [!NOTE]
-> If a name server hostname **falls under your domain** (for example `ns1.example.com` when delegating `example.com`), the registry needs **glue** so resolvers can reach those servers. DNSimple can create glue at the registry when the server is defined in a [name server set](/articles/name-server-sets/) that includes the glue IP addresses. For more detail, see [What Are Glue Records?](/articles/what-are-glue-records/). This situation also appears with [vanity name servers](/articles/what-are-vanity-name-servers/).
-
-## Use DNSimple for DNS
-
-To delegate to DNSimple’s name servers so your DNSimple zone is used on the public Internet, follow [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/).
+> If the name server hostname uses the same domain you are delegating, for example `ns1.example.com` for `example.com`, the registry needs glue records so resolvers can find the name server's IP address. DNSimple can create glue at the registry when the server is defined in a [name server set](/articles/name-server-sets/) that includes the glue IP addresses. For more detail, see [What Are Glue Records?](/articles/what-are-glue-records/). This situation also appears with [vanity name servers](/articles/what-are-vanity-name-servers/).
 
 ## Reserved name servers {#reserved-name-servers}
 

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -25,7 +25,7 @@ For vocabulary (delegation versus records in your zone), see [What Is Domain Del
 
 ## Change delegation to another DNS provider {#pointing-the-name-servers-to-another-provider}
 
-After delegation points to another provider, the domain resolves using **that** provider’s DNS. Records in your DNSimple account are **not** used for public DNS until delegation points back to DNSimple.
+After delegation points to another provider, the domain resolves using **that** provider's DNS. Records in your DNSimple account are **not** used for public DNS until delegation points back to DNSimple.
 
 <div class="section-steps" markdown="1">
 ##### To change delegation to another provider

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -1,12 +1,12 @@
 ---
-title: Change delegation to another DNS provider (DNSimple registration)
+title: Change delegation to another DNS provider
 excerpt: Point DNS to another provider when DNSimple is your registrar. Covers Edit delegation, glue via name server sets, and reserved rows from Secondary DNS or vanity name servers.
 meta: Change DNS delegation away from DNSimple when your domain is registered at DNSimple. Edit delegation to another DNS provider; glue may apply for in-zone NS names. Reserved name servers come from Secondary DNS or vanity name servers.
 categories:
   - Name Servers
 ---
 
-# Change delegation to another DNS provider (DNSimple registration)
+# Change delegation to another DNS provider
 
 ### Table of Contents {#toc}
 

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -1,12 +1,12 @@
 ---
-title: Setting the Name Servers for a Domain
-excerpt: To set the name servers, your domain must be registered with DNSimple. If it's not, use the control panel of your current domain registrar to update the name servers.
-meta: How to set name servers for your domain. Your domain must be registered with DNSimple, or use your current registrar's control panel.
+title: Change delegation to another DNS provider (DNSimple registration)
+excerpt: Point DNS to another provider when DNSimple is your registrar. Covers Edit delegation, glue via name server sets, and reserved rows from Secondary DNS or vanity name servers.
+meta: Change DNS delegation away from DNSimple when your domain is registered at DNSimple. Edit delegation to another DNS provider; glue may apply for in-zone NS names. Reserved name servers come from Secondary DNS or vanity name servers.
 categories:
   - Name Servers
 ---
 
-# Setting the Name Servers for a Domain Name
+# Change delegation to another DNS provider (DNSimple registration)
 
 ### Table of Contents {#toc}
 
@@ -15,65 +15,63 @@ categories:
 
 ---
 
-To set the name servers, your domain must be registered with DNSimple. If that's not the case, use the control panel of your current domain registrar to update the name servers.
+Use this guide when **DNSimple is your registrar** and you want DNS hosted **somewhere other than DNSimple** (for example Cloudflare or another DNS provider). You change **delegation**: which name servers are authoritative for your domain.
 
-You can set the name servers of a domain registered with DNSimple from your domain page.
+If your domain is **not** registered at DNSimple, update name servers at your **current registrar**.
 
-## Pointing the name servers to another provider
+If you want DNS hosted **by DNSimple**, follow [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/) instead of this article.
 
-Pointing the name servers to another provider will cause the domain to resolve using the DNS records configured at the other DNS provider. The DNS records in your DNSimple account will be ignored.
+For vocabulary (delegation versus records in your zone), see [What Is Domain Delegation?](/articles/what-is-domain-delegation/). For what authoritative name servers do, see [What is a name server?](/articles/what-is-a-nameserver/). For an overview when you are moving **to** DNSimple DNS, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/).
+
+## Change delegation to another DNS provider {#pointing-the-name-servers-to-another-provider}
+
+After delegation points to another provider, the domain resolves using **that** provider’s DNS. Records in your DNSimple account are **not** used for public DNS until delegation points back to DNSimple.
 
 <div class="section-steps" markdown="1">
-##### To point the name servers to another provider
+##### To change delegation to another provider
 
-1.  If you have more than one account, select the relevant one.
-1.  On the header, click the <label>Domain Names</label> tab, locate the relevant domain, and click on the name to access the domain page.
+1. If you have more than one account, select the relevant one.
+1. On the header, click the <label>Domain Names</label> tab, locate the relevant domain, and click on the name to access the domain page.
 
     ![Domain Page link](/files/domains-domain-link.png)
 
-1.  Click <label>Registration</label> on the left sidebar.
-1.  On the Domain delegation card, click <label>Edit delegation</label>.
+1. Click <label>Registration</label> on the left sidebar.
+1. On the Domain delegation card, click <label>Edit delegation</label>.
 
     ![Domain Delegation card](/files/domain-delegation-card.png)
 
-1.  Enter the names of the name servers you want to use.
+1. Enter the hostnames of the name servers you want to use.
 
     ![Enter name servers](/files/complete-name-server-change.png)
 
-1.  Instead of manually entering the name server names, you can also click <label>Add a name server set</label> to select a [name server set](/articles/name-server-sets/).
+1. Instead of entering hostnames manually, you can click <label>Add a name server set</label> to select a [name server set](/articles/name-server-sets/).
 
     ![Add a name server set](/files/domain-delegation-add-name-server-set.png)
 
-    If the name server has glue IP address(es) associated with it in the [name server set](/articles/name-server-sets/), and is a child zone of the domain which is having the delegation updated, glue records will be created for the domain at the registry. For instance, if `ns1.example.com` is being configured as a name server for the domain "example.com", and `ns1.example.com` has glue IP address(es) associated with it in the name server set it belongs to, the glue records needed to resolve `ns1.example.com` to its associated IP address(es) will be created at the registry.
-
-1.  Click <label>Change Name Servers</label> to apply the name server changes.
+1. Click <label>Change Name Servers</label> to apply the changes.
 
 </div>
 
 > [!NOTE]
 > DNSimple's listing of NS records for the domain will be updated to match the name server changes.
 
-## Pointing the name servers to DNSimple
+> [!NOTE]
+> If a name server hostname **falls under your domain** (for example `ns1.example.com` when delegating `example.com`), the registry needs **glue** so resolvers can reach those servers. DNSimple can create glue at the registry when the server is defined in a [name server set](/articles/name-server-sets/) that includes the glue IP addresses. For more detail, see [What Are Glue Records?](/articles/what-are-glue-records/). This situation also appears with [vanity name servers](/articles/what-are-vanity-name-servers/).
 
-Pointing the name servers to DNSimple provider will cause the domain to resolve using the DNS records configured in your DNSimple account.
+## Use DNSimple for DNS
 
-To change the name servers to DNSimple, follow the steps in [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/).
+To delegate to DNSimple’s name servers so your DNSimple zone is used on the public Internet, follow [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/).
 
 ## Reserved name servers {#reserved-name-servers}
 
-If you have [Secondary DNS](/articles/secondary-dns/) or [Vanity Name Servers](/articles/vanity-nameservers/) set up for your domain, the name servers belonging to the Secondary DNS or Vanity Name Servers configuration are considered "reserved", i.e. they cannot be edited or removed through the **Edit delegation** page.
+If you use [Secondary DNS](/articles/secondary-dns/) or [Vanity Name Servers](/articles/vanity-nameservers/), name servers from those configurations are **reserved**. You cannot edit or remove them through **Edit delegation** alone.
 
 ![Reserved name servers](/files/reserved-name-servers.png)
 
-To make changes to a reserved name server, click on the configuration icon next to it. You will be taken to the [Secondary DNS](/articles/secondary-dns/) or [Vanity Name Servers](/articles/vanity-nameservers/) configuration where you can make the necessary changes.
+Click the configuration icon next to a reserved entry to open [Secondary DNS](/articles/secondary-dns/) or [Vanity Name Servers](/articles/vanity-nameservers/) and change the configuration there.
 
 ![Edit reserved name servers through configuration](/files/reserved-name-servers-edit-configuration.png)
 
-## Glue records
-
-If you are adding a name server that is a child of the domain, glue records are required.
-For more information on glue records and how they work, see our [What Are Glue Records?](/articles/what-are-glue-records/) article.
-
 ## Have more questions?
 
-If you have further questions or need assistance setting up name servers for your domain, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.
+If you have further questions or need help with delegation or name servers, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -56,7 +56,7 @@ After delegation points to another provider, the domain resolves using **that** 
 > DNSimple's listing of NS records for the domain will be updated to match the name server changes.
 
 > [!NOTE]
-> If the name server hostname uses the same domain you are delegating, for example `ns1.example.com` for `example.com`, the registry needs glue records so resolvers can find the name server's IP address. DNSimple can create glue at the registry when the server is defined in a [name server set](/articles/name-server-sets/) that includes the glue IP addresses. For more detail, see [What Are Glue Records?](/articles/what-are-glue-records/). This situation also appears with [vanity name servers](/articles/what-are-vanity-name-servers/).
+> If the name server hostname uses the same domain you are delegating, for example `ns1.example.com` for `example.com`, the registry needs glue records so resolvers can find the name server's IP address. DNSimple can create glue at the registry when the server is defined in a [name server set](/articles/name-server-sets/) that includes the glue IP addresses. For more detail, see [What Are Glue Records?](/articles/what-are-glue-records/). This situation also applies to [vanity name servers](/articles/what-are-vanity-name-servers/).
 
 ## Reserved name servers {#reserved-name-servers}
 

--- a/content/articles/troubleshooting-domain-transfer-issues.md
+++ b/content/articles/troubleshooting-domain-transfer-issues.md
@@ -123,7 +123,7 @@ If your domain has entered the redemption period, you must [restore the domain](
 
 If you are already experiencing downtime:
 
-1. [Point your domain to DNSimple name servers](/articles/delegating-dnsimple-registered/) after the transfer completes, or [manually configure name servers](/articles/setting-name-servers/) to point to your DNS provider.
+1. [Point your domain to DNSimple name servers](/articles/delegating-dnsimple-registered/) after the transfer completes, or [change the name server delegation](/articles/setting-name-servers/) to point to your DNS provider.
 2. If you are using an external DNS provider, ensure your name servers are correctly configured to point to that provider.
 
 ## DNSSEC issues during transfer {#dnssec-issues-during-transfer}


### PR DESCRIPTION
## Summary

Updates `content/articles/setting-name-servers.md` only (same slug `/articles/setting-name-servers/`). Clarifies this How-to as **changing delegation to another DNS provider** when **DNSimple is the registrar**, preserves anchors `#pointing-the-name-servers-to-another-provider` and `#reserved-name-servers`, improves steps and GFM notes, links to Name Servers Explanation articles for context without turning the page into an Explanation.

## Customer Success scope

Closes dnsimple/dnsimple-customer-success#207

## Checklist

- [x] Clearer title and intro (when to use this article)
- [x] Task-focused body; no new article; file not renamed; URL unchanged
- [x] `categories/name_servers.yaml` title string updated
- [x] Article remains under **Configuring name servers** in Name Servers category
- [x] Internal links that used the old visible title updated (`secondary-dnsimple.md`, `cloudflare-ds-record.md`, `cloudflare-service.md`)
- [x] `bundle exec rake compile` not run locally (Bundler 2.6.6 missing on this environment); please verify in review / CI

## Files

| File | Change |
|------|--------|
| `content/articles/setting-name-servers.md` | Full rewrite per Diátaxis How-to |
| `categories/name_servers.yaml` | List entry matches new `title:` |
| `content/articles/secondary-dnsimple.md` | Link label |
| `content/articles/cloudflare-ds-record.md` | Link label |
| `content/articles/cloudflare-service.md` | Link label |