### PR TITLE
Deprecate Hexonet (ispapi.net) sender references

### DIFF
--- a/content/articles/changing-domain-contact.md
+++ b/content/articles/changing-domain-contact.md
@@ -63,7 +63,7 @@ You can update the contact details to change existing contact information. DNSim
 ## Monitoring a contact change
 
 > [!NOTE]
-> When a domain contact has been changed, you will receive a confirmation email from no-reply@ispapi.net. You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
+> When a domain contact has been changed, you will receive a confirmation email from noreply@emailverification.info. You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
 
 Some TLDs require extra steps before authorizing a registrant change.
 

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -47,7 +47,7 @@ To update the contact for a specific domain, you will need to [replace the domai
 
 > [!NOTE]
 > When you update a domain contact:
-> - You will receive a confirmation email from no-reply@ispapi.net.
+> - You will receive a confirmation email from noreply@emailverification.info.
 > - You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
 > - If you update the contact's email address you may also receive an specific email to verify the new email address.
 

--- a/content/articles/expiring-domain-email-notifications.md
+++ b/content/articles/expiring-domain-email-notifications.md
@@ -27,7 +27,7 @@ ICANN mandates expiration notifications to ensure domain owners are informed abo
 
 ![Domain Expiration Email #2](/files/domain-expiration-email-2.png)
 
-These emails will be sent from one of these addresses: `<donotreply@name-services.com>`, `no-reply@domainrenewals.ispapi.net`, or `noreply@expirationwarning.net`.
+These emails will be sent from one of these addresses: `<donotreply@name-services.com>` or `noreply@expirationwarning.net`.
 
 If your domain is set to auto-renew, you can safely disregard the notification.
 


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/31472

DNSimple migrated its domains off Hexonet (the ISPAPI platform), so the `ispapi.net` email-sender references in the help docs are stale. This deprecates them. 

## Files changed

- `content/articles/contact-management.md` — contact-update confirmation sender `no-reply@ispapi.net` → `noreply@emailverification.info`
- `content/articles/changing-domain-contact.md` — contact-change confirmation sender `no-reply@ispapi.net` → `noreply@emailverification.info`
- `content/articles/expiring-domain-email-notifications.md` — dropped `no-reply@domainrenewals.ispapi.net` from the list of possible expiration-notice senders

Intentionally left as-is: the `hexonet.net` "Appendix W" link in `content/articles/domains-gay.md` — it remains the canonical source of that CentralNic registrant agreement.

## Review

- [x] Verify links
