### PR TITLE
Add domain delegation and name servers explanation

### DIFF
--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -3,6 +3,7 @@ Getting started:
 
 Explanation:
   Name server concepts:
+    - "Domain Delegation and Name Servers Explained"
     - "What is a name server?"
     - "What Are Vanity Name Servers?"
     - "What Are Glue Records?"

--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -3,10 +3,10 @@ Getting started:
 
 Explanation:
   Name server concepts:
-    - "Domain Delegation and Name Servers Explained"
     - "What is a name server?"
     - "What Are Vanity Name Servers?"
     - "What Are Glue Records?"
+    - "Domain Delegation and Name Servers Explained"
 
 How-to:
   Domain delegation:

--- a/content/articles/domain-delegation-and-name-servers.md
+++ b/content/articles/domain-delegation-and-name-servers.md
@@ -8,7 +8,7 @@ categories:
 
 # Domain Delegation and Name Servers Explained
 
-This article explains how **delegation**, **name servers**, **DNS hosting**, and **DNS records** relate to each other. When you are ready to complete a change, use the table at the end to open the right How-to guide.
+**Delegation** tells the global DNS system which name servers are authoritative for your domain. Customers describe this workflow as "pointing," "delegating," "setting name servers," or "changing name servers." The correct steps depend on where the domain is registered and where DNS is hosted. Use the table at the end of this page to find the right guide.
 
 ### Table of Contents {#toc}
 
@@ -25,7 +25,7 @@ For a fuller description of the delegation chain, see [What Is Domain Delegation
 
 ## How delegation and name servers are related {#delegation-and-name-servers}
 
-In everyday language, people say **name servers** when they talk about delegation because delegation lists **hostnames** (for example `ns1.dnsimple.com`) that must answer DNS for your domain. Changing delegation usually means **changing which name server hostnames are listed at the registrar** for your domain.
+In everyday language, people say **name servers** when they talk about delegation because delegation lists **hostnames** (for example `ns1.dnsimple-edge.com`) that must answer DNS for your domain. Changing delegation usually means **changing which name server hostnames are listed at the registrar** for your domain.
 
 Authoritative name servers host your zone file (your A, MX, CNAME, and other records). For vocabulary and resolver basics, see [What is a name server?](/articles/what-is-a-nameserver/).
 
@@ -63,7 +63,7 @@ They are related but not the same: you can register a domain with DNSimple and h
 
 ## Why DNSimple DNS records may not appear on the public internet {#why-records-may-not-be-used}
 
-DNSimple stores your zone configuration when you host DNS with DNSimple. **Public resolvers only use that zone when delegation lists DNSimple's authoritative name servers** (or otherwise reaches servers that will serve your DNSimple zone, such as in some secondary or advanced setups you configure on purpose).
+DNSimple stores your zone configuration when you host DNS with DNSimple. **Public resolvers only use that zone when delegation lists DNSimple's authoritative name servers.** Secondary DNS or other advanced configurations can also route queries to your DNSimple zone, but those require intentional setup.
 
 If delegation still points to another provider, that provider's zone is what the public internet uses. Edits in DNSimple will not change public resolution until delegation points to DNSimple (or the relevant architecture you intend).
 
@@ -73,7 +73,7 @@ All of the following must line up for DNSimple-hosted DNS to be what the world q
 
 1. **DNSimple subscription is active** for the account that owns the DNS hosting work you are doing.
 2. **The zone exists and is managed in DNSimple** for that domain (your records live in that zone).
-3. **Delegation lists DNSimple name servers** you intend to use for that domain (for standard hosting, the hostnames in [DNSimple Name Servers](/articles/dnsimple-nameservers/) unless your setup uses vanity or other advanced configuration).
+3. **Delegation lists DNSimple name servers** for that domain. For standard hosting, use the hostnames in [DNSimple Name Servers](/articles/dnsimple-nameservers/). If your setup uses vanity name servers or another advanced configuration, the hostnames will differ.
 
 If something still fails after delegation looks correct, propagation and caching can delay visible changes. See [What is TTL?](/articles/what-is-ttl/) and [Troubleshoot Domain Resolution Issues](/articles/domain-resolution-issues/).
 
@@ -88,7 +88,7 @@ If something still fails after delegation looks correct, propagation and caching
 | Name servers use names **under your own domain** (for example `ns1.example.com` for `example.com`) and you need glue context | [What Are Glue Records?](/articles/what-are-glue-records/) |
 
 > [!TIP]
-> If you are unsure where the domain is registered, check the registrar listed for the domain, then return to this table.
+> If you are unsure where the domain is registered, check the registrar in a [WHOIS](https://dnsimple.com/whois) lookup for the domain, or inspect delegation with a tool such as [zone.vision](https://zone.vision/#/). Then return to this table.
 
 ## Have more questions?
 

--- a/content/articles/domain-delegation-and-name-servers.md
+++ b/content/articles/domain-delegation-and-name-servers.md
@@ -1,0 +1,95 @@
+---
+title: Domain Delegation and Name Servers Explained
+excerpt: How delegation, name servers, and DNS hosting fit together, why customers use different words for the same workflow, and which DNSimple guide matches your situation.
+meta: Explanation of domain delegation and authoritative name servers. Points customers to the correct DNSimple article whether the domain is registered here or elsewhere, DNS is at DNSimple or another provider, or only a subdomain is delegated.
+categories:
+  - Name Servers
+---
+
+# Domain Delegation and Name Servers Explained
+
+This article explains how **delegation**, **name servers**, **DNS hosting**, and **DNS records** relate to each other. When you are ready to complete a change, use the table at the end to open the right How-to guide.
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+## What domain delegation means {#what-domain-delegation-means}
+
+**Delegation** is how the global DNS system learns which servers are **authoritative** for your domain. That authority is published as **NS** records from your domain's parent (usually via your **registrar** sending information to the registry). Delegation answers the question: which name servers should resolvers query for records in this zone?
+
+For a fuller description of the delegation chain, see [What Is Domain Delegation?](/articles/what-is-domain-delegation/).
+
+## How delegation and name servers are related {#delegation-and-name-servers}
+
+In everyday language, people say **name servers** when they talk about delegation because delegation lists **hostnames** (for example `ns1.dnsimple.com`) that must answer DNS for your domain. Changing delegation usually means **changing which name server hostnames are listed at the registrar** for your domain.
+
+Authoritative name servers host your zone file (your A, MX, CNAME, and other records). For vocabulary and resolver basics, see [What is a name server?](/articles/what-is-a-nameserver/).
+
+## Common terms customers use {#common-terms}
+
+Customers often use different phrases for the same general workflow of **pointing DNS traffic at a provider**:
+
+- "Pointing the domain"
+- "Delegating"
+- "Setting name servers"
+- "Changing name servers"
+
+Those phrases usually mean updating **delegation** so the internet uses a new set of authoritative servers. They do **not** automatically mean editing records inside your DNS zone. Record edits and registrar delegation are related but different actions.
+
+## Why the steps depend on where the domain is registered {#steps-and-registration}
+
+The registrar is where **registration** is managed and where **delegation for the apex domain** is updated for most TLD workflows. So:
+
+- If DNSimple is **not** your registrar, you change delegation at the registrar that holds the domain (DNSimple cannot change another registrar's delegation for you).
+- If DNSimple **is** your registrar, you change delegation inside DNSimple when that domain's registration lives with us.
+
+That split is why DNSimple splits How-to articles between domains registered here and domains registered elsewhere.
+
+## Delegation changes are made at the registrar {#delegation-at-registrar}
+
+**Delegation for your apex domain** is configured through the registration path for your domain (the registrar and registry system). That is separate from adding NS records **inside** your own zone for a **child** subdomain, which is zone configuration on an authoritative server you already control. For child zones, see [Adding NS Records for a Subdomain](/articles/add-ns-records-for-subdomain/).
+
+## Domain registration and DNS hosting {#registration-and-dns-hosting}
+
+**Domain registration** means your registrar relationship for the domain name (renewals, contacts, transfer locks).
+
+**DNS hosting** means which provider operates authoritative DNS for your zone and serves your records.
+
+They are related but not the same: you can register a domain with DNSimple and host DNS elsewhere, or register elsewhere and host DNS with DNSimple. Delegation is what connects registration data at the registry to the DNS hosting you choose.
+
+## Why DNSimple DNS records may not appear on the public internet {#why-records-may-not-be-used}
+
+DNSimple stores your zone configuration when you host DNS with DNSimple. **Public resolvers only use that zone when delegation lists DNSimple's authoritative name servers** (or otherwise reaches servers that will serve your DNSimple zone, such as in some secondary or advanced setups you configure on purpose).
+
+If delegation still points to another provider, that provider's zone is what the public internet uses. Edits in DNSimple will not change public resolution until delegation points to DNSimple (or the relevant architecture you intend).
+
+## What must be true for DNSimple to answer public DNS {#requirements}
+
+All of the following must line up for DNSimple-hosted DNS to be what the world queries:
+
+1. **DNSimple subscription is active** for the account that owns the DNS hosting work you are doing.
+2. **The zone exists and is managed in DNSimple** for that domain (your records live in that zone).
+3. **Delegation lists DNSimple name servers** you intend to use for that domain (for standard hosting, the hostnames in [DNSimple Name Servers](/articles/dnsimple-nameservers/) unless your setup uses vanity or other advanced configuration).
+
+If something still fails after delegation looks correct, propagation and caching can delay visible changes. See [What is TTL?](/articles/what-is-ttl/) and [Troubleshoot Domain Resolution Issues](/articles/domain-resolution-issues/).
+
+## Choose the right guide {#choose-the-right-guide}
+
+| Situation | Start here |
+|-----------|------------|
+| Domain is registered **elsewhere** and you want DNS hosted **by DNSimple** | [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) |
+| Domain is registered **with DNSimple** and you want DNS hosted **by DNSimple** | [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/) |
+| Domain is registered **with DNSimple** and you want DNS hosted **by another provider** | [Setting the Name Servers for a Domain](/articles/setting-name-servers/) |
+| You need to delegate **only a subdomain** (child zone) | [Adding NS Records for a Subdomain](/articles/add-ns-records-for-subdomain/) |
+| Name servers use names **under your own domain** (for example `ns1.example.com` for `example.com`) and you need glue context | [What Are Glue Records?](/articles/what-are-glue-records/) |
+
+> [!TIP]
+> If you are unsure where the domain is registered, check the registrar listed for the domain, then return to this table.
+
+## Have more questions?
+
+If you need help choosing the right path or interpreting delegation output, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/pointing-domain-to-dnsimple.md
+++ b/content/articles/pointing-domain-to-dnsimple.md
@@ -12,6 +12,8 @@ Pointing a domain name servers to DNSimple is required if you want to use DNSimp
 
 Pointing the name servers to DNSimple will cause the domain to resolve using the DNS records configured in your DNSimple account.
 
+If you want background on how delegation, registration, and DNS hosting relate before you follow the steps, read [Domain Delegation and Name Servers Explained](/articles/domain-delegation-and-name-servers/).
+
 ## Domain registered with DNSimple
 
 Follow these instructions to [delegate a domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/).

--- a/content/articles/what-is-a-nameserver.md
+++ b/content/articles/what-is-a-nameserver.md
@@ -25,6 +25,8 @@ For security purposes, we don't make these changes on your behalf. If you purcha
 
 If you transfer your domain to DNSimple to manage your DNS, you'll need to update the name servers. Luckily, the name servers are easy to change and easy to remember by following [these step-by-step instructions](/articles/delegating-dnsimple-registered/).
 
+If you are not sure which steps apply to your domain, see [Domain Delegation and Name Servers Explained](/articles/domain-delegation-and-name-servers/) for how registration, delegation, and DNS hosting fit together, and for links to the right How-to guides.
+
 > [!NOTE] Check your name servers
 > Make sure to [check your nameservers](/articles/pointing-domain-to-dnsimple/). If your domain isn't delegated to DNSimple, then [changes you make to DNS records](/articles/record-editor/) won't resolve.
 > If you want to know which name servers your domain is using, you can use [zone.vision](https://zone.vision/#/) to do a DNS Lookup.

--- a/content/articles/what-is-domain-delegation.md
+++ b/content/articles/what-is-domain-delegation.md
@@ -31,7 +31,7 @@ It is important to understand that delegation is separate from domain registrati
 
 ## Changing delegation {#changing-delegation}
 
-You can change your domain's delegation at any time by [updating the name servers](/articles/setting-name-servers/). You update the name server settings in your registrar account. Changes to delegation can take up to 24-48 hours to propagate globally. Your domain continues to resolve during the change, as long as both old and new name servers are configured correctly. Changing delegation does not affect your domain registration. You remain the owner of the domain, and the registration period is unchanged.
+You can change your domain's delegation at any time by [updating the name servers](/articles/setting-name-servers/). For a guide to choosing the right DNSimple article for your situation, see [Domain Delegation and Name Servers Explained](/articles/domain-delegation-and-name-servers/). You update the name server settings in your registrar account. Changes to delegation can take up to 24-48 hours to propagate globally. Your domain continues to resolve during the change, as long as both old and new name servers are configured correctly. Changing delegation does not affect your domain registration. You remain the owner of the domain, and the registration period is unchanged.
 
 ## Delegation and DNS hosting {#delegation-and-dns-hosting}
 
@@ -47,4 +47,4 @@ Delegation is independent of [domain transfers](/articles/what-is-domain-transfe
 
 ## Have more questions?
 
-If you have any questions about domain delegation or need help with your domains, just [contact our support team](https://dnsimple.com/feedback) — we are here to help.
+If you have any questions about domain delegation or need help with your domains, just [contact our support team](https://dnsimple.com/feedback) - we are here to help.


### PR DESCRIPTION
## Summary

Adds a new Explanation article for domain delegation and name servers.

The article explains how delegation relates to name servers, why customers often use terms like pointing, delegating, setting name servers, and changing name servers for the same workflow, and why the correct steps depend on where the domain is registered.

## What changed

1. Added `content/articles/domain-delegation-and-name-servers.md`.
2. Added the article to `categories/name_servers.yaml` under **Explanation** → **Name server concepts**.
3. Explained when DNSimple DNS records are used for public DNS.
4. Added guidance for choosing the correct support article based on the customer's situation (table of links to existing How-to articles).

No other articles were modified in this PR.

## Test plan

1. Confirm the support site builds (`bundle exec rake compile`; CI runs full checks).
2. Confirm the article appears under the Name Servers Explanation section.
3. Confirm internal links work.
4. Confirm the article uses plain ASCII punctuation only.
5. Confirm the article stays Explanation-focused and does not duplicate How-to procedures.

## Related

Closes dnsimple/dnsimple-customer-success#208

Part of dnsimple/dnsimple-customer-success#159