### PR TITLE
Add internal links to increase coverage for under-linked articles

### DIFF
--- a/content/articles/dnsimple-services.md
+++ b/content/articles/dnsimple-services.md
@@ -15,7 +15,7 @@ DNSimple provides essential services for every Internet-connected system:
 - One-Click DNS services
 - SSL certificates
 
-New to DNSimple? See [how to pronounce the name](/articles/how-is-dnsimple-pronounced/).
+For the correct pronunciation of DNSimple, see [How to Pronounce DNSimple](/articles/how-is-dnsimple-pronounced/).
 
 If you manage domains across different services, our [Domain Control Plane](https://dnsimple.com/products/domain-control-plane) lets you connect your domains and DNS from various [DNS](/articles/integrated-dns-providers/) and [domain](/articles/integrated-domain-providers/) providers to manage all your domains through a single unified API and user interface.
 

--- a/content/articles/dnsimple-services.md
+++ b/content/articles/dnsimple-services.md
@@ -15,6 +15,8 @@ DNSimple provides essential services for every Internet-connected system:
 - One-Click DNS services
 - SSL certificates
 
+New to DNSimple? See [how to pronounce the name](/articles/how-is-dnsimple-pronounced/).
+
 If you manage domains across different services, our [Domain Control Plane](https://dnsimple.com/products/domain-control-plane) lets you connect your domains and DNS from various [DNS](/articles/integrated-dns-providers/) and [domain](/articles/integrated-domain-providers/) providers to manage all your domains through a single unified API and user interface.
 
 ## DNS hosting

--- a/content/articles/dnsimple-support.md
+++ b/content/articles/dnsimple-support.md
@@ -65,7 +65,7 @@ If you are not an authorized user on the account, please reach out to someone wh
 
 Absolutely! If you want to talk about your DNS and domain management needs, contact [Sales](https://dnsimple.com/sales), and we'll help you find the account that's right for you.
 
-If you have general questions about DNSimple, our products, and features, just fill out the 'Email Us' section on our [contact page](https://dnsimple.com/feedback).
+If you have general questions about DNSimple, our products, and features, just fill out the 'Email Us' section on our [contact page](https://dnsimple.com/feedback). For positive feedback, [leave a review](/articles/leave-a-review/).
 
 ## Can I call you?
 

--- a/content/articles/domain-resolution-issues.md
+++ b/content/articles/domain-resolution-issues.md
@@ -43,6 +43,8 @@ DNSimple provides four name servers. All four should be listed to ensure redunda
 `ns3.dnsimple-edge.io`
 `ns4.dnsimple-edge.org`
 
+For a compact verification reference including `dig` commands, see the [Name Server Delegation Checklist](/articles/name-server-delegation-checklist/).
+
 ## Check that the domain is using *only* DNSimple name servers {#check-that-the-domain-is-using-only-dnsimple-name-servers}
 
 In some cases, a misconfiguration may result in DNSimple name servers listed along with third party name servers.

--- a/content/articles/getting-started.md
+++ b/content/articles/getting-started.md
@@ -25,7 +25,7 @@ Prefer to watch? Try our video tutorials:
 </div>
 
 ## Introduction
-This how-to guide shows you how to accomplish basic tasks with DNSimple. Our services are streamlined and make managing your DNS, domains, and certificates straightforward with our simple interface and powerful tools.
+This how-to guide shows you how to accomplish basic tasks with DNSimple. Our services are streamlined and make managing your DNS, domains, and certificates straightforward with our simple interface and powerful tools. If you are unsure how to pronounce the name, see [How to Pronounce DNSimple](/articles/how-is-dnsimple-pronounced/).
 
 We recommend having this guide open alongside your DNSimple account so you can follow along. When you've completed this, you will be able to register, transfer, and set up DNS for your domain. If you don't have an account, check out [our plans](https://dnsimple.com/pricing/) to register and follow along.
 
@@ -187,6 +187,8 @@ You just added a DNS zone for your domain.
 ## What's next?
 
 Now that you have completed some tasks in DNSimple, what's next? You can [automate domain management or get analytics with our API](https://dnsimple.com/api). If you want to protect your site in the case of DNS servers going offline, [try setting up Secondary DNS](/articles/secondary-dns/). To add secure connections between your domain and a client, [learn how an SSL Certificate makes that happen](/articles/ssl-certificates/). Check out our [DNSimple Services](/articles/dnsimple-services/) page for a full overview of everything we offer. Check out [our comics](https://dnsimple.com/comics/) to see how DNS and the surrounding technologies work.
+
+If DNSimple is working well for you, [leave a review](/articles/leave-a-review/) - it helps others find us.
 
 ## Have more questions?
 

--- a/content/articles/pointing-domain-to-dnsimple.md
+++ b/content/articles/pointing-domain-to-dnsimple.md
@@ -22,5 +22,7 @@ Follow these instructions to [delegate a domain registered with DNSimple to DNSi
 
 Follow these instructions to [delegate a domain registered with another registrar to DNSimple](/articles/delegating-dnsimple-hosted/).
 
+For a compact reference to the DNSimple name server targets and verification commands, see the [Name Server Delegation Checklist](/articles/name-server-delegation-checklist/).
+
 > [!NOTE] Name server propagation
 > Please note that it may take up to 24 hours for a name server change to propagate. The whois response is normally a good way to [determine if the changes have been submitted properly](/articles/domain-resolution-issues/).

--- a/content/articles/reasons-hosting-dns.md
+++ b/content/articles/reasons-hosting-dns.md
@@ -22,7 +22,7 @@ We take [security](/articles/account-securing/) seriously and ensure your domain
 
 We also believe in choosing the best tooling to get the job done. With no vendor lock-in, you can point your name servers wherever you choose. If you want to keep your domain registered elsewhere, and just use our DNS resolver or [email forwarding](/articles/email-forwarding/), you can still use our name servers.
 
-Explore DNSimple's variety of [services](/articles/services/), read what other companies [have to say](https://dnsimple.com/customers) about their experiences using DNSimple, and delve into our [API](https://dnsimple.com/api) with video tutorials for each supported language.
+Explore DNSimple's variety of [services](/articles/services/), read what other companies [have to say](https://dnsimple.com/customers) about their experiences using DNSimple, and delve into our [API](https://dnsimple.com/api) with video tutorials for each supported language. If you are one of those customers, [leave a review](/articles/leave-a-review/) and help others find DNSimple.
 
 You can even try DNSimple [free for 30 days](https://dnsimple.com/signup), and explore our simple, secure DNS solutions for yourself. Whether you're registering your first domain name or you've got a business with a portfolio of domains, we've got a plan to fit your needs.
 

--- a/content/articles/troubleshoot-email-subdomains-after-delegation-changes.md
+++ b/content/articles/troubleshoot-email-subdomains-after-delegation-changes.md
@@ -31,6 +31,7 @@ Read [How DNS Caching and TTL Affect Delegation and Record Changes](/articles/ho
 1. Run `dig NS yourdomain.com +short` (replace `yourdomain.com`).
 1. Compare the result to [DNSimple name servers](/articles/dnsimple-nameservers/). All four should appear and no unexpected third-party NS should remain unless you intentionally use [Secondary DNS](/articles/secondary-dns/).
 1. If delegation is wrong, follow [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) and wait for caches to expire, then retest.
+1. For a quick reference to the four NS targets and `dig` commands, see the [Name Server Delegation Checklist](/articles/name-server-delegation-checklist/).
 
 </div>
 > [!NOTE]

--- a/content/articles/troubleshoot-email-subdomains-after-delegation-changes.md
+++ b/content/articles/troubleshoot-email-subdomains-after-delegation-changes.md
@@ -31,9 +31,11 @@ Read [How DNS Caching and TTL Affect Delegation and Record Changes](/articles/ho
 1. Run `dig NS yourdomain.com +short` (replace `yourdomain.com`).
 1. Compare the result to [DNSimple name servers](/articles/dnsimple-nameservers/). All four should appear and no unexpected third-party NS should remain unless you intentionally use [Secondary DNS](/articles/secondary-dns/).
 1. If delegation is wrong, follow [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) and wait for caches to expire, then retest.
-1. For a quick reference to the four NS targets and `dig` commands, see the [Name Server Delegation Checklist](/articles/name-server-delegation-checklist/).
 
 </div>
+
+For a quick reference to the four NS targets and `dig` commands, see the [Name Server Delegation Checklist](/articles/name-server-delegation-checklist/).
+
 > [!NOTE]
 > `dig NS example.com +short` uses the resolver you query. Results can be cached, so if you changed delegation recently, you may still see old name servers until the previous delegation TTL expires. For background, see [How DNS Caching and TTL Affect Delegation and Record Changes](/articles/how-dns-caching-and-ttl-affect-delegation-and-record-changes/).
 Broader checks: [Troubleshoot DNSimple Name Servers](/articles/troubleshoot-dnsimple-name-servers/) and [Troubleshoot Domain Resolution Issues](/articles/domain-resolution-issues/).


### PR DESCRIPTION
## Summary

- Adds 3 inbound links to `name-server-delegation-checklist` from `pointing-domain-to-dnsimple`, `domain-resolution-issues`, and `troubleshoot-email-subdomains-after-delegation-changes`
- Adds 2 inbound links to `how-is-dnsimple-pronounced` from `dnsimple-services` and `getting-started`
- Adds 3 inbound links to `leave-a-review` from `getting-started`, `dnsimple-support`, and `reasons-hosting-dns`

## Why

All three articles had only one dofollow inbound internal link, flagged as an SEO issue. Each new link is placed inline where it fits naturally in the existing content - no standalone "See also" blocks.

## Test plan

- [x] Verify all 7 edited articles render correctly
- [x] Confirm each new link resolves to the correct article URL