### PR TITLE
Update Account billing How-to articles

### DIFF
--- a/content/articles/billing-settings.md
+++ b/content/articles/billing-settings.md
@@ -1,7 +1,7 @@
 ---
 title: Billing Settings
-excerpt: What you need to know about the billing information displayed on every invoice.
-meta: Customize billing information on invoices, including company name, tax ID, and address. Teams plans and higher can set a separate billing email.
+excerpt: How to customize billing information and billing email on DNSimple invoices.
+meta: Customize billing information on invoices, including company name, tax ID, and address. Teams plans and higher can set a separate billing email for invoices.
 categories:
 - Account
 ---
@@ -15,16 +15,17 @@ categories:
 
 ---
 
+Customize the billing details that appear on your DNSimple invoices and, on eligible plans, set where invoice emails are delivered.
+
 Custom billing email is only available on Teams plans or higher. [See the differences between plans](/articles/dnsimple-plans/).
 
-Invoices will be sent to the email address that corresponds to the DNSimple account. If you have more than one account, all invoices will be sent to the same email address.
+On Solo plans, invoices go to account administrators. On Teams plans and higher, you can set a separate billing email for invoices. This is different from the [notification email](/articles/changing-email/#setting-or-changing-the-notification-email) used for other account messages.
 
 ![Example Invoice Without Billing Information](/files/account-billing-settings-invoice-1.png)
 
+## Customizing billing information {#customizing-billing-information}
 
-## Customizing billing information
-
-You can replace the following billing details with custom information on all invoices:
+You can replace the following billing details with custom information on all future invoices:
 
 - Company
 - Tax ID
@@ -33,49 +34,46 @@ You can replace the following billing details with custom information on all inv
 ![Example Invoice With Billing Information](/files/account-billing-settings-invoice-2.png)
 
 > [!NOTE]
-> The account owner can modify this information any time, as often as needed. The new billing information will only be used for future invoices.
+> The account owner can modify this information any time. The new billing information will only be used for future invoices.
 
-If you need to change the billing information for an existing invoice, please [contact support](https://dnsimple.com/contact).
-
-### Changing your billing settings
+If you need to change the billing information for an existing invoice, [contact support](https://dnsimple.com/contact).
 
 <div class="section-steps" markdown="1">
 ##### To update your billing settings
 
-1. Choose the relevant account from the account switcher, then click the gear icon ⚙️ next to the account name to open **account settings**.
-1.  Scroll down to the invoices section. Click **Edit** at the bottom right of the section.
+1. Choose the relevant account from the account switcher, then click the gear icon next to the account name to open <label>account settings</label>.
+1. Scroll down to the invoices section. Click <label>Edit</label> at the bottom right of the section.
 
     ![Change billing settings](/files/account-billing-settings-link.png)
 
-1.  You'll see your current billing information (it will be empty if this is the first time you're editing it). Click **Edit**.
-1.  Fill in the form, and click **Save** when you're finished.
+1. You will see your current billing information (it will be empty if this is the first time you are editing it). Click <label>Edit</label>.
+1. Fill in the form, and click <label>Save</label> when you are finished.
 
     ![Change payment details](/files/account-billing-settings-update.png)
-</div>
 
+</div>
 
 All future invoices will display the information you provided.
 
 > [!NOTE]
-> If you're on a solo plan, you cannot change the billing email address. If you've set up a separate billing contact, they do not have authorized access to the account, and information cannot be shared with them if they contact us. All future invoices will display the information you provided.
+> If you are on a Solo plan, you cannot change the billing email address. If you have set up a separate billing contact, they do not have authorized access to the account, and information cannot be shared with them if they contact us.
 
-## Changing the billing email
+## Changing the billing email {#changing-the-billing-email}
 
-If you're on a Teams plan or higher, we can deliver your invoices to a different email address from the one you use to manage your domains. This is not available on Solo plans.
+If you are on a Teams plan or higher, DNSimple can deliver invoices to a different email address from your user email. This is not available on Solo plans.
 
 > [!NOTE]
 > Only account administrators can change the billing email address.
 
 <div class="section-steps" markdown="1">
-
 ##### To change your billing email
 
-1.  [Locate the account](https://dnsimple.com/user) on your dashboard. Click on the account to enter the account page.
-1.  Scroll down to the invoices section. Click **Edit**.
+1. [Locate the account](https://dnsimple.com/user) on your dashboard. Click the account to open the account page.
+1. Scroll down to the invoices section. Click <label>Edit</label>.
 
     ![Change billing settings](/files/account-billing-settings-link.png)
 
-1.  Update the email, and click **Save** when you are finished.
+1. Update the email, and click <label>Save</label> when you are finished.
 
     ![Change billing email](/files/account-edit-billing-email-update.png)
 
@@ -83,4 +81,4 @@ If you're on a Teams plan or higher, we can deliver your invoices to a different
 
 ## Have more questions?
 
-If you have any questions about your billing settings, [contact us](https://dnsimple.com/feedback), and we'll be happy to help.
+If you have questions about your billing settings, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/billing-settings.md
+++ b/content/articles/billing-settings.md
@@ -19,7 +19,7 @@ Customize the billing details that appear on your DNSimple invoices and, on elig
 
 Custom billing email is only available on Teams plans or higher. [See the differences between plans](/articles/dnsimple-plans/).
 
-On Solo plans, invoices go to account administrators. On Teams plans and higher, you can set a separate billing email for invoices. This is different from the [notification email](/articles/changing-email/#setting-or-changing-the-notification-email) used for other account messages.
+On Solo plans, invoices go to the account administrator. On Teams plans and higher, you can set a separate billing email for invoices. This is different from the [notification email](/articles/changing-email/#setting-or-changing-the-notification-email) used for other account messages.
 
 ![Example Invoice Without Billing Information](/files/account-billing-settings-invoice-1.png)
 

--- a/content/articles/billing-settings.md
+++ b/content/articles/billing-settings.md
@@ -15,8 +15,6 @@ categories:
 
 ---
 
-Customize the billing details that appear on your DNSimple invoices and, on eligible plans, set where invoice emails are delivered.
-
 Custom billing email is only available on Teams plans or higher. [See the differences between plans](/articles/dnsimple-plans/).
 
 On Solo plans, invoices go to the account administrator. On Teams plans and higher, you can set a separate billing email for invoices. This is different from the [notification email](/articles/changing-email/#setting-or-changing-the-notification-email) used for other account messages.

--- a/content/articles/billing-settings.md
+++ b/content/articles/billing-settings.md
@@ -20,7 +20,7 @@ Use Billing Settings to customize the billing details shown on your DNSimple inv
 On [Teams plans and higher](/articles/dnsimple-plans/), you can also set a separate billing email for invoices. This is different from the [notification email](/articles/changing-email/#setting-or-changing-the-notification-email), which is used for other account messages.
 
 > [!NOTE]
-> On Solo plans, invoices are sent to the account administrator. A separate billing email is only available on Teams plans and higher.
+> On Solo plans, invoices are sent to the account notification email, or to account administrators if none is set. A separate billing email is only available on Teams plans and higher.
 
 ![Example Invoice Without Billing Information](/files/account-billing-settings-invoice-1.png)
 

--- a/content/articles/billing-settings.md
+++ b/content/articles/billing-settings.md
@@ -15,15 +15,18 @@ categories:
 
 ---
 
-Custom billing email is only available on Teams plans or higher. [See the differences between plans](/articles/dnsimple-plans/).
+Use Billing Settings to customize the billing details shown on your DNSimple invoices. You can add company information, a tax ID, and a billing address for future invoices.
 
-On Solo plans, invoices go to the account administrator. On Teams plans and higher, you can set a separate billing email for invoices. This is different from the [notification email](/articles/changing-email/#setting-or-changing-the-notification-email) used for other account messages.
+On [Teams plans and higher](/articles/dnsimple-plans/), you can also set a separate billing email for invoices. This is different from the [notification email](/articles/changing-email/#setting-or-changing-the-notification-email), which is used for other account messages.
+
+> [!NOTE]
+> On Solo plans, invoices are sent to the account administrator. A separate billing email is only available on Teams plans and higher.
 
 ![Example Invoice Without Billing Information](/files/account-billing-settings-invoice-1.png)
 
 ## Customizing billing information {#customizing-billing-information}
 
-You can replace the following billing details with custom information on all future invoices:
+You can add or update the following billing details for future invoices:
 
 - Company
 - Tax ID
@@ -32,19 +35,21 @@ You can replace the following billing details with custom information on all fut
 ![Example Invoice With Billing Information](/files/account-billing-settings-invoice-2.png)
 
 > [!NOTE]
-> The account owner can modify this information any time. The new billing information will only be used for future invoices.
+> The account owner can modify this information at any time. Changes to billing information only apply to future invoices. They do not update invoices that have already been issued.
 
 If you need to change the billing information for an existing invoice, [contact support](https://dnsimple.com/contact).
 
 <div class="section-steps" markdown="1">
 ##### To update your billing settings
 
-1. Choose the relevant account from the account switcher, then click the gear icon next to the account name to open <label>account settings</label>.
-1. Scroll down to the invoices section. Click <label>Edit</label> at the bottom right of the section.
+1. Choose the relevant account from the account switcher.
+1. Click the gear icon next to the account name to open <label>account settings</label>.
+1. Click the <label>Billing and plans</label> tab.
+1. Scroll to the <label>Invoices</label> section, then click <label>Edit</label>.
 
     ![Change billing settings](/files/account-billing-settings-link.png)
 
-1. You will see your current billing information (it will be empty if this is the first time you are editing it). Click <label>Edit</label>.
+1. You will see your current billing information (it will be empty if this is the first time you are editing it).
 1. Fill in the form, and click <label>Save</label> when you are finished.
 
     ![Change payment details](/files/account-billing-settings-update.png)
@@ -54,7 +59,9 @@ If you need to change the billing information for an existing invoice, [contact 
 All future invoices will display the information you provided.
 
 > [!NOTE]
-> If you are on a Solo plan, you cannot change the billing email address. If you have set up a separate billing contact, they do not have authorized access to the account, and information cannot be shared with them if they contact us.
+> On Solo plans, you cannot set a separate billing email address. Invoice emails are delivered to the account [notification email](/articles/changing-email/#setting-or-changing-the-notification-email), or to account administrators if none is set.
+>
+> On Teams plans and higher, the [billing email](/articles/billing-settings/#changing-the-billing-email) only controls where invoice emails are delivered. It does not give the recipient authorized access to the account, and DNSimple cannot share account information with them unless they are also added as an [account member](/articles/account-users/) with the [appropriate access](/articles/what-is-domain-access-control/).
 
 ## Changing the billing email {#changing-the-billing-email}
 
@@ -66,11 +73,14 @@ If you are on a Teams plan or higher, DNSimple can deliver invoices to a differe
 <div class="section-steps" markdown="1">
 ##### To change your billing email
 
-1. [Locate the account](https://dnsimple.com/user) on your dashboard. Click the account to open the account page.
-1. Scroll down to the invoices section. Click <label>Edit</label>.
+1. Choose the relevant account from the account switcher.
+1. Click the gear icon next to the account name to open <label>account settings</label>.
+1. Click the <label>Billing and plans</label> tab.
+1. Scroll to the <label>Invoices</label> section, then click <label>Edit</label>.
 
     ![Change billing settings](/files/account-billing-settings-link.png)
 
+1. Enter the billing email address you want to use for invoices.
 1. Update the email, and click <label>Save</label> when you are finished.
 
     ![Change billing email](/files/account-edit-billing-email-update.png)

--- a/content/articles/cancel-subscription.md
+++ b/content/articles/cancel-subscription.md
@@ -1,44 +1,54 @@
 ---
 title: Unsubscribe From Your DNSimple Plan
 excerpt: How to cancel the recurring subscription for a DNSimple account.
-meta: Easily cancel your DNSimple subscription with our step-by-step guide. Follow these simple instructions to manage your account and stop recurring charges today.
+meta: Cancel your DNSimple subscription and stop recurring charges. Your domains and records remain in the account unless you delete them.
 categories:
 - Account
 ---
 
 # Unsubscribe From Your DNSimple Plan
 
-If you no longer need DNSimple's services, you can unsubscribe at any time.
+### Table of Contents {#toc}
 
-Once you unsubscribe, your card on file will no longer be charged the monthly subscription fee.
+* TOC
+{:toc}
 
-Apart from the subscription fee, the following will take effect immediately:
-- All domains pointing to our name servers will stop resolving — they will no longer function, and your site will be inaccessible to your users.
-- [WHOIS Privacy](/articles/whois-privacy/) will be disabled for all domains registered with DNSimple.
+---
+
+Unsubscribe when you no longer need an active DNSimple subscription. This stops recurring subscription charges but does not delete your account, domains, or records.
+
+Once you unsubscribe, the card on file will no longer be charged the monthly subscription fee.
+
+Apart from the subscription fee, the following take effect immediately:
+
+- All domains pointing to our name servers stop resolving. Your site will be inaccessible to visitors.
+- [WHOIS privacy](/articles/whois-privacy/) is disabled for all domains registered with DNSimple.
 - Any domain in your account that is registered will not renew.
-- [Email Forwarding](/articles/email-forwarding/) will stop working.
+- [Email forwarding](/articles/email-forwarding/) stops working.
 
 > [!NOTE]
-> This is not an account deletion. If you do not delete your domains from the account, all domains and corresponding records will remain in your account should you choose to [reactivate](/articles/reactivate-subscription/). To permanently delete yourself as a DNSimple user, see [Deleting Yourself as a User](/articles/close-account/).
+> This is not account deletion. If you do not delete your domains, they and their records remain in your account if you choose to [reactivate your subscription](/articles/reactivate-subscription/). To permanently delete yourself as a DNSimple user, see [Deleting Yourself as a User](/articles/close-account/).
+
+## Unsubscribe from your plan {#unsubscribe-from-your-plan}
 
 <div class="section-steps" markdown="1">
-##### To unsubscribe from your DNSimple plan:
+##### To unsubscribe from your DNSimple plan
 
-1. Choose the relevant account from the account switcher, then click the gear icon ⚙️ next to the account name to open **account settings**.
-1. On the left side of the screen, select the **Billings and plans** tab.
-1. Scroll down to the end of the page to find the Unsubscribe section.
+1. Choose the relevant account from the account switcher, then click the gear icon next to the account name to open <label>account settings</label>.
+1. On the left side of the screen, select the <label>Billing and plans</label> tab.
+1. Scroll to the <label>Unsubscribe</label> section at the end of the page.
 
     ![Unsubscribe section](/files/account-unsubscribe.png)
 
-1.  Click the <label>Unsubscribe</label> button.
-1.  Confirm that you want to unsubscribe by typing your account's email address:
+1. Click <label>Unsubscribe</label>.
+1. Confirm that you want to unsubscribe by typing the notification email address for the account:
 
     ![Account unsubscribe confirmation](/files/account-unsubscribe-confirmation.png)
 
-</div>
+1. Click <label>Unsubscribe</label> to complete the process.
 
-After typing your email address and clicking **Unsubscribe**, you will be unsubscribed from your DNSimple account.
+</div>
 
 ## Have more questions?
 
-Feel free to [contact our support team](https://dnsimple.com/feedback) with any questions or concerns about unsubscribing from your account. We'll be happy to help.
+If you have questions about unsubscribing from your account, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/cancel-subscription.md
+++ b/content/articles/cancel-subscription.md
@@ -25,6 +25,7 @@ Apart from the subscription fee, the following take effect immediately:
 - [WHOIS privacy](/articles/whois-privacy/) is disabled for all domains registered with DNSimple.
 - Any domain in your account that is registered will not renew.
 - [Email forwarding](/articles/email-forwarding/) stops working.
+- Any account credit or promotions applied to your account are lost.
 
 > [!NOTE]
 > This is not account deletion. If you do not delete your domains, they and their records remain in your account if you choose to [reactivate your subscription](/articles/reactivate-subscription/). To permanently delete yourself as a DNSimple user, see [Deleting Yourself as a User](/articles/close-account/).
@@ -41,7 +42,7 @@ Apart from the subscription fee, the following take effect immediately:
     ![Unsubscribe section](/files/account-unsubscribe.png)
 
 1. Click <label>Unsubscribe</label>.
-1. Confirm that you want to unsubscribe by typing the notification email address for the account:
+1. Confirm that you want to unsubscribe by typing your account name:
 
     ![Account unsubscribe confirmation](/files/account-unsubscribe-confirmation.png)
 

--- a/content/articles/cancel-subscription.md
+++ b/content/articles/cancel-subscription.md
@@ -28,16 +28,16 @@ Apart from the subscription fee, the following take effect immediately:
 - Any account credit or promotions applied to your account are lost.
 
 > [!NOTE]
-> This is not account deletion. If you do not delete your domains, they and their records remain in your account if you choose to [reactivate your subscription](/articles/reactivate-subscription/). To permanently delete yourself as a DNSimple user, see [Deleting Yourself as a User](/articles/close-account/).
+> This is not an account deletion. If you do not delete your domains from the account, all domains and corresponding records will remain in your account should you choose to [reactivate your subscription](/articles/reactivate-subscription/). To permanently delete yourself as a DNSimple user, see [Deleting Yourself as a User](/articles/close-account/).
 
 ## Unsubscribe from your plan {#unsubscribe-from-your-plan}
 
 <div class="section-steps" markdown="1">
 ##### To unsubscribe from your DNSimple plan
 
-1. Choose the relevant account from the account switcher, then click the gear icon next to the account name to open <label>account settings</label>.
+1. Choose the relevant account from the account switcher, then click the gear icon ⚙️ next to the account name to open <label>account settings</label>.
 1. On the left side of the screen, select the <label>Billing and plans</label> tab.
-1. Scroll to the <label>Unsubscribe</label> section at the end of the page.
+1. Scroll down to the bottom of the page to find the <label>Unsubscribe</label> section.
 
     ![Unsubscribe section](/files/account-unsubscribe.png)
 

--- a/content/articles/changing-payment-details.md
+++ b/content/articles/changing-payment-details.md
@@ -1,31 +1,45 @@
 ---
 title: Changing Payment Details
-excerpt: How to change a DNSimple account's payment details.
-meta: Easily update your DNSimple account's payment details with our step-by-step guide. Ensure your billing information is always current and secure.
+excerpt: How to change the payment method on a DNSimple account.
+meta: Update the credit card or payment method on your DNSimple account. Account owners and members with Full Access can change billing payment details.
 categories:
 - Account
 ---
 
-# Changing an Account's Payment Details
+# Changing Payment Details
 
-Account owners and team members with full-access can change the credit card associated with the DNSimple account any time.
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+Update the credit card or payment method DNSimple uses for your account subscription and purchases.
+
+Account owners and members with [Full Access](/articles/what-is-domain-access-control/#full-access) can change the payment method associated with the account.
 
 > [!NOTE]
-> Teams and higher plans have Domain Access Controls. Only those with a full-access seat will be able to update Billing information.
+> On Teams and Enterprise plans with [Domain Access Control](/articles/what-is-domain-access-control/), only members with Full Access can update billing information.
 
-### To update an account's payment details
+## Changing payment details {#changing-payment-details}
 
-1. Select the account you want to update the payment information for. From the account switcher at the top-right corner of the screen, click the gear icon ⚙️ next to the account name to open **account settings**.
-1. Select <label>Billing and plans</label> from the left side bar.
-1. Find the card showing your credit card information, and click <label>Edit</label>.
+<div class="section-steps" markdown="1">
+##### To update payment details
 
-   ![Change payment details](/files/account-billing-update-card-link.png)
+1. Select the account you want to update from the account switcher at the top-right corner of the screen, then click the gear icon next to the account name to open <label>account settings</label>.
+1. Select <label>Billing and plans</label> from the left sidebar.
+1. On the card showing your credit card information, click <label>Edit</label>.
 
-1.  Fill in your new credit card data and click <label>Update</label>.
-1.  Once the card has successfully updated, you'll see the confirmation.
+    ![Change payment details](/files/account-billing-update-card-link.png)
 
-![screenshot: card updated success message](/files/card-updated-msg.png)
+1. Fill in your new credit card details and click <label>Update</label>.
+1. When the card has updated successfully, you will see a confirmation message.
+
+    ![screenshot: card updated success message](/files/card-updated-msg.png)
+
+</div>
 
 ## Have more questions?
 
-If you have any questions about changing your payment details, [contact us](https://dnsimple.com/feedback), and we'll be happy to help.
+If you have questions about changing your payment details, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/changing-payment-details.md
+++ b/content/articles/changing-payment-details.md
@@ -15,9 +15,9 @@ categories:
 
 ---
 
-Use this guide to update the credit card DNSimple uses for your account subscription and purchases.
+Update the credit card or payment method DNSimple uses for your account subscription and purchases.
 
-Account owners and team members with [Full Access](/articles/what-is-domain-access-control/#full-access) can change the payment method associated with the DNSimple account any time.
+Account owners and team members with [Full Access](/articles/what-is-domain-access-control/#full-access) can change the payment method associated with the DNSimple account at any time.
 
 > [!NOTE]
 > On Teams and Enterprise plans with [Domain Access Control](/articles/what-is-domain-access-control/), only members with Full Access can update billing information.
@@ -28,7 +28,7 @@ Account owners and team members with [Full Access](/articles/what-is-domain-acce
 ##### To update payment details
 
 1. Select the account you want to update from the account switcher at the top-right corner of the screen, then click the gear icon next to the account name to open <label>account settings</label>.
-1. Select <label>Billing and plans</label> tab from the left sidebar.
+1. Select the <label>Billing and plans</label> tab from the left sidebar.
 1. On the card showing your credit card information, click <label>Edit</label>.
 
     ![Change payment details](/files/account-billing-update-card-link.png)

--- a/content/articles/changing-payment-details.md
+++ b/content/articles/changing-payment-details.md
@@ -15,9 +15,9 @@ categories:
 
 ---
 
-Update the credit card or payment method DNSimple uses for your account subscription and purchases.
+Use this guide to update the credit card DNSimple uses for your account subscription and purchases.
 
-Account owners and members with [Full Access](/articles/what-is-domain-access-control/#full-access) can change the payment method associated with the account.
+Account owners and team members with [Full Access](/articles/what-is-domain-access-control/#full-access) can change the payment method associated with the DNSimple account any time.
 
 > [!NOTE]
 > On Teams and Enterprise plans with [Domain Access Control](/articles/what-is-domain-access-control/), only members with Full Access can update billing information.
@@ -28,7 +28,7 @@ Account owners and members with [Full Access](/articles/what-is-domain-access-co
 ##### To update payment details
 
 1. Select the account you want to update from the account switcher at the top-right corner of the screen, then click the gear icon next to the account name to open <label>account settings</label>.
-1. Select <label>Billing and plans</label> from the left sidebar.
+1. Select <label>Billing and plans</label> tab from the left sidebar.
 1. On the card showing your credit card information, click <label>Edit</label>.
 
     ![Change payment details](/files/account-billing-update-card-link.png)

--- a/content/articles/changing-plans.md
+++ b/content/articles/changing-plans.md
@@ -1,77 +1,89 @@
 ---
 title: Changing Subscription Plan
 excerpt: How to change the subscribed plan for a DNSimple account.
-meta: Easily update your DNSimple subscription plan with our step-by-step guide. Learn how to manage your account and choose the right plan for your needs.
+meta: Upgrade or downgrade your DNSimple subscription plan. Learn when plan changes take effect, how proration works, and how to check incompatible features.
 categories:
 - Account
 ---
 
-# Change Subscription Plan
+# Changing Subscription Plan
 
-As a DNSimple customer, you might require features that aren't available on your current plan. This article discusses how to switch to the most appropriate subscription to meet your current needs. You can explore the various options and get an estimate of your costs on our [pricing page](https://dnsimple.com/pricing).
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+Change your DNSimple subscription when you need features from a different plan. Compare options and estimate costs on the [pricing page](https://dnsimple.com/pricing).
+
+For how proration appears on invoices, see [Understanding Your DNSimple Invoice](/articles/understanding-invoice/#proration).
 
 > [!NOTE]
-> We do not offer refunds for plan changes. If you upgrade your plan, you will receive a proration credit for the time remaining on your previous plan. If you downgrade, we wait until the end of the billing cycle, then charge you for the new subscription.
+> DNSimple does not offer refunds for plan changes. If you upgrade, you receive a proration credit for unused time on your previous plan. If you downgrade, the new plan is billed at the end of your current billing cycle.
 
-## Upgrading your plan
+## Upgrading your plan {#upgrading-your-plan}
 
-If you **upgrade** your subscription before your monthly renewal, **the changes take effect and are billed immediately**.
+If you **upgrade** before your monthly renewal, the changes take effect and are billed immediately.
 
-You will receive a prorated discount corresponding to the unused time in your current subscription plan. This credit doesn't include extra items like email forwards or active zones, as these are pay-per-use features. These will be billed again as part of the plan change.
+You receive a prorated discount for unused time on your current subscription plan. This credit does not include extra items like email forwards or active zones, because these are pay-per-use features. These will be billed again as part of the plan change.
 
-Read more about [subscription proration](/articles/understanding-invoice/#proration).
+## Downgrading your plan {#downgrading-your-plan}
 
-## Downgrading your plan
+If you **downgrade**, the changes are billed at the end of your current billing cycle along with your subscription renewal. All changes take effect at renewal.
 
-If you **downgrade** your subscription, **the changes will be billed at the end of your current billing cycle**, along with your subscription renewal. All changes take effect at the time of renewal.
+There is no proration credit for downgrades. DNSimple waits until the end of the billing cycle, then changes your plan.
 
-There is no proration credit for downgrades. We wait until the end of the billing cycle, then change your plan.
-
-You can cancel these plan changes in your account settings:
+You can cancel a pending downgrade in account settings:
 
 ![Cancel plan change](/files/account-billing-cancel-plan-change.png)
 
+## Changing your subscription plan {#changing-your-subscription-plan}
 
-## Changing your subscription plan
+<div class="section-steps" markdown="1">
+##### To change your subscription plan
 
-1. Select the relevant account from the account switcher at the top-right corner of the screen, then click the gear icon ⚙️ next to the account name to open **account settings**.
-1.  Click the **Change plan** link under your plan section.
+1. Select the relevant account from the account switcher at the top-right corner of the screen, then click the gear icon next to the account name to open <label>account settings</label>.
+1. Click the <label>Change plan</label> link under your plan section.
 
-![Screenshot of how to change plan](/files/change-plan-screenshot.png)
+    ![Screenshot of how to change plan](/files/change-plan-screenshot.png)
 
-1.  Explore the features for each plan. Click the **Select** button on the plan that best suits your needs.
+1. Review the features for each plan. Click <label>Select</label> on the plan that best suits your needs.
 
-![screenshot of selecting a plan](/files/select-plan-screenshot.png)
+    ![screenshot of selecting a plan](/files/select-plan-screenshot.png)
 
-1.  Verify the charges that will be made on your account. To complete the plan change, click **Confirm**.
+1. Review the charges that will be made on your account. To complete the plan change, click <label>Confirm</label>.
 
     ![Verify charges](/files/change-plan-3.png)
 
-1.  Once the change is complete, you'll receive the corresponding invoice.
-
-## Incompatible features
-
-When downgrading your account, you might not be able to use some features from your current plan. Common issues you may encounter are: [removing scoped access tokens](/articles/api-access-token/#removing-an-account-access-token), [removing URL records for https redirects](/articles/manage-url-record/#removing-a-url-record), and [removing seats](/articles/managing-seats/#decreasing-the-number-of-seats), among others.
-
-<div class="section-steps" markdown="1">
-To learn if any features you're using are incompatible with your plan change:
-
-1. Log in to your DNSimple account.
-1. Choose the relevant account and navigate to the Account page.
-1. Click **Billing and plans**, then **Change plan**.
-1. You'll be taken to a personalized version of the pricing page. Click **See incompatible features**.
-
-![screenshot of incompatible features button](/files/incompatable-features-screenshot.png)
-
-The breakdown includes any incompatible features, along with specific information for each one:
-
-![screenshot of incompatible features list](/files/incompatable-features-list-screenshot.png)
-
-We'll also alert you to any incompatibility issues when you initiate your plan change:
-
-![Incompatible Features](/files/account-billing-incompatible-features.png)
+1. When the change is complete, you will receive the corresponding invoice.
 
 </div>
 
+## Incompatible features {#incompatible-features}
+
+When downgrading, you may not be able to keep some features from your current plan. Common issues include [removing scoped access tokens](/articles/api-access-token/#removing-an-account-access-token), [removing URL records for HTTPS redirects](/articles/manage-url-record/#removing-a-url-record), and [removing seats](/articles/managing-seats/#decreasing-the-number-of-seats).
+
+<div class="section-steps" markdown="1">
+##### To check incompatible features before downgrading
+
+1. Log in to DNSimple.
+1. Choose the relevant account and open <label>account settings</label>.
+1. Click <label>Billing and plans</label>, then <label>Change plan</label>.
+1. On your personalized pricing page, click <label>See incompatible features</label>.
+
+    ![screenshot of incompatible features button](/files/incompatable-features-screenshot.png)
+
+</div>
+
+The breakdown lists incompatible features with details for each one:
+
+![screenshot of incompatible features list](/files/incompatable-features-list-screenshot.png)
+
+DNSimple also alerts you to incompatibility issues when you start a plan change:
+
+![Incompatible Features](/files/account-billing-incompatible-features.png)
+
 ## Have more questions?
-If you have any questions about changing your subscription plan, proration credits, or how to handle incompatible features, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.
+
+If you have questions about changing your subscription plan, proration credits, or incompatible features, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/changing-plans.md
+++ b/content/articles/changing-plans.md
@@ -20,7 +20,7 @@ Change your DNSimple subscription when you need features from a different plan. 
 For how proration appears on invoices, see [Understanding Your DNSimple Invoice](/articles/understanding-invoice/#proration).
 
 > [!NOTE]
-> DNSimple does not offer refunds for plan changes. If you upgrade, you receive a proration credit for unused time on your previous plan. If you downgrade, the new plan is billed at the end of your current billing cycle.
+> We do not offer refunds for plan changes. If you upgrade your plan, you will receive a proration credit for the time remaining on your previous plan. If you downgrade, we wait until the end of the billing cycle, then charge you for the new subscription.
 
 ## Upgrading your plan {#upgrading-your-plan}
 
@@ -30,11 +30,11 @@ You receive a prorated discount for unused time on your current subscription pla
 
 ## Downgrading your plan {#downgrading-your-plan}
 
-If you **downgrade**, the changes are billed at the end of your current billing cycle along with your subscription renewal. All changes take effect at renewal.
+If you **downgrade**, your current plan will remain active until the end of the billing cycle. The new plan will take effect and be billed at your next renewal.
 
-There is no proration credit for downgrades. DNSimple waits until the end of the billing cycle, then changes your plan.
+Because the downgrade does not take effect immediately, there is no proration credit.
 
-You can cancel a pending downgrade in account settings:
+You can cancel a pending downgrade from the <label>Billing and plans</label> tab in your account settings:
 
 ![Cancel plan change](/files/account-billing-cancel-plan-change.png)
 

--- a/content/articles/changing-plans.md
+++ b/content/articles/changing-plans.md
@@ -20,7 +20,7 @@ Change your DNSimple subscription when you need features from a different plan. 
 For how proration appears on invoices, see [Understanding Your DNSimple Invoice](/articles/understanding-invoice/#proration).
 
 > [!NOTE]
-> We do not offer refunds for plan changes. If you upgrade your plan, you will receive a proration credit for the time remaining on your previous plan. If you downgrade, we wait until the end of the billing cycle, then charge you for the new subscription.
+> DNSimple does not offer refunds for plan changes. If you upgrade your plan, you will receive a proration credit for the time remaining on your previous plan. If you downgrade, the new plan takes effect and is billed at your next renewal.
 
 ## Upgrading your plan {#upgrading-your-plan}
 

--- a/content/articles/reactivate-subscription.md
+++ b/content/articles/reactivate-subscription.md
@@ -1,52 +1,84 @@
 ---
 title: Reactivate Your Subscription
-excerpt: How to reactivate the subscription for a DNSimple account.
-meta: Learn how to easily reactivate your DNSimple subscription with our step-by-step guide, ensuring uninterrupted access to your domain management features.
+excerpt: How to reactivate the subscription for a DNSimple account after unsubscribing or suspension.
+meta: Reactivate your DNSimple subscription after unsubscribing or non-payment. Start a new subscription on a current plan while keeping your domains, records, and account history.
 categories:
 - Account
 ---
 
 # Reactivate Your Subscription
 
-When you unsubscribe, or your account was [closed due to non-payment](/articles/account-suspended/), all of your domains and records remain in your account. You can reactivate your subscription and start using DNSimple's services again at any time.
+### Table of Contents {#toc}
 
-When your account is deactivated, [WHOIS privacy](/articles/whois-privacy/), [domain auto-renewal](/articles/domain-auto-renewal/), and [email forwarding](/articles/email-forwarding/) are immediately disabled.
+* TOC
+{:toc}
 
-When you reactivate your account, all previous preferences will be reactivated, including WHOIS privacy, auto-renewal, and email forwarding.
+---
 
-> [!WARNING]
-> If you subscribed to DNSimple in the past, you've already enjoyed our 30-day trial. **Reactivating your subscription will not grant you another free trial**.
-
-## How to reactivate your subscription
+Reactivate your DNSimple subscription when you have [unsubscribed](/articles/cancel-subscription/) or your account was [suspended due to non-payment](/articles/account-suspended/). Your domains, DNS records, contacts, and account history remain in the account.
 
 > [!NOTE]
-> If your account was on one of our legacy plans, you will not be able to reactivate it on the same plan, and will need to choose one of our [available plans](https://dnsimple.com/pricing).
+> Reactivation creates a **new subscription** on a current plan. It does not resume your previous subscription terms. Your account data, including domains and records, stays in place.
 
-### From the dashboard
+When your account is deactivated, [WHOIS privacy](/articles/whois-privacy/), [domain auto-renewal](/articles/domain-auto-renewal/), and [email forwarding](/articles/email-forwarding/) are disabled immediately.
+
+When you reactivate your account, DNSimple restores those preferences where they still apply, including WHOIS privacy, auto-renewal, and email forwarding.
+
+> [!WARNING]
+> If you subscribed to DNSimple in the past, you have already used the 30-day trial. Reactivating your subscription will not grant another free trial.
+
+> [!NOTE]
+> If your account was on a legacy plan, you cannot reactivate on that same plan. Choose one of our [available plans](https://dnsimple.com/pricing).
+
+For what happens when payment stops, see [What Happens If You Stop Paying for DNSimple](/articles/what-happens-if-i-stop-paying/).
+
+## Reactivate from the dashboard {#reactivate-from-the-dashboard}
+
+<div class="section-steps" markdown="1">
+##### To reactivate from the dashboard
+
 1. Log in to DNSimple with your user credentials.
 1. Go to [your dashboard](https://dnsimple.com/dashboard).
-1. Locate the accounts section of your dashboard.
-1. You'll see a card with your account name on it. Click **Unlock advanced features** on this card.
+1. In the accounts section, find the card for the account you want to reactivate.
+1. Click <label>Unlock advanced features</label> on that card.
+
     ![screenshot selecting a plan](/files/select-a-plan.png)
-1. Choose the plan that fits your needs, and click **Get started**.
-1. Enter your payment information and click **Create Subscription**.
 
-### From the Billings and plans page:
+1. Choose the plan that fits your needs, and click <label>Get started</label>.
+1. Enter your payment information and click <label>Create Subscription</label>.
+
+</div>
+
+## Reactivate from Billing and plans {#reactivate-from-billing-and-plans}
+
+<div class="section-steps" markdown="1">
+##### To reactivate from Billing and plans
+
 1. Click the account switcher at the top-right corner of the screen.
-1. Click on the account you want to reactivate, then select **Account settings**.
-1. Click the **Billing and plans** tab on the left side of the screen.
-1. You'll see a card with a **Unlock more with a plan** message. Click **Unlock advanced features** at the bottom of this card.
-    ![screenshot no plan selected](/files/no-plan-selected.png)
-1. Choose the plan that fits your needs, and click **Get started**.
-1. Enter your payment information and click **Create Subscription**.
+1. Select the account you want to reactivate, then open <label>account settings</label>.
+1. Click the <label>Billing and plans</label> tab on the left side of the screen.
+1. On the card with the <label>Unlock more with a plan</label> message, click <label>Unlock advanced features</label>.
 
-### From the alert banner:
+    ![screenshot no plan selected](/files/no-plan-selected.png)
+
+1. Choose the plan that fits your needs, and click <label>Get started</label>.
+1. Enter your payment information and click <label>Create Subscription</label>.
+
+</div>
+
+## Reactivate from the alert banner {#reactivate-from-the-alert-banner}
+
+<div class="section-steps" markdown="1">
+##### To reactivate from the alert banner
+
 1. Log in to DNSimple with your user credentials.
 1. Go to your [dashboard](https://dnsimple.com/dashboard).
-1. If your account still has domains stored in it, you'll see an alert banner at the top of the screen. Click **Choose plan**.
-1. Choose the plan that fits your needs, and click **Get started**.
-1. Enter your payment information and click **Create Subscription**.
+1. If your account still has domains stored in it, click <label>Choose plan</label> in the alert banner at the top of the screen.
+1. Choose the plan that fits your needs, and click <label>Get started</label>.
+1. Enter your payment information and click <label>Create Subscription</label>.
+
+</div>
 
 ## Have more questions?
 
-If you have any questions about our currently available subscription plans or reactivating your account, [contact us](https://dnsimple.com/feedback), and we'll be happy to help.
+If you have questions about reactivating your subscription or choosing a plan, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/reactivate-subscription.md
+++ b/content/articles/reactivate-subscription.md
@@ -45,7 +45,7 @@ For what happens when payment stops, see [What Happens If You Stop Paying for DN
     ![screenshot selecting a plan](/files/select-a-plan.png)
 
 1. Choose the plan that fits your needs, and click <label>Get started</label>.
-1. Enter your payment information and click <label>Create Subscription</label>.
+1. Enter your payment information and click <label>Create new subscription</label>.
 
 </div>
 
@@ -62,7 +62,7 @@ For what happens when payment stops, see [What Happens If You Stop Paying for DN
     ![screenshot no plan selected](/files/no-plan-selected.png)
 
 1. Choose the plan that fits your needs, and click <label>Get started</label>.
-1. Enter your payment information and click <label>Create Subscription</label>.
+1. Enter your payment information and click <label>Create new subscription</label>.
 
 </div>
 
@@ -75,7 +75,7 @@ For what happens when payment stops, see [What Happens If You Stop Paying for DN
 1. Go to your [dashboard](https://dnsimple.com/dashboard).
 1. If your account still has domains stored in it, click <label>Choose plan</label> in the alert banner at the top of the screen.
 1. Choose the plan that fits your needs, and click <label>Get started</label>.
-1. Enter your payment information and click <label>Create Subscription</label>.
+1. Enter your payment information and click <label>Create new subscription</label>.
 
 </div>
 

--- a/content/articles/wallet-replenishment.md
+++ b/content/articles/wallet-replenishment.md
@@ -1,7 +1,7 @@
 ---
 title: Digital Wallet Replenishment
-excerpt: How to add funds to your digital wallet
-meta: Learn how to easily add funds to your DNSimple digital wallet, ensuring seamless transactions and uninterrupted service for your domain management needs.
+excerpt: How to add funds to your DNSimple digital wallet.
+meta: Add funds to your DNSimple digital wallet by card or wire transfer. Enterprise customers use wallet balance for domain and certificate purchases.
 categories:
 - Account
 - Enterprise
@@ -16,50 +16,62 @@ categories:
 
 ---
 
-[Enterprise customers](https://dnsimple.com/sales) can add funds to a digital wallet for use on future purchases, like domain registrations, domain renewals, domain transfers, and SSL certificates. We support ACH, wire transfer, and card payments to add funds to your digital wallet.
+[Enterprise customers](https://dnsimple.com/sales) can add funds to a digital wallet for future purchases, such as domain registrations, domain renewals, domain transfers, and SSL certificates. DNSimple supports ACH, wire transfer, and card payments to add funds to your digital wallet.
 
 > [!NOTE]
 > Automatic wallet replenishments are not yet available. You need to manually add funds to your wallet.
 
-## Adding funds to your wallet
-1. From the account switcher, select the account you want to update the payment information for. This takes you to the domain list for the account.
-1. Select **Account settings** from the account switcher at the top-right corner of the screen.
-1. Select the **Billing and plans** tab on the left side.
-1. In the **Wallet** card, click **Add funds**.
+## Adding funds to your wallet {#adding-funds-to-your-wallet}
+
+<div class="section-steps" markdown="1">
+##### To add funds to your digital wallet
+
+1. From the account switcher, select the account you want to fund. This takes you to the domain list for that account.
+1. Open <label>account settings</label> from the account switcher at the top-right corner of the screen.
+1. Select the <label>Billing and plans</label> tab on the left side.
+1. On the <label>Wallet</label> card, click <label>Add funds</label>.
 
     ![Wallet card](/files/wallet-card.png)
 
 1. Fill in the replenishment amount, an optional purchase order ID, and a payment method (credit card or wire).
-1. Click **Proceed to confirmation**.
+1. Click <label>Proceed to confirmation</label>.
 
     ![Add funds form](/files/add-funds-form.png)
 
-1. Verify the details, then click **Add funds**.
+1. Verify the details, then click <label>Add funds</label>.
 
     ![Add funds confirm](/files/add-funds-confirm.png)
 
-1. The funds are immediately added to your digital wallet, and you will receive a corresponding invoice.
+</div>
 
-### Payments by card
+The funds are added to your digital wallet immediately, and you will receive a corresponding invoice.
+
+### Payments by card {#payments-by-card}
+
 Your card on file will be charged. You cannot currently add an alternate card for wallet replenishments.
 
-### Payments by wire
-All wire payments must be paid 30 days after receiving the invoice. To discuss different payment terms, please contact your account manager.
+### Payments by wire {#payments-by-wire}
 
-## Replenishment budget
+All wire payments must be paid within 30 days after receiving the invoice. To discuss different payment terms, contact your account manager.
+
+## Replenishment budget {#replenishment-budget}
+
 You can configure a monthly limit for wallet replenishment.
 
-This limit cannot be exceeded. Once the limit is reached, all subsequent wallet replenishments will be denied. The cumulative total of replenishments is tracked throughout the month. At the start of each new month, this total resets, making the full budget allocation available again.
+This limit cannot be exceeded. Once the limit is reached, all subsequent wallet replenishments are denied. The cumulative total of replenishments is tracked throughout the month. At the start of each new month, this total resets and the full budget allocation is available again.
 
-To set up a replenishment budget, please get in touch with your account manager.
+To set up a replenishment budget, contact your account manager.
 
-## Low balance alerts
-We proactively monitor your wallet balance and send automatic notifications when it falls below a predetermined threshold. This gives you time to add funds before running out, ensuring continual availability of funds.
+## Low balance alerts {#low-balance-alerts}
 
-Please contact your account manager to customize your low balance alerts.
+DNSimple monitors your wallet balance and sends automatic notifications when it falls below a predetermined threshold. This gives you time to add funds before running out.
 
-## Custom email
-All wallet replenishment notifications are automatically sent to the billing email address on your account. If you'd like these notifications to go to additional email addresses, please contact your account manager.
+Contact your account manager to customize your low balance alerts.
+
+## Custom email {#custom-email}
+
+All wallet replenishment notifications are sent to the billing email address on your account. To send these notifications to additional email addresses, contact your account manager.
 
 ## Have more questions?
-If you have any questions about wallet replenishment, [contact us](https://dnsimple.com/feedback), and we'll be happy to help.
+
+If you have questions about wallet replenishment, [contact support](https://dnsimple.com/feedback), and we will be happy to help.


### PR DESCRIPTION
## Summary

Rules and accuracy pass for six Account billing How-to articles (PR 2 of 4 for the How-to bundle).

- **Reactivate Your Subscription:** states reactivation creates a new subscription; domains, records, and account history remain
- **Billing Settings:** billing email vs notification email clarity
- Structure pass on all six: TOC, anchors, section-steps, standard closing

Part of dnsimple/dnsimple-customer-success#217.

## Test plan

- [x] Preview on Netlify deploy
- [x] Verify H1 matches frontmatter `title` on all six articles
- [x] Confirm reactivate-subscription note about new subscription is accurate
- [x] Check internal links resolve