### PR TITLE
Document password reset and recovery code confirmation prompts

### DIFF
--- a/content/articles/account-securing.md
+++ b/content/articles/account-securing.md
@@ -36,7 +36,7 @@ If you've noticed fraudulent activity, or suspect someone has taken over your ac
 - We strongly recommend enabling [multi-factor authentication (MFA)](/articles/multi-factor-authentication/) for an extra layer of security. MFA is available free for every subscription.
 - [Enforce MFA](/articles/multi-factor-authentication-enforcement/) for every team member managing domains on your account.
 - Download and secure your recovery codes.
-- Users who don't enable MFA are required to change their password every three months to maintain security. The new password cannot match any of the last five passwords used.
+- Users who do not enable MFA are required to change their password every three months to maintain security. The new password cannot match any of the last five passwords used. When a reset is due, DNSimple shows a **Password reset required** page on your next visit. Use the button on that page to send reset instructions to your email address. You will be signed out. You cannot continue using your account until you sign back in with a new password set from the emailed link.
 
 ## Forgotten password
 

--- a/content/articles/multi-factor-authentication.md
+++ b/content/articles/multi-factor-authentication.md
@@ -154,7 +154,7 @@ When you enable your first MFA method, a recovery code is created as a safeguard
 > The recovery code **is the only way to recover access to your account** if you can't generate a one-time password with an authenticator app or activate a security key for completing the 2-step verification process. Store the recovery code in a secure place. **We cannot disable multi-factor authentication without this recovery code**.
 
 > [!NOTE]
-> To help you keep your recovery code accessible, we will periodically ask you to confirm that you still have it saved. Twice a year, you'll see a prompt to verify you have access to your recovery code, along with the option to save a copy. We recommend taking a moment to review where it's stored each time this prompt appears.
+> To help you keep your recovery code accessible, we periodically ask you to confirm that you still have it. About twice a year, the next time you sign in, you'll be asked to enter the last 4 characters of your recovery code before you can continue using your account. The prompt also lets you copy your recovery code again or download a fresh PDF copy, so take a moment to check where it's stored each time it appears.
 
 When you enter a valid recovery code, multi-factor protection will immediately be disabled. To keep your account protected, you'll need to enable it again by connecting a one-time password authenticator application or security key to your user profile. A new recovery code will be generated.
 


### PR DESCRIPTION
## Summary

Two authentication flows changed in the product, and these articles still described the old behavior. This updates both to match.

- **Password Reset Required page**: a user whose password reset is due now lands on the page, sends reset instructions with an explicit button, is signed out, and cannot continue until they sign back in with a new password. The previous "Continue" escape that let users keep browsing is gone.
- **Recovery code confirmation prompt**: MFA users are prompted on a cadence to confirm they still hold their recovery code. The prompt is mandatory - they must enter the last 4 characters of the code before they can continue browsing.

## Files changed

- `content/articles/account-securing.md` - expanded the "every three months" password rule to describe the Password Reset Required page experience (send instructions, sign-out, no way to continue until reset).
- `content/articles/multi-factor-authentication.md` - rewrote the recovery code NOTE so it states the periodic prompt is mandatory (enter the last 4 characters to continue) and that the prompt lets you copy or download a fresh PDF copy of the code.

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [x] Cross-links added on first mention of related concepts
- [x] Existing articles updated to link back (if applicable)
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`
- [x] Tested locally with `rake run`

## Review

- [x] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)
