### PR TITLE
Defer loopback callback URL matching to the developer guide

### DIFF
--- a/content/articles/oauth-applications.md
+++ b/content/articles/oauth-applications.md
@@ -48,7 +48,7 @@ Your applications are listed here. From this page you can create a new applicati
 
 Click **Add** to create a new application.
 
-Provide an Application Name, a Homepage URL, and an Authorization Callback URL. The callback URL must use HTTPS. For native apps such as command-line tools, you can use a loopback address (`http://127.0.0.1`, `http://[::1]`, or `http://localhost`); the port is matched leniently so the app can listen on whatever local port is free.
+Provide an Application Name, a Homepage URL, and an Authorization Callback URL. The callback URL must use HTTPS, or HTTP with `localhost` or a loopback IP address (`http://127.0.0.1`, `http://[::1]`) for native apps such as command-line tools. For the loopback IP addresses, the registered port is matched leniently, so the app can listen on whatever local port is free. `localhost` is matched strictly, including its port.
 
 If your account can register [public applications](#client-types), the form also asks what kind of application you are building. Choose **Web app (server-side)** for a confidential application or **Native or browser app** for a public one.
 

--- a/content/articles/oauth-applications.md
+++ b/content/articles/oauth-applications.md
@@ -48,7 +48,7 @@ Your applications are listed here. From this page you can create a new applicati
 
 Click **Add** to create a new application.
 
-Provide an Application Name, a Homepage URL, and an Authorization Callback URL. The callback URL must use HTTPS, or HTTP with `localhost` or a loopback IP address (`http://127.0.0.1`, `http://[::1]`) for native apps such as command-line tools. For the loopback IP addresses, the registered port is matched leniently, so the app can listen on whatever local port is free. `localhost` is matched strictly, including its port.
+Provide an Application Name, a Homepage URL, and an Authorization Callback URL. The callback URL must use HTTPS, or HTTP with `localhost` or a loopback address (`127.0.0.1`, `[::1]`) for native apps such as command-line tools. See the [OAuth developer guide](https://developer.dnsimple.com/v2/oauth/) for how loopback redirect URIs are matched.
 
 If your account can register [public applications](#client-types), the form also asks what kind of application you are building. Choose **Web app (server-side)** for a confidential application or **Native or browser app** for a public one.
 


### PR DESCRIPTION
Follow-up to #1984. The OAuth applications article described the loopback callback URL port matching inaccurately for `localhost`: it grouped `http://localhost` with the loopback IP literals and said *"the port is matched leniently."* Only the loopback IP literals `127.0.0.1` and `::1` get port leniency (RFC 8252 §7.3); `localhost` is matched strictly, including its port.

Rather than restate the precise runtime matching rule here (which is exactly how the `localhost` error crept in), this article now keeps to the **registration constraint** (what callback URL forms you may enter) and defers the **runtime matching semantics** to the [OAuth developer guide](https://developer.dnsimple.com/v2/oauth/), which already owns that detail and is already linked from this article.

The precise rule now lives in exactly one customer-facing place (the developer guide, dnsimple/dnsimple-developer#1031), so it can't drift across surfaces again.
