### PR TITLE
Fix render-blocking marketing.js to improve mobile LCP

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -15,7 +15,7 @@
   <%= render "/analytics.*" %>
 
   <link rel="canonical" href="<%= @config[:base_url] %><%= @item.path %>" />
-  <script src="https://dnsimple.com/components/marketing.js"></script>
+  <script defer src="https://dnsimple.com/components/marketing.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary

- Adds `defer` to the `<script>` tag that loads `https://dnsimple.com/components/marketing.js` in `layouts/default.html`
- Without `defer`, this cross-origin script blocks HTML parsing on every page load - the browser must fully download and execute it before painting anything
- `<dnsimple-marketing-banner>` sits at the top of `<body>` and is the LCP element on mobile; it cannot render until the script is done, which pushes LCP past 2.5s on mobile connections

## Context

Google Search Console Core Web Vitals report (last updated 5/27/26) shows 343 article URLs with LCP > 2.5s on mobile, first detected 10/13/25. All 343 URLs fall into a single group (example: `what-is-ssl-certificate-chain`), which confirms the problem is in the shared layout, not any individual article. Group LCP is 2.6s - just over the 2.5s threshold.

## Change

```html
- <script src="https://dnsimple.com/components/marketing.js"></script>
+ <script defer src="https://dnsimple.com/components/marketing.js"></script>
```

`defer` allows HTML parsing to continue while the script downloads, then executes it after the DOM is parsed. The `<dnsimple-marketing-banner>` and `<dnsimple-marketing-hiring>` custom elements should still render correctly since they are defined in the DOM before the script runs.

## Test plan

- [x] Verify `<dnsimple-marketing-banner>` renders correctly at the top of the page
- [x] Verify `<dnsimple-marketing-hiring>` renders correctly in the header
- [ ] Run a Lighthouse mobile audit on any article page and confirm LCP improvement