### PR TITLE
Fix missing alt text on disable-autorenew image

### DIFF
--- a/content/articles/domain-auto-renewal.md
+++ b/content/articles/domain-auto-renewal.md
@@ -77,7 +77,7 @@ You can enable auto-renewal when you first register a domain or any time after t
 
 Auto-renewal can be disabled for any domain at any time, except when the auto-renewal process is currently in progress. Once disabled, the domain will require manual renewal before expiration. This gives you flexibility to manage renewals manually for domains where you want more control over the renewal timing or payment method.
 
-![](/files/disable-autorenew.png)
+!["Auto-renew this domain before it expires" checkbox unchecked on the Registration status card](/files/disable-autorenew.png)
 
 ## Have more questions?
 

--- a/content/articles/enabling-disabling-domain-auto-renewal.md
+++ b/content/articles/enabling-disabling-domain-auto-renewal.md
@@ -53,7 +53,7 @@ To turn off auto-renewal for a domain, follow these steps:
 1. If you have more than one account, select the relevant one from the account switcher in the top-right corner of the screen.
 1. On the header, click the <label>Domain Names</label> tab. Click the relevant domain name to access the domain page.
 1. In the **Overview** tab, uncheck <label>Auto-renew this domain before it expires</label> on the **Registration status** card.
-    ![](/files/disable-autorenew.png)
+    !["Auto-renew this domain before it expires" checkbox unchecked on the Registration status card](/files/disable-autorenew.png)
 
 Auto-renewal is now disabled on your domain.
 </div>


### PR DESCRIPTION
## Summary

- Adds descriptive alt text to the `disable-autorenew.png` image in two articles
- Fixes the Ahrefs "images missing alt attribute" issue flagged for both pages

## Files changed

- `content/articles/domain-auto-renewal.md`
- `content/articles/enabling-disabling-domain-auto-renewal.md`

## Test plan

- [x] Confirm alt text renders correctly on both pages