### PR TITLE
Fix 404 pages reported in Google Search Console

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -107,9 +107,13 @@
 /articles/zone-files                                                      /articles/what-is-zone-file/
 /articles/zone-files/                                                     /articles/what-is-zone-file/
 /articles/zone-files/index.html                                           /articles/what-is-zone-file/
-/categories/github-and-dnsimple                                           /categories/heroku-and-dnsimple/
-/categories/github-and-dnsimple/                                          /categories/heroku-and-dnsimple/
-/categories/github-and-dnsimple/index.html                                /categories/heroku-and-dnsimple/
+/categories/github-and-dnsimple                                           /categories/services/
+/categories/github-and-dnsimple/                                          /categories/services/
+/categories/github-and-dnsimple/index.html                                /categories/services/
+/categories/heroku-and-dnsimple                                           /categories/services/
+/categories/heroku-and-dnsimple/                                          /categories/services/
+/categories/cloudflare-and-dnsimple                                       /categories/services/
+/categories/cloudflare-and-dnsimple/                                      /categories/services/
 /categories/domains/                                                      /categories/domains-and-transfers/
 /categories/domains/index.html                                            /categories/domains-and-transfers/
 /categories/domain-transfers/                                             /categories/domains-and-transfers/
@@ -190,5 +194,8 @@
 /articles/installing-ssl-certificate/                                     /articles/install-ssl-certificate/
 /articles/reissuing-ssl-certificate                                       /articles/reissue-ssl-certificate/
 /articles/reissuing-ssl-certificate/                                      /articles/reissue-ssl-certificate/
+/articles/announcement-ns2-ns4-ip-addresses                               /articles/announcement-ns1-ns3-ip-addresses/
+/articles/announcement-ns2-ns4-ip-addresses/                              /articles/announcement-ns1-ns3-ip-addresses/
+/dnsimple.com/contact                                                     https://dnsimple.com/contact
 /articles/:slug                                                           /articles/:slug/    301
 /categories/:slug                                                         /categories/:slug/  301

--- a/priorities/categories.yaml
+++ b/priorities/categories.yaml
@@ -19,5 +19,3 @@
 - "/categories/services.html"
 - "/categories/templates.html"
 - "/categories/guides.html"
-- "/categories/cloudflare-and-dnsimple.html"
-- "/categories/heroku-and-dnsimple.html"


### PR DESCRIPTION
## Summary

- Fixes broken `github-and-dnsimple` category redirect (was pointing to the non-existent `heroku-and-dnsimple/` category)
- Adds redirects for `heroku-and-dnsimple` and `cloudflare-and-dnsimple` categories to `/categories/services/`
- Adds redirect for `announcement-ns2-ns4-ip-addresses` article to the correct `announcement-ns1-ns3-ip-addresses/` slug
- Adds redirect for the malformed `/dnsimple.com/contact` URL to `https://dnsimple.com/contact`
- Removes non-existent `cloudflare-and-dnsimple.html` and `heroku-and-dnsimple.html` entries from `priorities/categories.yaml`

## Context

These 404s were identified in Google Search Console. Fixing them removes crawl errors and prevents link equity from being lost on inbound links to old URLs.

## Test plan

- [x] Verify `/categories/github-and-dnsimple/` redirects to `/categories/services/`
- [x] Verify `/categories/heroku-and-dnsimple/` redirects to `/categories/services/`
- [x] Verify `/categories/cloudflare-and-dnsimple/` redirects to `/categories/services/`
- [x] Verify `/articles/announcement-ns2-ns4-ip-addresses/` redirects to `/articles/announcement-ns1-ns3-ip-addresses/`
- [x] Verify `/dnsimple.com/contact` redirects to `https://dnsimple.com/contact`