### PR TITLE
Fix legacy name servers across delegation and troubleshooting articles

### DIFF
--- a/content/articles/delegating-dnsimple-hosted.md
+++ b/content/articles/delegating-dnsimple-hosted.md
@@ -17,9 +17,9 @@ Pointing the [name servers](/articles/what-is-a-nameserver/) to DNSimple will ca
 1.  Find the place on your domain registrar's web site where you can enter our name servers.
 1.  Enter the [DNSimple name servers](/articles/dnsimple-nameservers/):
 
-    - ns1.dnsimple.com
+    - ns1.dnsimple-edge.com
     - ns2.dnsimple-edge.net
-    - ns3.dnsimple.com
+    - ns3.dnsimple-edge.io
     - ns4.dnsimple-edge.org
 </div>
 

--- a/content/articles/delegating-dnsimple-registered.md
+++ b/content/articles/delegating-dnsimple-registered.md
@@ -32,9 +32,9 @@ Switching the [name servers](/articles/what-is-a-nameserver/) to DNSimple will c
     ![Use DNSimple name servers confirmation](/files/use-dnsimple-name-servers-confirmation.png)
 
 1. Alternatively, the [DNSimple name servers](/articles/dnsimple-nameservers/) can be manually entered into the form.
-  - ns1.dnsimple.com
+  - ns1.dnsimple-edge.com
   - ns2.dnsimple-edge.net
-  - ns3.dnsimple.com
+  - ns3.dnsimple-edge.io
   - ns4.dnsimple-edge.org
 
     ![Enter name servers](/files/complete-name-server-change.png)

--- a/content/articles/domain-resolution-issues.md
+++ b/content/articles/domain-resolution-issues.md
@@ -38,9 +38,9 @@ DNSimple provides four name servers. All four should be listed to ensure redunda
 
 **DNSimple name servers are**:
 
-`ns1.dnsimple.com` 
-`ns2.dnsimple-edge.net`  
-`ns3.dnsimple.com` 
+`ns1.dnsimple-edge.com`
+`ns2.dnsimple-edge.net`
+`ns3.dnsimple-edge.io`
 `ns4.dnsimple-edge.org`
 
 ## Check that the domain is using *only* DNSimple name servers {#check-that-the-domain-is-using-only-dnsimple-name-servers}
@@ -51,9 +51,9 @@ Problematic configuration example:
 
 ```
 $ dig NS example.com +short
-ns1.dnsimple.com.
+ns1.dnsimple-edge.com.
 ns2.dnsimple-edge.net.
-ns3.dnsimple.com.
+ns3.dnsimple-edge.io.
 ns4.dnsimple-edge.org.
 ns1.thirdparty.com.
 ns2.thirdparty.com.

--- a/content/articles/name-server-delegation-checklist.md
+++ b/content/articles/name-server-delegation-checklist.md
@@ -14,9 +14,9 @@ Use this page as a compact reference when you need the DNSimple delegation targe
 
 Your registrar (or DNSimple **Edit delegation** for DNSimple-registered domains) must list exactly these authoritative hostnames for DNSimple DNS hosting:
 
-- `ns1.dnsimple.com`
+- `ns1.dnsimple-edge.com`
 - `ns2.dnsimple-edge.net`
-- `ns3.dnsimple.com`
+- `ns3.dnsimple-edge.io`
 - `ns4.dnsimple-edge.org`
 
 All four should be present. Remove other providers' NS unless you intentionally run [Secondary DNS](/articles/secondary-dns/).

--- a/content/articles/secondary-dns.md
+++ b/content/articles/secondary-dns.md
@@ -40,16 +40,16 @@ You can configure Secondary DNS on all domains whether they delegate to us or no
 
 If you don't have your domain registered with us, update the delegation of your domain at your registrar to use the secondary name servers you have chosen. If you set up the secondary name servers `ns1.secondary.com` and `ns2.secondary.com`, delegation at your registrar will need to change from:
 
-- `ns1.dnsimple.com`
+- `ns1.dnsimple-edge.com`
 - `ns2.dnsimple-edge.net`
-- `ns3.dnsimple.com`
+- `ns3.dnsimple-edge.io`
 - `ns4.dnsimple-edge.org`
 
 to
 
-- `ns1.dnsimple.com`
+- `ns1.dnsimple-edge.com`
 - `ns2.dnsimple-edge.net`
-- `ns3.dnsimple.com`
+- `ns3.dnsimple-edge.io`
 - `ns4.dnsimple-edge.org`
 - `ns1.secondary.com`
 - `ns2.secondary.com`

--- a/content/articles/troubleshoot-dnsimple-name-servers.md
+++ b/content/articles/troubleshoot-dnsimple-name-servers.md
@@ -18,9 +18,9 @@ You can use `dig` or any other DNS tool to get the name servers for the domain.
 
 ```
 $ dig NS example.com +short
-ns1.dnsimple.com.
+ns1.dnsimple-edge.com.
 ns2.dnsimple-edge.net.
-ns3.dnsimple.com.
+ns3.dnsimple-edge.io.
 ns4.dnsimple-edge.org.
 ```
 


### PR DESCRIPTION
## Summary

- Updates `ns1.dnsimple.com` and `ns3.dnsimple.com` to `ns1.dnsimple-edge.com` and `ns3.dnsimple-edge.io` across six articles that instruct users which name servers to delegate to
- Affected articles: `delegating-dnsimple-hosted`, `delegating-dnsimple-registered`, `name-server-delegation-checklist`, `domain-resolution-issues`, `secondary-dns`, `troubleshoot-dnsimple-name-servers`

## Test plan

- [x] Verify all four name servers in each article match the canonical list in `dnsimple-nameservers.md`