### PR TITLE
Fix broken cross-link anchors across articles

### DIFF
--- a/content/articles/account-creation.md
+++ b/content/articles/account-creation.md
@@ -40,7 +40,7 @@ Until your email address is verified, some sensitive actions will be unavailable
 
 ## Adding additional accounts
 
-DNSimple allows users to manage multiple accounts. If you've already signed up for DNSimple and want to add another account to your user profile, [follow these steps](/articles/account-multi/#creating).
+DNSimple allows users to manage multiple accounts. If you've already signed up for DNSimple and want to add another account to your user profile, [follow these steps](/articles/account-multi/#creating-a-separate-account).
 
 ## Signing up via Google
 

--- a/content/articles/buy-sectigo-ssl-certificate.md
+++ b/content/articles/buy-sectigo-ssl-certificate.md
@@ -29,7 +29,7 @@ To order an SSL certificate you need a DNSimple account.
 
 You can order an SSL certificate for a domain, even if the domain is hosted elsewhere or registered with another registrar. **You are not required to transfer or host a domain with us to purchase a Sectigo SSL certificate**.
 
-Please ensure you comply with all the [technical requirements](/articles/getting-started-ssl-certificates/#requirements) in our [Getting Started with SSL Certificates](/articles/getting-started-ssl-certificates/) page before ordering the certificate.
+Please ensure you comply with all the [technical requirements](/articles/getting-started-ssl-certificates/#before-you-order) in our [Getting Started with SSL Certificates](/articles/getting-started-ssl-certificates/) page before ordering the certificate.
 
 For more details about the configuration, approval, and installation of the certificate, read the [Getting Started with SSL Certificates](/articles/getting-started-ssl-certificates/) article, or follow the instructions on the site after you purchase the SSL certificate order.
 

--- a/content/articles/changing-whois-contact.md
+++ b/content/articles/changing-whois-contact.md
@@ -25,7 +25,7 @@ To check the existing public WHOIS record for a domain you can use our [WHOIS to
 
 ## Changing or updating WHOIS information {#changing-or-updating-whois-information}
 
-To update the WHOIS information associated with a domain name in DNSimple, simply follow the procedure to [update an existing contact information](/articles/changing-domain-contact/#changing-an-existing-contact-information), or [replace the contact](/articles/changing-domain-contact/#replacing-a-domain-contact) if you want to completely replace the contact details.
+To update the WHOIS information associated with a domain name in DNSimple, simply follow the procedure to [update an existing contact information](/articles/changing-domain-contact/#updating-a-domain-contact), or [replace the contact](/articles/changing-domain-contact/#assigning-a-new-domain-contact) if you want to completely replace the contact details.
 
 > [!WARNING]
 > Changing or updating WHOIS information may result in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -43,7 +43,7 @@ You can also create a new contact at any time through the **Contacts** page.
 
 If a contact is associated with multiple domains, updating that contact also updates all the contact information associated with these domains. You don't need to individually update these domains if they're associated with the same contact.
 
-To update the contact for a specific domain, you will need to [replace the domain contact](/articles/changing-domain-contact/#replacing-a-domain-contact) with a new one.
+To update the contact for a specific domain, you will need to [replace the domain contact](/articles/changing-domain-contact/#assigning-a-new-domain-contact) with a new one.
 
 > [!NOTE]
 > When you update a domain contact:

--- a/content/articles/dashboard.md
+++ b/content/articles/dashboard.md
@@ -61,7 +61,7 @@ The **Latest activity** section provides a view of activity across all accounts 
 
 Similar to the activity view, the information displayed highlights the *Type, Event, Text, User, Date, and Account*. Each is linked to the individual event listed, so you can see information specific to an account without scrolling back up to the account card.
 
-To learn more about the highlighted categories and how the information is organized, read [this guide](/articles/activity-tracking/#activity-tracking-at-the-account-level). From the individual account and domain activity views, you can filter based on events to easily find what you need.
+To learn more about the highlighted categories and how the information is organized, read [this guide](/articles/activity-tracking/#account-activity-tracking). From the individual account and domain activity views, you can filter based on events to easily find what you need.
 
 ## Have more questions?
 

--- a/content/articles/domain-apex-heroku.md
+++ b/content/articles/domain-apex-heroku.md
@@ -44,7 +44,7 @@ These are the steps that you will need to follow to add an ALIAS record that poi
 ##### To create an ALIAS for the apex domain
 
 1.  Log in to DNSimple with your user credentials.
-1.  Follow [these instructions](/articles/record-editor/#access-the-record-editor) to edit your domain's records.
+1.  Follow [these instructions](/articles/record-editor/#accessing-the-record-editor) to edit your domain's records.
 1.  Click <label>Add a Record</label>, and select the `ALIAS` record type.
 
     ![Add a Record](/files/add-alias-heroku-1.jpg)

--- a/content/articles/getting-started-ssl-certificates.md
+++ b/content/articles/getting-started-ssl-certificates.md
@@ -63,7 +63,7 @@ Your choice depends on what you need to secure and how you want to manage the ce
 
 If your domain resolves with DNSimple, both Sectigo and Let's Encrypt certificates are available. If your domain resolves elsewhere, only Sectigo certificates can be ordered. You do not need to transfer or host your domain with DNSimple to purchase a Sectigo certificate.
 
-For help deciding between the two CAs, see [Sectigo vs Let's Encrypt — Which is right for me?](/articles/standard-vs-letsencrypt/#whichone). For a broader look at certificate categories (single-name, wildcard, multi-domain, and validation levels), see [SSL Certificate Types](/articles/ssl-certificates-types/).
+For help deciding between the two CAs, see [Sectigo vs Let's Encrypt — Which is right for me?](/articles/standard-vs-letsencrypt/#choosing). For a broader look at certificate categories (single-name, wildcard, multi-domain, and validation levels), see [SSL Certificate Types](/articles/ssl-certificates-types/).
 
 ### Choose the certificate names {#choose-names}
 

--- a/content/articles/how-long-to-issue-ssl-certificate.md
+++ b/content/articles/how-long-to-issue-ssl-certificate.md
@@ -19,7 +19,7 @@ The time required to issue a new [SSL certificate](/articles/ssl-certificates/) 
 
 ## Sectigo certificates {#sectigo}
 
-For Sectigo [single-name](/articles/ssl-certificates/#standard-singlename) and [wildcard](/articles/ssl-certificates/#standard-wildcard) certificates, issuance typically takes from one hour to several hours after email approval is completed.
+For Sectigo [single-name](/articles/ssl-certificates/#sectigo-singlename) and [wildcard](/articles/ssl-certificates/#sectigo-wildcard) certificates, issuance typically takes from one hour to several hours after email approval is completed.
 
 The issuance process begins once the certificate authority receives and validates the email approval. The actual certificate generation and signing happens relatively quickly once validation is confirmed.
 

--- a/content/articles/integrated-dns-provider-amazon-route53.md
+++ b/content/articles/integrated-dns-provider-amazon-route53.md
@@ -34,10 +34,10 @@ To connect [Amazon Route 53](https://aws.amazon.com/route53/) as an Integrated D
 
 ## Supported features {#supported-features}
 
-- **Import integrated zones**: When you connect Route 53 to your DNSimple account, you can [select](/articles/integrated-dns-providers/#managing-integrated-zone-selection) the zones hosted on Route 53 that are to be imported into DNSimple and listed on the [Domain Names](/articles/managing-integrated-zones/) page.
+- **Import integrated zones**: When you connect Route 53 to your DNSimple account, you can [select](/articles/import-integrated-zone-records/) the zones hosted on Route 53 that are to be imported into DNSimple and listed on the [Domain Names](/articles/managing-integrated-zones/) page.
 - **Adding and removing integrated zones**: [Add](/articles/integrated-dns-provider-zones/#adding-a-zone-to-an-integrated-dns-provider/) or [delete](/articles/integrated-dns-provider-zones/#deleting-a-zone-from-an-integrated-dns-provider/) zones to/from Route 53, from within DNSimple. You can also [remove](/articles/integrated-dns-provider-zones/#removing-integrated-zones-from-dnsimple/) an integrated zone from DNSimple while keeping it at Route 53.
 - **Management of integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Record Editor](/articles/record-editor-integrated-zones/). (See: [Supported record types for Route 53](/articles/integrated-dns-provider-amazon-route53/#supported-record-types))
-- **Two-way record syncing**: Sync your zone records from Route 53 to DNSimple, or from DNSimple to Route 53, with the [Record Editor](/articles/record-editor-integrated-zones/#record-syncing).
+- **Two-way record syncing**: Sync your zone records from Route 53 to DNSimple, or from DNSimple to Route 53, with the [Record Editor](/articles/sync-integrated-zone-records/#syncing-zone-records).
 
 ## Supported record types {#supported-record-types}
 

--- a/content/articles/integrated-dns-provider-azure-dns.md
+++ b/content/articles/integrated-dns-provider-azure-dns.md
@@ -36,10 +36,10 @@ To connect [Azure DNS](https://azure.microsoft.com/en-us/products/dns) as an [In
 > [!WARNING]
 > Azure record set [tags](https://learn.microsoft.com/en-us/azure/dns/dns-zones-records#tags) and [metadata](https://learn.microsoft.com/en-us/azure/dns/dns-zones-records#metadata) will not be retained and will be <strong>lost</strong> when using this integration.
 
-- **Import integrated zones**: When you connect Azure DNS to your DNSimple account, you can [select](/articles/integrated-dns-providers/#managing-integrated-zone-selection) the zones hosted on Azure that are to be imported into DNSimple and listed on the [Domain Names](/articles/managing-integrated-zones/) page.
+- **Import integrated zones**: When you connect Azure DNS to your DNSimple account, you can [select](/articles/import-integrated-zone-records/) the zones hosted on Azure that are to be imported into DNSimple and listed on the [Domain Names](/articles/managing-integrated-zones/) page.
 - **Adding and removing integrated zones**: [Add](/articles/integrated-dns-provider-zones/#adding-a-zone-to-an-integrated-dns-provider/) or [delete](/articles/integrated-dns-provider-zones/#deleting-a-zone-from-an-integrated-dns-provider/) zones to/from Azure, from within DNSimple. You can also [remove](/articles/integrated-dns-provider-zones/#removing-integrated-zones-from-dnsimple/) an integrated zone from DNSimple while keeping it at Azure.
 - **Management of integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Record Editor](/articles/record-editor-integrated-zones/). (See: [Supported record types for Azure DNS](/articles/integrated-dns-provider-azure-dns/#supported-record-types))
-- **Two-way record syncing**: Sync your zone records from Azure to DNSimple, or from DNSimple to Azure, with the [Record Editor](/articles/record-editor-integrated-zones/#record-syncing).
+- **Two-way record syncing**: Sync your zone records from Azure to DNSimple, or from DNSimple to Azure, with the [Record Editor](/articles/sync-integrated-zone-records/#syncing-zone-records).
 
 ## Supported record types {#supported-record-types}
 

--- a/content/articles/integrated-dns-provider-coredns.md
+++ b/content/articles/integrated-dns-provider-coredns.md
@@ -28,7 +28,7 @@ This article serves as a reference for the prerequisites, supported features, an
 ## Supported features {#supported-features}
 
 - **Management of integrated zone records**: List, create, update, and delete integrated zone records from DNSimple using the [Record Editor](/articles/record-editor-integrated-zones/).
-- **Sync integrated zone records**: Sync your zone records from DNSimple to multiple CoreDNS instances, and verify the sync state with the [Record Editor](/articles/record-editor-integrated-zones/#record-syncing).
+- **Sync integrated zone records**: Sync your zone records from DNSimple to multiple CoreDNS instances, and verify the sync state with the [Record Editor](/articles/sync-integrated-zone-records/#syncing-zone-records).
 
 The CoreDNS Integrated Provider supports one-way syncing of zone records configured at DNSimple. All records configured for the zone at DNSimple will be synced to CoreDNS on startup and again during each refresh interval. Zone records for any other Integrated DNS Provider must first be synced to DNSimple before they will be available to CoreDNS instances.
 

--- a/content/articles/integrated-dns-provider-zones.md
+++ b/content/articles/integrated-dns-provider-zones.md
@@ -20,7 +20,7 @@ After connecting an Integrated DNS Provider to your DNSimple account, you can vi
 
 - When you **add** a zone, it will be imported into DNSimple and listed on the [Domain Names](/articles/managing-integrated-zones/) page.
 -  When you **remove** a zone, it will remain both in DNSimple and at the provider. Removal will not delete the zone or its records. However, you will no longer be able to
-    - [Synchronize](/articles/record-editor-integrated-zones/#record-syncing) changes in the zone between DNSimple and the provider.
+    - [Synchronize](/articles/sync-integrated-zone-records/#syncing-zone-records) changes in the zone between DNSimple and the provider.
     - Make record changes to the zone on the provider's end via DNSimple.
 - When you **delete** a zone, this retains the zone and its records at DNSimple, but deletes them from the provider.
   
@@ -82,7 +82,7 @@ Once the provider is connected, the zone will be added to the provider or just i
 
 If you imported a zone into DNSimple from an Integrated DNS Provider, you can use the **DNS Zone Providers** card to remove the zone from DNSimple without deleting it. 
 
-This retains the zone and its records at both DNSimple and at the Integrated DNS Provider. However, you will no longer be able to [synchronize](/articles/record-editor-integrated-zones/#record-syncing) changes in the zone between DNSimple and the provider, or make record changes to the zone hosted by the provider via DNSimple.
+This retains the zone and its records at both DNSimple and at the Integrated DNS Provider. However, you will no longer be able to [synchronize](/articles/sync-integrated-zone-records/#syncing-zone-records) changes in the zone between DNSimple and the provider, or make record changes to the zone hosted by the provider via DNSimple.
 
 **Steps to remove an integrated provider zone**
 

--- a/content/articles/manage-a-record.md
+++ b/content/articles/manage-a-record.md
@@ -16,7 +16,7 @@ categories:
 
 You can manage [A records](/articles/a-record/) in DNSimple using the [DNS record editor](/articles/record-editor/).
 
-The instructions in this article assume you are familiar with the [A record format](/articles/a-record/#record-format) and usage.
+The instructions in this article assume you are familiar with the [A record format](/articles/a-record/#how-a-records-work) and usage.
 
 ## Adding an A record {#adding-an-a-record}
 

--- a/content/articles/manage-aaaa-record.md
+++ b/content/articles/manage-aaaa-record.md
@@ -16,7 +16,7 @@ categories:
 
 You can manage [AAAA records](/articles/aaaa-record/) in DNSimple using the [DNS record editor](/articles/record-editor/).
 
-The instructions in this article assume you are familiar with the [AAAA record format](/articles/aaaa-record/#record-format) and usage.
+The instructions in this article assume you are familiar with the [AAAA record format](/articles/aaaa-record/#how-aaaa-records-work) and usage.
 
 ## Adding an AAAA record {#adding-an-aaaa-record}
 

--- a/content/articles/managing-integrated-zones.md
+++ b/content/articles/managing-integrated-zones.md
@@ -27,7 +27,7 @@ From the **Domain Names** page, you can see both your DNSimple zones and zones f
 
 ## Refreshing and importing integrated zones {#refreshing-and-importing-integrated-zones}
 
-Loading the Domain Names page automatically [refreshes](/articles/record-editor-integrated-zones/#importing-integrated-zone-records) the current state of integrated zones and their records from connected Integrated DNS Providers that support zone imports. The zones and zone records will be refreshed in the background upon page load, and the Domain Names page will automatically update to reflect them once ready.
+Loading the Domain Names page automatically [refreshes](/articles/import-integrated-zone-records/) the current state of integrated zones and their records from connected Integrated DNS Providers that support zone imports. The zones and zone records will be refreshed in the background upon page load, and the Domain Names page will automatically update to reflect them once ready.
 
 You can also manage the selection of [zones to import](/articles/integrated-dns-provider-zones/) by going to your **Account settings → Integrated Providers** page and updating the selection of zones.
 

--- a/content/articles/redirect-heroku.md
+++ b/content/articles/redirect-heroku.md
@@ -34,7 +34,7 @@ In this case, the simplest solution is to use our [redirector service](/articles
 <div class="section-steps" markdown="1">
 ##### To handle the redirect using the redirector {#redirect-nohttps-redirector}
 
-1.  Go to the record editor and [add a URL record](/articles/url-record/#create).
+1.  Go to the record editor and [add a URL record](/articles/url-record/#managing-url-records).
 
     - Add the redirect subdomain in the _Name_ field.
     - Add the URL of the target domain in the _URL_ field.

--- a/content/articles/ssl-certificate-lifecycle.md
+++ b/content/articles/ssl-certificate-lifecycle.md
@@ -55,7 +55,7 @@ Before a CA will issue a certificate, it must confirm that the requester control
 The validation method depends on the certificate type:
 
 - **Sectigo certificates** use [email-based validation](/articles/ssl-certificates-email-validation/). The CA sends a verification email to an administrative address at the domain (e.g., `admin@example.com`), and the domain owner must click a link in that email to approve the certificate.
-- **Let's Encrypt certificates** use DNS-based validation. DNSimple automatically creates the required DNS records and submits the challenge to Let's Encrypt — no manual action is needed, provided the domain [resolves with DNSimple](/articles/letsencrypt/#integration).
+- **Let's Encrypt certificates** use DNS-based validation. DNSimple automatically creates the required DNS records and submits the challenge to Let's Encrypt — no manual action is needed, provided the domain [resolves with DNSimple](/articles/letsencrypt/#dnsimple-integration).
 
 > [!WARNING]
 > Validation must be completed for every new certificate, including renewals. If you don't complete validation, the certificate will not be issued.

--- a/content/articles/ssl-domain-validation-methods.md
+++ b/content/articles/ssl-domain-validation-methods.md
@@ -60,7 +60,7 @@ DNS-based validation (known as the **DNS-01 challenge** in the [ACME protocol](h
 
 This method is well-suited to automation because the DNS record can be created and removed programmatically. It is the method used by [Let's Encrypt](/articles/letsencrypt/).
 
-When you order a Let's Encrypt certificate through DNSimple, the DNS records are created and verified automatically — no manual action is required, provided the domain [resolves with DNSimple's name servers](/articles/letsencrypt/#integration).
+When you order a Let's Encrypt certificate through DNSimple, the DNS records are created and verified automatically — no manual action is required, provided the domain [resolves with DNSimple's name servers](/articles/letsencrypt/#dnsimple-integration).
 
 ### HTTP-based validation {#http}
 

--- a/content/articles/transferring-domain-away.md
+++ b/content/articles/transferring-domain-away.md
@@ -35,7 +35,7 @@ The _transfer code_ (also called _authorization code_, _auth code_, or _auth inf
 
 Some TLDs have different transfer procedures:
 
-- [.UK TLDs](/articles/domains-uk/#transfer-away)
+- [.UK TLDs](/articles/domains-uk/#transferring-outgoing)
 
 
 ## 1. Unlocking the domain and requesting a transfer code {#unlock-and-transfer-code}

--- a/content/articles/verifying-domain-resolution.md
+++ b/content/articles/verifying-domain-resolution.md
@@ -29,7 +29,7 @@ Your domain needs to be registered for it to be accessible via DNS. You can regi
 
 When you are not using a zone, you may decide to deactivate it to avoid being billed. When you resume using it, re-activating it can easily be overlooked.
 
-Your domain's DNS zone needs to be active for the domain to resolve and for your changes to take effect. You can activate the DNS zone for your domain by clicking **Activate zone** in the notification. Refer to our [guide](/articles/dns-hosting/#activating-a-dns-zone) on activating a DNS zone for more information.
+Your domain's DNS zone needs to be active for the domain to resolve and for your changes to take effect. You can activate the DNS zone for your domain by clicking **Activate zone** in the notification. Refer to our [guide](/articles/activate-deactivate-dns-zone/#activating-a-dns-zone) on activating a DNS zone for more information.
 
 ## Domain is delegated elsewhere {#domain-is-delegated-elsewhere}
 


### PR DESCRIPTION
## Summary

Repairs **25 internal cross-links** that pointed to article sections no longer reachable at the referenced anchor. Some also pointed to the *wrong article* after content was split into dedicated pages. Found via an anchor-resolution pass over `content/articles/`.

This is a standalone hygiene pass, independent of the Account Explanation work in #2012. (The two remaining `changing-email/#changing-the-account-email` links are part of the notification-email terminology migration and are handled in #2012, so they are intentionally not touched here.)

## Fixes by cause

**Slug / rename drift** (anchor renamed, same article)

| File | Old | New |
|---|---|---|
| getting-started-ssl-certificates | `standard-vs-letsencrypt/#whichone` | `#choosing` |
| account-creation | `account-multi/#creating` | `#creating-a-separate-account` |
| domain-apex-heroku | `record-editor/#access-the-record-editor` | `#accessing-the-record-editor` |
| dashboard | `activity-tracking/#activity-tracking-at-the-account-level` | `#account-activity-tracking` |
| ssl-certificate-lifecycle, ssl-domain-validation-methods | `letsencrypt/#integration` | `#dnsimple-integration` |
| buy-sectigo-ssl-certificate | `getting-started-ssl-certificates/#requirements` | `#before-you-order` |
| transferring-domain-away | `domains-uk/#transfer-away` | `#transferring-outgoing` |
| manage-a-record, manage-aaaa-record | `a-record/#record-format` | `#how-a-records-work` |
| redirect-heroku | `url-record/#create` | `#managing-url-records` |

**`Standard` → `Sectigo` terminology**

- how-long-to-issue-ssl-certificate: `ssl-certificates/#standard-singlename` → `#sectigo-singlename`, `#standard-wildcard` → `#sectigo-wildcard`

**Contact links** repointed to the real sections in *Changing a Domain Contact*

- changing-whois-contact, contact-management: `#changing-an-existing-contact-information` → `#updating-a-domain-contact`, `#replacing-a-domain-contact` → `#assigning-a-new-domain-contact`

**Moved to a dedicated article** (wrong target article, not just anchor)

- Zone activation → [Activate and Deactivate a DNS Zone](/articles/activate-deactivate-dns-zone/#activating-a-dns-zone) (was `dns-hosting/...`)
- Record syncing → [Sync Integrated Zone Records](/articles/sync-integrated-zone-records/#syncing-zone-records) (was `record-editor-integrated-zones/#record-syncing`; 5 links across the Route 53, Azure, CoreDNS, and zones guides)
- Zone import/selection → [Import Integrated Zone Records](/articles/import-integrated-zone-records/) (was `record-editor-integrated-zones/#importing-integrated-zone-records` and `integrated-dns-providers/#managing-integrated-zone-selection`)

## Test plan

- [x] Every changed link resolves to a real section (or article, for the import page which has no sub-anchor)
- [x] Link text still matches the destination section