### PR TITLE
Add NIS2 contact email verification article

### DIFF
--- a/categories/contacts.yaml
+++ b/categories/contacts.yaml
@@ -3,5 +3,9 @@ Managing contacts:
 - "Managing Your Contacts"
 - "What Is Domain Trustee?"
 
+Verification:
+- "NIS2 Contact Email Verification"
+- "Domain Validation Requirements"
+
 Troubleshooting:
 - "ICANN 60-Day Lock After Change of Registrant"

--- a/categories/domains_and_transfers.yaml
+++ b/categories/domains_and_transfers.yaml
@@ -32,6 +32,7 @@ Explanation:
     - "Expiring Product Email Notifications"
   "Policies & Requirements":
     - "ICANN 60-Day Lock After Change of Registrant"
+    - "NIS2 Contact Email Verification"
   "TLDs":
     - "Regulated Top-Level Domains"
 

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -37,7 +37,7 @@ You can also create a new contact at any time through the **Contacts** page.
 ![creating a new contact](/files/change-contact-1.png)
 
 > [!NOTE]
-> If the email address on the contact has not been verified to comply with [NIS2 regulations](https://nis2directive.eu/what-is-nis2/), you will receive a verification email. Follow the link in the email to complete the verification.
+> If the email address on the contact has not been verified to comply with [NIS2 regulations](https://nis2directive.eu/what-is-nis2/), you will receive a verification email. Follow the link in the email to complete the verification. For details, see [NIS2 Contact Email Verification](/articles/nis2-contact-verification/).
 
 ## Updating contacts
 

--- a/content/articles/icann-domain-validation.md
+++ b/content/articles/icann-domain-validation.md
@@ -4,6 +4,7 @@ excerpt: Learn about domain validation requirements and how to verify your regis
 meta: Understand domain validation requirements, verification processes, and how to ensure your domain contact information is properly validated to avoid suspension.
 categories:
   - Domains and Transfers
+  - Contacts
 ---
 
 # Domain Validation Requirements
@@ -18,6 +19,9 @@ categories:
 Domain registries and organizations that oversee domain name registrations require validation of your registrant email address whenever a new domain is registered or your registrant email address or name is changed. This validation helps ensure the accuracy of contact information in the domain registration database and protects domain owners from unauthorized changes.
 
 For most top-level domains, validation is required by [ICANN](https://www.icann.org/) (the Internet Corporation for Assigned Names and Numbers) as part of their [RDDS Accuracy program](https://www.icann.org/resources/pages/rdds-2013-02-28-en). Failure to validate your registrant email address results in suspension of the domain name after 15 days of non-compliance.
+
+> [!NOTE]
+> This validation is separate from [NIS2 contact email verification](/articles/nis2-contact-verification/). ICANN validation is sent from `noreply@emailverification.info` and can lead to suspension. NIS2 verification is sent from `support@dnsimple.com` and does not cause suspension. A domain can require both at the same time.
 
 ## Why domain validation exists
 

--- a/content/articles/nis2-contact-verification.md
+++ b/content/articles/nis2-contact-verification.md
@@ -1,0 +1,83 @@
+---
+title: NIS2 Contact Email Verification
+excerpt: Learn what NIS2 contact email verification is, how to complete it, and how it differs from ICANN registrant validation.
+meta: NIS2 contact email verification at DNSimple confirms that the email address on a domain contact is valid. It is sent from support@dnsimple.com and, unlike ICANN registrant validation, does not cause domain suspension.
+categories:
+- Domains and Transfers
+- Contacts
+---
+
+# NIS2 Contact Email Verification
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+NIS2 contact email verification confirms that you have access to the email address on a [domain contact](/articles/what-are-domain-contacts/). DNSimple sends it from `DNSimple <support@dnsimple.com>` with the subject "Action Required: Verify your contact email address." This verification is separate from the [ICANN registrant validation](/articles/icann-domain-validation/) that many domains also require, and it does not cause domain suspension.
+
+## What NIS2 verification is {#what-it-is}
+
+NIS2 refers to the EU [Network and Information Security Directive 2](https://nis2directive.eu/what-is-nis2/), which sets requirements for the accuracy of domain registration data. To meet these requirements, DNSimple verifies that the email address on a contact belongs to someone who can receive mail at it.
+
+The verification applies to the contact's email address, not to a specific top-level domain. You may be asked to verify a contact even when the domain itself is not an EU domain. Once an email address is verified, that verified status applies wherever the contact is used.
+
+A verified contact email is required to use that contact for domain registration, transfer, or change of ownership.
+
+## When you receive a verification email {#when}
+
+DNSimple sends a NIS2 verification email when the email address on a contact has not yet been verified. This commonly happens when you:
+
+- Create a new contact during [domain registration](/articles/registering-domain/) or from the **Contacts** page.
+- Update an existing contact to a new email address.
+
+If you [change a domain contact](/articles/changing-domain-contact/) to one whose email is already verified, no new verification is required.
+
+## What the verification email looks like {#email}
+
+The email has these characteristics:
+
+- **From:** `DNSimple <support@dnsimple.com>`
+- **Subject:** Action Required: Verify your contact email address
+- **Link:** a `https://dnsimple.com/email_verification/...` address unique to that contact email
+
+The link is time-limited. The message states the exact date and time the link expires, so complete the verification before then. If you cannot find the email, check your spam folder.
+
+## How to complete the verification {#complete}
+
+<div class="section-steps" markdown="1">
+##### Verify a contact email address
+
+1. Open the verification email sent from `support@dnsimple.com`.
+1. Click <label>Verify Email Address</label>, or copy the link into your browser.
+1. Confirm the "Email Address Verified" page appears for the contact email.
+</div>
+
+If a domain still shows an "Email verification required" banner after you verify, click <label>Refresh</label> on the domain page to force DNSimple to fetch the latest status.
+
+> [!NOTE]
+> If the contact email was already verified, clicking the link sends you to your account settings with a message that verification has already been completed. That message refers to the contact email address, even though the page shown is your account settings. The verification is complete, and no further action is needed.
+
+## NIS2 verification does not suspend your domain {#no-suspension}
+
+If a contact email is not verified for NIS2, your domain is not suspended. An unverified contact email only limits using that contact for registration, transfer, or change of ownership. This is the main difference from [ICANN registrant validation](/articles/icann-domain-validation/), where failure to validate results in suspension of the domain after 15 days.
+
+## How NIS2 verification differs from ICANN registrant validation {#vs-icann}
+
+A domain can require both verifications at the same time. They come from different senders and satisfy different requirements.
+
+| | NIS2 contact email verification | [ICANN registrant validation](/articles/icann-domain-validation/) |
+|---|---|---|
+| Requirement | EU NIS2 directive (registration data accuracy) | ICANN RDDS Accuracy program (RAA) |
+| What it verifies | Access to the email address on a contact | The registrant email address for a domain |
+| Sender | `support@dnsimple.com` | `noreply@emailverification.info` or `donotreply@name-services.com` |
+| Link destination | `dnsimple.com/email_verification/...` | `emailverification.info` |
+| If not completed | The contact cannot be used for registration, transfer, or ownership | Domain suspension after 15 days |
+
+If you received two emails about the same domain, complete both. Verifying one does not satisfy the other.
+
+## Have more questions?
+
+If you need help completing NIS2 verification or are unsure which email to act on, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/nis2-contact-verification.md
+++ b/content/articles/nis2-contact-verification.md
@@ -22,18 +22,11 @@ NIS2 contact email verification confirms that you have access to the email addre
 
 NIS2 refers to the EU [Network and Information Security Directive 2](https://nis2directive.eu/what-is-nis2/), which sets requirements for the accuracy of domain registration data. To meet these requirements, DNSimple verifies that the email address on a contact belongs to someone who can receive mail at it.
 
-The verification applies to the contact's email address, not to a specific top-level domain. You may be asked to verify a contact even when the domain itself is not an EU domain. Once an email address is verified, that verified status applies wherever the contact is used.
+## When verification is required {#when}
+
+DNSimple requires verification when the email address on a contact has not yet been confirmed. This applies to the contact's email address itself, not to a specific top-level domain, so you may be asked to verify a contact even when the domain is not an EU domain. Once an email address is verified, that verified status applies wherever the contact is used.
 
 A verified contact email is required to use that contact for domain registration, transfer, or change of ownership.
-
-## When you receive a verification email {#when}
-
-DNSimple sends a NIS2 verification email when the email address on a contact has not yet been verified. This commonly happens when you:
-
-- Create a new contact during [domain registration](/articles/registering-domain/) or from the **Contacts** page.
-- Update an existing contact to a new email address.
-
-If you [change a domain contact](/articles/changing-domain-contact/) to one whose email is already verified, no new verification is required.
 
 ## What the verification email looks like {#email}
 
@@ -43,22 +36,37 @@ The email has these characteristics:
 - **Subject:** Action Required: Verify your contact email address
 - **Link:** a `https://dnsimple.com/email_verification/...` address unique to that contact email
 
-The link is time-limited. The message states the exact date and time the link expires, so complete the verification before then. If you cannot find the email, check your spam folder.
+The link is time-limited. The message states the exact date and time it expires, so complete the verification before then. If you cannot find the email, check your spam folder.
 
-## How to complete the verification {#complete}
+## How to verify your contact email address {#verify}
 
 <div class="section-steps" markdown="1">
-##### Verify a contact email address
+##### Confirm the contact email
 
-1. Open the verification email sent from `support@dnsimple.com`.
+1. Open the verification email from `support@dnsimple.com`.
 1. Click <label>Verify Email Address</label>, or copy the link into your browser.
 1. Confirm the "Email Address Verified" page appears for the contact email.
 </div>
 
-If a domain still shows an "Email verification required" banner after you verify, click <label>Refresh</label> on the domain page to force DNSimple to fetch the latest status.
+## Resend the verification email {#resend}
+
+If you did not receive the email, resend it from the contact's page.
+
+<div class="section-steps" markdown="1">
+##### Resend verification
+
+1. Log into DNSimple.
+1. On the header, click the <label>Contacts</label> tab.
+1. Select the contact whose email needs verification.
+1. In the <label>Verification pending</label> notice, click <label>Resend verification email</label>.
+</div>
 
 > [!NOTE]
 > If the contact email was already verified, clicking the link sends you to your account settings with a message that verification has already been completed. That message refers to the contact email address, even though the page shown is your account settings. The verification is complete, and no further action is needed.
+
+## If you cannot receive email at that address {#cannot-receive}
+
+You must be able to receive mail at the contact email address to verify it. If the address is wrong or cannot receive email, [change the domain contact](/articles/changing-domain-contact/) to one with an email address you can access. A new verification is sent automatically for the updated email. If you still cannot complete verification, [contact support](https://dnsimple.com/feedback) with the affected domain name.
 
 ## NIS2 verification does not suspend your domain {#no-suspension}
 
@@ -73,7 +81,7 @@ A domain can require both verifications at the same time. They come from differe
 | Requirement | EU NIS2 directive (registration data accuracy) | ICANN RDDS Accuracy program (RAA) |
 | What it verifies | Access to the email address on a contact | The registrant email address for a domain |
 | Sender | `support@dnsimple.com` | `noreply@emailverification.info` or `donotreply@name-services.com` |
-| Link destination | `dnsimple.com/email_verification/...` | `emailverification.info` |
+| Where you act | The contact's page in DNSimple | The domain's page in DNSimple |
 | If not completed | The contact cannot be used for registration, transfer, or ownership | Domain suspension after 15 days |
 
 If you received two emails about the same domain, complete both. Verifying one does not satisfy the other.


### PR DESCRIPTION
## What

Adds a dedicated support article explaining **NIS2 contact email verification**, which was previously only mentioned in passing (in `contact-management.md`, `domains-de.md`, and `tlds.md`) with no standalone reference.

Prompted by this customer ticket: https://dnsimple.groovehq.com/tickets/556540 — the customer confused the NIS2 verification (from `support@dnsimple.com`) with the ICANN/RAA registrant validation (from `noreply@emailverification.info`) and worried their domains would be suspended.

## Changes

- **New article** `nis2-contact-verification.md` (Explanation): what NIS2 verification is, when the email is sent, what it looks like, how to complete it, that it does **not** cause domain suspension, and a comparison table vs ICANN registrant validation.
- `icann-domain-validation.md`: added a NOTE distinguishing it from NIS2 verification.
- `contact-management.md`: linked the existing NIS2 note to the new article.
- Both verification articles added to the **Contacts** category (new "Verification" group) in addition to Domains and Transfers.
- Category index updates in `domains_and_transfers.yaml` and `contacts.yaml`.

## Notes

Customer-facing facts were verified against the `dnsimple-app` source:
- Sender `DNSimple <support@dnsimple.com>`, subject "Action Required: Verify your contact email address", link `dnsimple.com/email_verification/...`.
- NIS2 verification does **not** suspend domains (confirmed via the admin tooltip).
- The "redirect to account settings / already completed" experience is the already-verified code path, not a bug — documented as expected behavior.