### PR TITLE
Fix category Other listings - add missing articles and create guides.yaml

### DIFF
--- a/categories/dns.yaml
+++ b/categories/dns.yaml
@@ -57,6 +57,8 @@ Explanation:
     - How Does Zone Verification Work?
     - What Is Zone Verification and Why Does It Matter?
     - How Long Does a New DNS Record Take to Resolve?
+    - How DNS Caching and TTL Affect Record Changes
+    - Recursive vs Authoritative DNS Resolvers
     - Protection Against DDoS Attacks
     - Why DNSSEC and Secondary DNS May Not Work Together
     - How ALIAS Records Resolve with Secondary DNS
@@ -129,6 +131,7 @@ How to:
     - Troubleshoot Empty Non-Terminal Issues
     - Troubleshoot Record Resolution Issues
     - How to Fix Empty Responses from Empty Non-Terminals
+    - Email and Subdomain Issues After Delegation
 
 Reference:
   - DNS Glossary

--- a/categories/emails.yaml
+++ b/categories/emails.yaml
@@ -63,6 +63,7 @@ How to:
     - "Email Forwarding Not Working"
     - "Email Forwarding Issues with Outlook and Yahoo"
     - "Troubleshoot Email Authentication"
+    - "Email and Subdomain Issues After Delegation"
 
 Reference:
   Email Forwarding:

--- a/categories/guides.yaml
+++ b/categories/guides.yaml
@@ -1,0 +1,5 @@
+Getting Started:
+  - "First Steps With Your DNSimple Account"
+  - "First Steps Guide to Setting Up Your Team"
+  - "Transfer or Register Domains With DNSimple"
+  - "Set Up Your First Zone and Delegate Zones to DNSimple"

--- a/categories/services.yaml
+++ b/categories/services.yaml
@@ -19,7 +19,7 @@ Web hosting:
 
 Productivity:
 - "Google Workspace (formerly G Suite) Service"
-- "Office 365 Service"
+- "Microsoft 365 (formerly Office 365) Service"
 - "KickoffLabs Service"
 - "Tender Service"
 


### PR DESCRIPTION
## Summary

- **`dns.yaml`** - Added 3 missing articles that were falling under Other: `Recursive vs Authoritative DNS Resolvers` and `How DNS Caching and TTL Affect Record Changes` (both to DNS Concepts), and `Email and Subdomain Issues After Delegation` (to Troubleshooting)
- **`emails.yaml`** - Added `Email and Subdomain Issues After Delegation` to the Troubleshooting section
- **`services.yaml`** - Updated stale title `Office 365 Service` to match the article's actual title `Microsoft 365 (formerly Office 365) Service`
- **`guides.yaml`** - Created new file listing all 4 guide articles under Getting Started, fixing the missing YAML that caused all guides to fall under Other on `/categories/guides.html`

## Test plan

- [x] Visit `/categories/dns.html` and confirm no Other section appears
- [x] Visit `/categories/emails.html` and confirm no Other section appears
- [x] Visit `/categories/services.html` and confirm Microsoft 365 appears in the Productivity section
- [x] Visit `/categories/guides.html` and confirm all 4 guide articles appear under Getting Started with no Other section