### PR TITLE
Add internal links to name server management hub

### DIFF
--- a/content/articles/delegating-dnsimple-hosted.md
+++ b/content/articles/delegating-dnsimple-hosted.md
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-Use this guide when your domain is **not** registered at DNSimple and you want DNSimple to host DNS. You update name servers at your **current registrar** (not in DNSimple). For a hub that covers both registration cases, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/).
+Use this guide when your domain is **not** registered at DNSimple and you want DNSimple to host DNS. You update name servers at your **current registrar** (not in DNSimple). For a hub that covers both registration cases, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/). For the full name server documentation index, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).
 
 Pointing the [name servers](/articles/what-is-a-nameserver/) to DNSimple makes the domain resolve using the DNS records configured in your DNSimple account.
 

--- a/content/articles/delegating-dnsimple-registered.md
+++ b/content/articles/delegating-dnsimple-registered.md
@@ -8,7 +8,7 @@ categories:
 
 # Delegating a Domain registered with DNSimple to DNSimple
 
-Switching the [name servers](/articles/what-is-a-nameserver/) to DNSimple will cause the domain to resolve using the DNS records configured in your DNSimple account.
+Switching the [name servers](/articles/what-is-a-nameserver/) to DNSimple will cause the domain to resolve using the DNS records configured in your DNSimple account. For the full name server documentation index, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).
 
 <div class="section-steps" markdown="1">
 ##### Changing the name servers to DNSimple

--- a/content/articles/dnsimple-nameservers.md
+++ b/content/articles/dnsimple-nameservers.md
@@ -8,7 +8,7 @@ categories:
 
 # DNSimple Name Servers
 
-For DNSimple to provide DNS for one of your domain names, you must change the name servers for your domain at your domain registrar.
+For DNSimple to provide DNS for one of your domain names, you must change the name servers for your domain at your domain registrar. For delegation how-tos, troubleshooting, and the full documentation index, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).
 
 The DNSimple name servers are:
 

--- a/content/articles/domain-delegation-and-name-servers.md
+++ b/content/articles/domain-delegation-and-name-servers.md
@@ -8,7 +8,7 @@ categories:
 
 # Domain Delegation and Name Servers Explained
 
-**Delegation** tells the global DNS system which name servers are authoritative for your domain. Customers describe this workflow as "pointing," "delegating," "setting name servers," or "changing name servers." The correct steps depend on where the domain is registered and where DNS is hosted. Use the table at the end of this page to find the right guide.
+**Delegation** tells the global DNS system which name servers are authoritative for your domain. Customers describe this workflow as "pointing," "delegating," "setting name servers," or "changing name servers." The correct steps depend on where the domain is registered and where DNS is hosted. Use the table at the end of this page to find the right guide, or browse [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/) for the complete documentation index.
 
 ### Table of Contents {#toc}
 

--- a/content/articles/name-server-delegation-checklist.md
+++ b/content/articles/name-server-delegation-checklist.md
@@ -8,7 +8,7 @@ categories:
 
 # Name Server Delegation Checklist
 
-Use this page as a compact reference when you need the DNSimple delegation targets and the order of checks. For narrative detail, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) and [DNSimple Name Servers](/articles/dnsimple-nameservers/).
+Use this page as a compact reference when you need the DNSimple delegation targets and the order of checks. For narrative detail, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) and [DNSimple Name Servers](/articles/dnsimple-nameservers/). For all name server documentation, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).
 
 ## Delegation targets {#delegation-targets}
 

--- a/content/articles/name-servers-glossary.md
+++ b/content/articles/name-servers-glossary.md
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-A reference for name server and delegation terminology. For broader DNS terms, see the [DNS Glossary](/articles/dns-glossary/).
+A reference for name server and delegation terminology. For how-to guides, troubleshooting, and the full documentation index, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/). For broader DNS terms, see the [DNS Glossary](/articles/dns-glossary/).
 
 ## Name Servers and Resolution {#name-servers-and-resolution}
 

--- a/content/articles/pointing-domain-to-dnsimple.md
+++ b/content/articles/pointing-domain-to-dnsimple.md
@@ -17,7 +17,7 @@ categories:
 
 Use this guide when you want DNSimple to host DNS for your domain and you need to point the domain's [name servers](/articles/what-is-a-nameserver/) to DNSimple. That process is also called delegating the domain. After delegation, the domain resolves using the DNS records in your DNSimple account.
 
-For how registration, delegation, and DNS hosting fit together, read [Domain Delegation and Name Servers Explained](/articles/domain-delegation-and-name-servers/). For propagation timing, read [How DNS Caching and TTL Affect Delegation and Record Changes](/articles/how-dns-caching-and-ttl-affect-delegation-and-record-changes/). Before you change delegation, you can use the [Name Server Delegation Checklist](/articles/name-server-delegation-checklist/).
+For how registration, delegation, and DNS hosting fit together, read [Domain Delegation and Name Servers Explained](/articles/domain-delegation-and-name-servers/). For propagation timing, read [How DNS Caching and TTL Affect Delegation and Record Changes](/articles/how-dns-caching-and-ttl-affect-delegation-and-record-changes/). Before you change delegation, you can use the [Name Server Delegation Checklist](/articles/name-server-delegation-checklist/). For the full index of name server guides, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).
 
 ## Domain registered with DNSimple {#domain-registered-with-dnsimple}
 

--- a/content/articles/troubleshoot-dnsimple-name-servers.md
+++ b/content/articles/troubleshoot-dnsimple-name-servers.md
@@ -8,7 +8,7 @@ categories:
 ---
 
 # Troubleshoot DNSimple Name Servers
-If your domain is not resolving correctly with DNSimple, follow these steps to troubleshoot common issues with name servers.
+If your domain is not resolving correctly with DNSimple, follow these steps to troubleshoot common issues with name servers. For related guides and the full name server documentation index, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).
 
 ## Ensure the domain is using the DNSimple name servers {#ensure-the-domain-is-using-the-dnsimple-name-servers}
 

--- a/content/articles/what-is-a-nameserver.md
+++ b/content/articles/what-is-a-nameserver.md
@@ -42,7 +42,7 @@ DNSimple does not change delegation on your behalf without your action. To point
 - If the domain is registered elsewhere, see [Delegating a Domain registered with another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/).
 - If the domain is registered with DNSimple and you want to use another DNS provider, see [Setting the Name Servers for a Domain](/articles/setting-name-servers/).
 
-For a general overview of pointing a domain to DNSimple, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/). The hostnames and addresses you delegate to are listed in [DNSimple Name Servers](/articles/dnsimple-nameservers/).
+For a general overview of pointing a domain to DNSimple, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/). The hostnames and addresses you delegate to are listed in [DNSimple Name Servers](/articles/dnsimple-nameservers/). For the full index of name server guides, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).
 
 > [!TIP]
 > If your domain is not delegated to DNSimple name servers, [changes you make in the record editor](/articles/record-editor/) will not be used for public resolution. To verify what the world sees, use [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) or an external lookup tool such as [zone.vision](https://zone.vision/#/).


### PR DESCRIPTION
## Summary
- Adds cross-links from 9 related Name Servers articles to the [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/) hub page

## Test plan
- [x] Confirm each updated article renders the new link correctly
- [x] Verify `/articles/name-server-management-in-dnsimple/` is linked from the updated articles and the Name Servers category page