### PR TITLE
Expand thin API stub articles with substantive content

### DIFF
--- a/content/articles/api-documentation.md
+++ b/content/articles/api-documentation.md
@@ -1,16 +1,96 @@
 ---
-title: API Documentation
-excerpt: You can find our API documentation at the developer site.
-meta: DNSimple API documentation for developers. Integrate and automate domain registration, DNS management, and SSL certificate operations.
+title: DNSimple API Overview
+excerpt: The DNSimple API lets you manage domains, DNS records, SSL certificates, contacts, and more programmatically over HTTPS.
+meta: Overview of the DNSimple REST API v2. Manage domains, DNS records, SSL certificates, and contacts programmatically. Covers authentication, base URL, response format, and links to full developer documentation.
 categories:
 - API
 - Enterprise
 ---
 
-# API Documentation
+# DNSimple API Overview
 
-You can find our API documentation at [developer.dnsimple.com](https://developer.dnsimple.com/).
+### Table of Contents {#toc}
 
-This site includes details about all of our API endpoints as well as libraries and tools that have been built on top of the library. For how API errors are represented and interpreted, see [API Errors](/articles/api-errors/).
+* TOC
+{:toc}
 
-If you build a library or tool and would like it included in the list, please [contact us](https://dnsimple.com/contact) - we'd love to hear from you!
+---
+
+The DNSimple API is a REST API that lets you automate domain registration, DNS management, SSL certificate provisioning, and account administration. All requests are made over HTTPS and responses are JSON.
+
+## Base URL {#base-url}
+
+All API v2 requests go to:
+
+```
+https://api.dnsimple.com/v2/
+```
+
+Most endpoints are scoped to an account and require your account ID in the path:
+
+```
+https://api.dnsimple.com/v2/{account_id}/domains
+```
+
+For testing and development, use the [Sandbox environment](/articles/sandbox/) at `api.sandbox.dnsimple.com`. Sandbox requests do not affect live domains or billing.
+
+## Authentication {#authentication}
+
+The API authenticates using bearer tokens. Include your [API access token](/articles/api-access-token/) in the `Authorization` header on every request:
+
+```bash
+curl -H "Authorization: Bearer $DNSIMPLE_TOKEN" \
+     -H "Accept: application/json" \
+     "https://api.dnsimple.com/v2/whoami"
+```
+
+DNSimple offers two token types:
+
+- **Account tokens** - Access resources within one specific account. Recommended for most integrations.
+- **User tokens** - Access resources across all accounts associated with a user.
+
+For applications that need to request access on behalf of a user, use [OAuth 2.0](/articles/oauth-applications/) instead of a static token.
+
+## Response format {#responses}
+
+All successful responses return a JSON object with a `data` key:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "name": "example.com"
+  }
+}
+```
+
+List endpoints return an array under `data` along with a `pagination` object. By default, lists return 30 results per page up to a maximum of 100. See [API Best Practices](/articles/api-best-practices/#pagination) for how to handle pagination.
+
+## What you can do with the API {#capabilities}
+
+| Resource | What you can do |
+|---|---|
+| Domains | Register, transfer, renew, list, and delete domains |
+| DNS zones and records | Create and manage A, CNAME, MX, TXT, and other record types |
+| SSL certificates | Order, renew, and download Sectigo and Let's Encrypt certificates |
+| Contacts | Create and manage registrant contacts |
+| Webhooks | Register endpoints to receive real-time event notifications |
+| Account | Manage users, access tokens, and billing |
+
+## Rate limits {#rate-limits}
+
+Authenticated requests are limited to 2,400 per hour. See [API Rate Limit](/articles/api-rate-limit/) for details on headers and how to handle `429 Too Many Requests` responses.
+
+## Error handling {#errors}
+
+The API uses standard HTTP status codes. All error responses return a JSON object with a `message` field. See [API Errors](/articles/api-errors/) for a full reference of status codes and error formats.
+
+## Developer documentation {#dev-docs}
+
+The complete API reference - including every endpoint, request parameters, and response schemas - is at [developer.dnsimple.com](https://developer.dnsimple.com/).
+
+The developer site also lists official client libraries and community-built tools. If you build a library or tool and would like it included, [contact us](https://dnsimple.com/contact).
+
+## Have more questions?
+
+If you have questions about the DNSimple API or need help with your integration, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/api-errors.md
+++ b/content/articles/api-errors.md
@@ -1,7 +1,7 @@
 ---
 title: API Errors
-excerpt: You can find more information about API errors in our developer site.
-meta: API error reference on the DNSimple developer site. Common error codes, troubleshooting tips, and solutions for API integration issues.
+excerpt: The DNSimple API uses standard HTTP status codes and returns JSON error objects that describe what went wrong.
+meta: Reference guide for DNSimple API error responses. Covers HTTP status codes, JSON error object structure, and how to interpret and handle common API errors.
 categories:
 - API
 - Enterprise
@@ -9,4 +9,118 @@ categories:
 
 # API Errors
 
-You can find more information about API errors in our [Developer Documentation](https://developer.dnsimple.com/v2/#errors).
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+The DNSimple API uses standard HTTP status codes to indicate whether a request succeeded or failed. All error responses include a JSON body with at least a `message` field describing the problem.
+
+## HTTP status codes {#status-codes}
+
+### Successful responses
+
+| Code | Meaning |
+|---|---|
+| `200 OK` | Request succeeded. |
+| `201 Created` | Resource created successfully (typical for POST requests). |
+| `202 Accepted` | Request accepted for asynchronous processing (for example, a domain transfer). |
+| `204 No Content` | Request succeeded with no response body (typical for DELETE requests). |
+
+### Client errors
+
+| Code | Meaning |
+|---|---|
+| `400 Bad Request` | The request is invalid or the payload has a problem. See [400 errors](#400) below. |
+| `401 Unauthorized` | Authentication credentials are missing or invalid. See [Authentication](/articles/api-access-token/). |
+| `402 Payment Required` | Your account is not subscribed or has outstanding invoices. |
+| `403 Permission Denied` | The token does not have permission to access this resource. See [scoped access tokens](/articles/api-access-token/#scoped-access-tokens). |
+| `404 Not Found` | The resource does not exist, or the token does not have permission to see it. |
+| `412 Precondition Failed` | Your current plan does not include the required feature. |
+| `429 Too Many Requests` | You have exceeded the [rate limit](/articles/api-rate-limit/). Back off and retry. |
+
+### Server errors
+
+| Code | Meaning |
+|---|---|
+| `500`, `502`, `503`, `504` | Something went wrong on DNSimple's end. These are rare and temporary. |
+
+## Error response format {#format}
+
+All `4xx` and `5xx` responses return a JSON object with at least a `message` key:
+
+```json
+{"message": "Not Found"}
+```
+
+`400 Bad Request` responses often include an additional `errors` key with field-level detail:
+
+```json
+{
+  "message": "Validation failed",
+  "errors": {
+    "content": ["can't be blank"],
+    "ttl": ["is not a number"]
+  }
+}
+```
+
+The `errors` object maps field names to an array of error strings describing what is wrong with that field.
+
+## Common error scenarios {#common}
+
+### 400 - Validation failed {#400}
+
+Returned when required fields are missing or contain invalid values. Inspect the `errors` object to identify which fields need to be corrected:
+
+```json
+{
+  "message": "Validation failed",
+  "errors": {
+    "email": ["can't be blank", "is an invalid email address"],
+    "first_name": ["can't be blank"]
+  }
+}
+```
+
+### 401 - Authentication failed {#401}
+
+```json
+{"message": "Authentication failed"}
+```
+
+Check that your [API access token](/articles/api-access-token/) is correct and included in the `Authorization: Bearer` header. Tokens are only displayed once at creation time - if you have lost it, generate a new one.
+
+### 403 - Permission denied {#403}
+
+```json
+{"message": "Permission Denied. Required Scope: domains:*:read"}
+```
+
+Your token does not have the required scope for this operation. If you are using a [scoped access token](/articles/api-access-token/#scoped-access-tokens), verify that it has been granted the necessary permissions.
+
+### 404 - Not found {#404}
+
+```json
+{"message": "Not Found"}
+```
+
+Either the resource does not exist, or the token does not have access to it. DNSimple returns `404` in both cases to avoid leaking information about resources the caller cannot access.
+
+### 429 - Rate limit exceeded {#429}
+
+```json
+{"message": "quota exceeded"}
+```
+
+You have sent too many requests. Check the `X-RateLimit-Reset` header in the response for the Unix timestamp when your limit resets, then retry after that time. See [API Rate Limit](/articles/api-rate-limit/) for details on limits and headers.
+
+## Full error reference {#reference}
+
+For the complete list of error codes, response examples, and endpoint-specific error behavior, see the [DNSimple Developer Documentation](https://developer.dnsimple.com/v2/#errors).
+
+## Have more questions?
+
+If you need help interpreting an API error or troubleshooting your integration, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/api-rate-limit.md
+++ b/content/articles/api-rate-limit.md
@@ -1,7 +1,7 @@
 ---
 title: API Rate Limit
-excerpt: You can find our API rate limit at the developer site.
-meta: Explore the API rate limits for DNSimple to optimize your application's performance and ensure smooth integration with our services.
+excerpt: The DNSimple API allows up to 2,400 authenticated requests per hour. Rate limit status is reported in HTTP response headers on every request.
+meta: DNSimple API rate limit reference. Authenticated requests are capped at 2,400 per hour. Learn how to read rate limit headers, handle 429 errors, and design integrations that stay within limits.
 categories:
 - API
 - Enterprise
@@ -9,4 +9,75 @@ categories:
 
 # API Rate Limit
 
-You can find more information about our API rate limit in our [Developer Documentation](https://developer.dnsimple.com/v2/#rate-limiting).
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+The DNSimple API enforces rate limits to protect service quality. Authenticated requests are capped at 2,400 per hour. Unauthenticated requests are capped at 30 per hour.
+
+## Rate limit headers {#headers}
+
+Every API response includes headers showing your current rate limit status:
+
+| Header | Description |
+|---|---|
+| `X-RateLimit-Limit` | Maximum requests allowed per hour. |
+| `X-RateLimit-Remaining` | Requests remaining in the current window. |
+| `X-RateLimit-Reset` | Unix timestamp when the current window resets. |
+
+You can check these headers on any request:
+
+```bash
+curl -H "Authorization: Bearer $DNSIMPLE_TOKEN" \
+     -I "https://api.dnsimple.com/v2/whoami"
+```
+
+A typical response:
+
+```
+HTTP/1.1 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1449836141
+```
+
+## When you exceed the limit {#exceeded}
+
+Once you go over the limit, the API returns `429 Too Many Requests`:
+
+```
+HTTP/1.1 429 Too Many Requests
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1449836141
+
+{"message":"quota exceeded"}
+```
+
+Check the `X-RateLimit-Reset` header, convert the Unix timestamp to a time, and wait until that point before retrying. Do not retry immediately - repeated requests after hitting the limit will not succeed until the window resets.
+
+> [!NOTE]
+> Individual API endpoints may have additional rate limiting in place beyond the account-wide limit.
+
+## Designing integrations that stay within limits {#best-practices}
+
+**Monitor headers proactively.** Read `X-RateLimit-Remaining` on every response. If it drops close to zero before the window resets, pause requests until `X-RateLimit-Reset`.
+
+**Use webhooks instead of polling.** If you are repeatedly calling the API to check whether something has changed, replace that pattern with [DNSimple webhooks](https://developer.dnsimple.com/v2/webhooks/webhooks/). Webhooks push change events to your endpoint in real time and eliminate unnecessary requests.
+
+**Handle pagination efficiently.** List endpoints return up to 100 results per page. Request the maximum `per_page=100` to minimize the number of calls required to retrieve large datasets. See [API Best Practices](/articles/api-best-practices/) for a pagination example.
+
+**Implement exponential backoff.** When you receive a `429`, wait for the reset window rather than retrying immediately. For other transient errors (`500`, `502`, `503`), apply exponential backoff with jitter.
+
+For a complete guide to building reliable integrations, see [DNSimple API Best Practices](/articles/api-best-practices/).
+
+## Full rate limit reference {#reference}
+
+For additional detail on rate limiting behavior and endpoint-specific limits, see the [DNSimple Developer Documentation](https://developer.dnsimple.com/v2/#rate-limiting).
+
+## Have more questions?
+
+If you are hitting rate limits unexpectedly or need help optimizing your integration, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.


### PR DESCRIPTION
## Summary

- `api-errors.md` - Expanded from 58 words to ~670. Now covers HTTP status codes, JSON error response format, and common error scenarios (400/401/403/404/429) with real examples.
- `api-rate-limit.md` - Expanded from 61 words to ~470. Now covers the 2,400 req/hour limit, rate limit response headers, how to handle 429 responses, and best practices for staying within limits.
- `api-documentation.md` - Expanded from 110 words to ~530. Now covers the base URL, authentication, response format, a capabilities table, and links to all related API articles.

## Why

Google Search Console shows 214 pages in "Crawled - currently not indexed" status. These three articles were essentially empty stubs that pointed to the developer docs with a single sentence. Google crawled them and chose not to index them due to thin content. This expansion gives each article enough standalone value to be indexed.

## Notes

All content is sourced from the official developer docs at developer.dnsimple.com and the existing `api-best-practices.md` article. No new information has been invented.