### PR TITLE
Add .PT Domains article for new contact verification requirements

### DIFF
--- a/categories/tlds.yaml
+++ b/categories/tlds.yaml
@@ -53,6 +53,7 @@ TLDs:
   - ".ORG.NZ Domains"
   - ".ORG.UK Domains"
   - ".PL Domains"
+  - ".PT Domains"
   - ".SE Domains"
   - ".SG Domains"
   - ".TIROL Domains"

--- a/content/articles/domains-pt.md
+++ b/content/articles/domains-pt.md
@@ -1,0 +1,54 @@
+---
+title: .PT Domains
+excerpt: This article explains the requirements and special procedures for .PT domain names, including the contact verification requirements that apply from 30 June 2026.
+meta: Register and transfer .PT domains through DNSimple. From 30 June 2026, the registry requires registrant email and telephone verification before registrations, ownership transfers, and contact updates.
+categories:
+- TLDs
+---
+
+# .PT Domain Names
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+This article explains the requirements and special procedures for [.PT](https://dnsimple.com/tlds/pt-domains) domain names. .PT is the country-code top-level domain (ccTLD) for Portugal, managed by the registry Associação DNS.PT.
+
+## Contact verification requirements (from 30 June 2026) {#contact-verification}
+
+Starting **30 June 2026**, the .PT registry introduces new contact verification requirements for registrant contact data. These requirements are part of Portugal's implementation of the EU NIS2 Directive and its Legal Framework for Cybersecurity (RJC).
+
+Under these rules, the registry requires the registrant's contact information to be **validated and verified** before certain domain operations can be completed. The contact data that must be verified is:
+
+- The registrant's **email address**
+- The registrant's **telephone number**
+
+> [!WARNING]
+> If the required verification cannot be completed, the registry will not process the requested operation.
+
+### Which operations are affected {#affected-operations}
+
+The verification requirement applies to:
+
+- **New domain registrations**: the registrant contact must be verified before it can be used to register a new .PT domain.
+- **Ownership (registrant) transfers**: when ownership of a .PT domain changes, the new holder's contact information must be verified before the change can be completed.
+- **Contact data updates**: verification is required when updating the contact data on a .PT domain.
+
+> [!NOTE]
+> These requirements apply only to the operations listed above. Routine actions such as DNS record changes and domain renewals are not affected.
+
+### What you need to do {#what-to-do}
+
+Before registering a .PT domain, requesting an ownership transfer, or updating [domain contacts](/articles/what-are-domain-contacts/) on or after 30 June 2026, make sure the registrant contact has an accurate and reachable:
+
+- Email address
+- Telephone number
+
+Keep your contact details up to date in your DNSimple account, and respond promptly to any verification request so your operation isn't delayed or rejected by the registry. If a contact cannot be verified, the registry will not complete the requested operation.
+
+## Have more questions?
+
+If you have any questions or need assistance with .PT domains or contact verification, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/domains-pt.md
+++ b/content/articles/domains-pt.md
@@ -21,7 +21,7 @@ This article explains the requirements and special procedures for [.PT](https://
 
 Starting **30 June 2026**, the .PT registry introduces new contact verification requirements for registrant contact data. These requirements are part of Portugal's implementation of the EU NIS2 Directive and its Legal Framework for Cybersecurity (RJC).
 
-Under these rules, the registry requires the registrant's contact information to be **validated and verified** before certain domain operations can be completed. The contact data that must be verified is:
+Under these rules, the registry requires the [registrant's contact information](/articles/what-are-domain-contacts/) to be **validated and verified** before certain domain operations can be completed. The contact data that must be verified is:
 
 - The registrant's **email address**
 - The registrant's **telephone number**

--- a/content/articles/what-are-domain-contacts.md
+++ b/content/articles/what-are-domain-contacts.md
@@ -41,6 +41,8 @@ Domain contact information helps registries and registrars maintain a clear chai
 
 To reduce the risk of unauthorized transfers, registries may apply temporary safeguards when registrant details are updated. For example, under ICANN policy, a registrant change can trigger a temporary transfer restriction intended to protect domain ownership. You can learn more about this policy in [ICANN 60-day transfer lock after registrant change](/articles/icann-60-day-lock-registrant-change/).
 
+Some registries also require contact data to be verified before certain operations can be completed. For example, the .PT registry requires the registrant's email and telephone number to be verified before registrations, ownership transfers, and contact updates. See [.PT Domains](/articles/domains-pt/) for details.
+
 ## Have more questions?
 
 If you have any questions about domain contacts or need help with your domains, just [contact our support team](https://dnsimple.com/feedback) — we are here to help.


### PR DESCRIPTION
## Summary

Belongs to https://github.com/dnsimple/dnsimple-app/issues/35511

Adds a new `.PT Domains` support article documenting the registry's new contact verification requirements that take effect **30 June 2026**.

Under Portugal's NIS2 / Legal Framework for Cybersecurity (RJC) implementation, the .PT registry (Associação DNS.PT) will require the registrant's **email address** and **telephone number** to be verified before:

- New domain registrations
- Ownership (registrant) transfers
- Contact data updates

The article is written for DNSimple customers and intentionally omits backend reseller-implementation details (registry control panel, AddContact/ModifyContact API commands, X-VERIFICATION framework), which are not customer-facing.

## Changes

- `content/articles/domains-pt.md` — new `.PT Domains` article
- `categories/tlds.yaml` — registers `.PT Domains` in the TLDs navigation (alphabetical, between .PL and .SE)
- `content/articles/what-are-domain-contacts.md` — back-link to the new article from the domain lifecycle section

## Note for reviewers

The exact customer-facing flow for **telephone** verification may not be finalized yet (phone verification has no standard registry workflow and the detailed registry KB was still pending). The article states the requirement accurately without inventing a specific UI flow. If engineering has since defined the customer steps, the "What you need to do" section should be updated.