### PR TITLE
Add NS Record Format reference article

### DIFF
--- a/categories/dns.yaml
+++ b/categories/dns.yaml
@@ -142,6 +142,7 @@ Reference:
   - DMARC Record Reference
   - HINFO Record Reference
   - MX Record Reference
+  - NS Record Format
   - POOL Record Reference
   - PTR Record Reference
   - SOA Record Reference

--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -30,6 +30,8 @@ Troubleshooting:
 Reference:
   Delegation checklist:
     - "Name Server Delegation Checklist"
+  NS record:
+    - "NS Record Format"
 Troubleshooting:
   After delegation:
     - "Troubleshoot Email or Subdomains After Delegation Changes"

--- a/content/articles/ns-record-format.md
+++ b/content/articles/ns-record-format.md
@@ -4,6 +4,7 @@ excerpt: The structure and canonical representation of an NS record.
 meta: Reference for NS record format and structure. Covers the RDATA definition from RFC 1035, canonical zone file representation, and the customizable fields in DNSimple.
 categories:
 - DNS
+- Name Servers
 ---
 
 # NS Record Format

--- a/content/articles/ns-record-format.md
+++ b/content/articles/ns-record-format.md
@@ -1,0 +1,51 @@
+---
+title: NS Record Format
+excerpt: The structure and canonical representation of an NS record.
+meta: Reference for NS record format and structure. Covers the RDATA definition from RFC 1035, canonical zone file representation, and the customizable fields in DNSimple.
+categories:
+- DNS
+---
+
+# NS Record Format
+
+The structure of an NS record follows the format defined in [RFC 1035, Section 3.3.11](https://datatracker.ietf.org/doc/html/rfc1035#section-3.3.11). The RDATA section is composed of one element:
+
+| Element  | Description |
+|:---------|:------------|
+| NSDNAME  | A fully qualified domain name that specifies the authoritative name server for the delegated domain or zone. |
+
+The canonical representation is:
+
+```
+NS <nsdname>
+```
+
+where `<nsdname>` is a fully qualified domain name such as `ns1.dnsimple-edge.com.`
+
+A complete NS record in a zone file looks like:
+
+```
+example.com.  3600  IN  NS  ns1.dnsimple-edge.com.
+```
+
+For a deeper explanation of what NS records are and how they work, see [What Is an NS Record?](/articles/ns-record/)
+
+## DNSimple fields {#dnsimple-fields}
+
+In DNSimple, NS records for subdomains are represented by the following customizable elements:
+
+| Element     | Description |
+|:------------|:------------|
+| Name        | The subdomain to delegate, without the apex domain name. DNSimple automatically appends the domain name. Use `@` to refer to the apex domain. |
+| TTL         | The time-to-live in seconds. This is how long resolvers are permitted to cache the record. |
+| Name Server | The fully qualified hostname of the authoritative name server. Must be a hostname, not an IP address. |
+
+## Apex and subdomain NS records {#apex-and-subdomain}
+
+NS records at the apex of a zone in DNSimple are system-managed and cannot be edited through the standard record editor. They reflect either the DNSimple edge name servers or your configured [vanity name servers](/articles/what-are-vanity-name-servers/). For information on updating apex zone NS records, see [Zone NS Records](/articles/zone-ns-records/).
+
+NS records for subdomains can be created and managed through the record editor to delegate a subdomain to a separate set of name servers. See [Adding NS Records for a Subdomain](/articles/add-ns-records-for-subdomain/) for step-by-step instructions.
+
+## Have more questions?
+
+If you have additional questions or need any assistance with your NS records, just [contact support](https://dnsimple.com/feedback), and we will be happy to help.


### PR DESCRIPTION
## Summary

- Adds `ns-record-format.md`, a new reference article covering the NS record RDATA structure per RFC 1035 Section 3.3.11, canonical zone file representation, and DNSimple-specific fields
- Adds "NS Record Format" to `categories/dns.yaml` under `Reference:` in alphabetical order

NS is the only major DNS record type with an explanation article (`ns-record.md`) but no corresponding format reference. Every other major record type has one (A, AAAA, ALIAS, CAA, CNAME, DKIM, DMARC, MX, SRV, TLSA, TXT, URL). This fills that gap.

The article also clarifies the distinction between system-managed apex NS records (not editable in the record editor) and user-managed subdomain NS records (added via the record editor to delegate child zones).

## Test plan

- [x] Verify "NS Record Format" appears in the DNS category Reference section
- [x] Check links to ns-record.md, zone-ns-records.md, add-ns-records-for-subdomain.md, and vanity-nameservers.md all resolve
- [x] Verify the zone file example renders correctly in the code block