### PR TITLE
Clarify that DNSSEC is not supported on zone cuts

### DIFF
--- a/content/articles/add-ns-records-for-subdomain.md
+++ b/content/articles/add-ns-records-for-subdomain.md
@@ -17,6 +17,8 @@ categories:
 
 Use this guide when DNSimple hosts DNS for your domain and you want a **subdomain** (for example `blog.example.com`) to be answered by **different** authoritative name servers. You add [NS records](/articles/ns-record/) in the DNSimple record editor for that subdomain. For field names in the editor, see [How To Add Common DNS Records](/articles/how-to-add-dns-records/).
 
+Subdomain delegation covers standard DNS resolution only. Publishing [DS records](/articles/what-are-ds-records/) for the delegated subdomain (a zone cut) is not supported, so the subdomain is not covered by a [DNSSEC chain of trust](/articles/dnssec-chain-of-trust/), even if the provider hosting the subdomain signs its zone. For feature compatibility details, see [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/).
+
 ## Confirm the domain uses DNSimple for DNS {#confirm-the-domain-uses-dnsimple-for-dns}
 
 Before you add NS records, the parent domain must be delegated to DNSimple. If the domain is registered with DNSimple, follow [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/). If the domain is registered elsewhere but uses DNSimple for DNS, follow [Delegating a Domain registered with another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/). If you are unsure which path applies, start from [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/).

--- a/content/articles/add-ns-records-for-subdomain.md
+++ b/content/articles/add-ns-records-for-subdomain.md
@@ -17,7 +17,7 @@ categories:
 
 Use this guide when DNSimple hosts DNS for your domain and you want a **subdomain** (for example `blog.example.com`) to be answered by **different** authoritative name servers. You add [NS records](/articles/ns-record/) in the DNSimple record editor for that subdomain. For field names in the editor, see [How To Add Common DNS Records](/articles/how-to-add-dns-records/).
 
-Subdomain delegation covers standard DNS resolution only. Publishing [DS records](/articles/what-are-ds-records/) for the delegated subdomain (a zone cut) is not supported, so the subdomain is not covered by a [DNSSEC chain of trust](/articles/dnssec-chain-of-trust/), even if the provider hosting the subdomain signs its zone. For feature compatibility details, see [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/).
+Subdomain delegation covers standard DNS resolution only. Publishing [DS records](/articles/what-are-ds-records/) for the delegated subdomain (a zone cut) is not supported in DNSimple, so the subdomain is not covered by a [DNSSEC chain of trust](/articles/dnssec-chain-of-trust/), even if the provider hosting the subdomain signs its zone. For feature compatibility details, see [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/).
 
 ## Confirm the domain uses DNSimple for DNS {#confirm-the-domain-uses-dnsimple-for-dns}
 

--- a/content/articles/dnssec-compatibility.md
+++ b/content/articles/dnssec-compatibility.md
@@ -19,6 +19,7 @@ Not all DNSimple features are compatible with DNSSEC. The following table summar
 | [Email forwarding](/articles/email-forwarding/) | Yes | Email forwarding adds standard MX and TXT records, which are signed normally by DNSSEC. |
 | [Control Plane](/articles/integrated-dns-providers/) | No | Multi-signer DNSSEC ([RFC 8901](https://www.rfc-editor.org/rfc/rfc8901.html)) is not supported by the current integrated providers, as they do not allow importing external keys into their DNSKEY RRset. DNSSEC record types are not synced between DNSimple and the external provider, and DNSSEC must be configured directly with each provider. |
 | [Reverse DNS](/articles/reverse-dns/) | No | Reverse DNS zones do not currently support DNSSEC. |
+| [Subdomain delegation (zone cuts)](/articles/add-ns-records-for-subdomain/) | No | DS records cannot be published for a subdomain delegated with NS records, so the DNSSEC chain of trust cannot extend across a zone cut to the name servers hosting the subdomain. |
 
 ## Have more questions?
 

--- a/content/articles/dnssec-glossary.md
+++ b/content/articles/dnssec-glossary.md
@@ -40,6 +40,14 @@ A DNSSEC Trust Anchor is a known, securely distributed public key that resolvers
 [The Trust Anchor (The Root of Trust)](/articles/dnssec-chain-of-trust/#how-the-chain-of-trust-works)
 [IANA Trust Anchors](https://www.iana.org/dnssec/files)
 
+### Zone Cut
+A zone cut is the boundary between a parent zone and a child zone in the DNS hierarchy. It is created when the parent zone delegates a subdomain to a different set of authoritative name servers by publishing NS records for it. In DNSSEC, the chain of trust only crosses a zone cut when the parent zone also publishes a DS record for the child zone. DNSimple does not support publishing DS records for zone cuts, so DNSSEC validation cannot extend to subdomains delegated away from a DNSimple-hosted zone.
+
+**Learn more:**
+[RFC 9499 §7](https://datatracker.ietf.org/doc/html/rfc9499#section-7)
+[Adding NS Records for a Subdomain](/articles/add-ns-records-for-subdomain/)
+[DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/)
+
 ## Record Types & Signing {#record-types-signing}
 
 ### RRSet

--- a/content/articles/dnssec-management-in-dnsimple.md
+++ b/content/articles/dnssec-management-in-dnsimple.md
@@ -26,6 +26,8 @@ categories:
 
 ### Add DS Record For Domain Not Delegated to DNSimple
 
+DS records are added for the registered domain only. Adding DS records for a delegated subdomain (a zone cut) is not supported. See [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/).
+
 ![Add DS Record button](/files/DNSSEC-DS-record-add-button-reference.png)
 
 1. **Add DS Record button** - Add a DS record.

--- a/content/articles/enabling-dnssec.md
+++ b/content/articles/enabling-dnssec.md
@@ -17,7 +17,7 @@ If you are new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/
 
 - The DNS resolution service must be enabled for your zone.
 - DNSimple as Secondary DNS cannot be enabled on the zone. You can read more about it in our [Why DNSSEC and Secondary DNS May Not Work Together](/articles/dnssec-and-secondary-dns/).
-- DNSSEC is applied to the whole zone at the domain apex. DS records for [subdomains delegated with NS records](/articles/add-ns-records-for-subdomain/) (zone cuts) are not supported. See [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/).
+- DNSSEC is applied to the whole zone, with signing keys published at the domain apex. DS records for [subdomains delegated with NS records](/articles/add-ns-records-for-subdomain/) (zone cuts) are not supported. See [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/).
 
 ## Enable DNSSEC
 1. Use the **account switcher** at the top of the page to select the appropriate account.

--- a/content/articles/enabling-dnssec.md
+++ b/content/articles/enabling-dnssec.md
@@ -17,6 +17,7 @@ If you are new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/
 
 - The DNS resolution service must be enabled for your zone.
 - DNSimple as Secondary DNS cannot be enabled on the zone. You can read more about it in our [Why DNSSEC and Secondary DNS May Not Work Together](/articles/dnssec-and-secondary-dns/).
+- DNSSEC is applied to the whole zone at the domain apex. DS records for [subdomains delegated with NS records](/articles/add-ns-records-for-subdomain/) (zone cuts) are not supported. See [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/).
 
 ## Enable DNSSEC
 1. Use the **account switcher** at the top of the page to select the appropriate account.

--- a/content/articles/manage-ds-record.md
+++ b/content/articles/manage-ds-record.md
@@ -14,7 +14,7 @@ categories:
 
 ---
 
-DS (Delegation Signer) records are used in [DNSSEC](/articles/dnssec/) to secure your domain. You would need to manage them if you are not delegating your domain to DNSimple, and you want to use DNSSEC with your DNS provider.
+DS (Delegation Signer) records are used in [DNSSEC](/articles/dnssec/) to secure your domain. You would need to manage them if you are not delegating your domain to DNSimple, and you want to use DNSSEC with your DNS provider. DS records in DNSimple are managed at the domain level: they apply to the registered domain and are published at the registry in the TLD zone. Adding DS records for a subdomain delegated with [NS records](/articles/add-ns-records-for-subdomain/) (a zone cut) is not supported, so the [chain of trust](/articles/dnssec-chain-of-trust/) cannot extend to a delegated subdomain.
 
 ## Adding a DS record {#adding-a-ds-record}
 

--- a/content/articles/manage-ds-record.md
+++ b/content/articles/manage-ds-record.md
@@ -14,7 +14,7 @@ categories:
 
 ---
 
-DS (Delegation Signer) records are used in [DNSSEC](/articles/dnssec/) to secure your domain. You would need to manage them if you are not delegating your domain to DNSimple, and you want to use DNSSEC with your DNS provider. DS records in DNSimple are managed at the domain level: they apply to the registered domain and are published at the registry in the TLD zone. Adding DS records for a subdomain delegated with [NS records](/articles/add-ns-records-for-subdomain/) (a zone cut) is not supported, so the [chain of trust](/articles/dnssec-chain-of-trust/) cannot extend to a delegated subdomain.
+DS (Delegation Signer) records are used in [DNSSEC](/articles/dnssec/) to secure your domain. You would need to manage them if you are not delegating your domain to DNSimple, and you want to use DNSSEC with your DNS provider. DS records in DNSimple are managed at the domain level: they apply to the registered domain and are published at the registry in the parent zone. Adding DS records for a subdomain delegated with [NS records](/articles/add-ns-records-for-subdomain/) (a zone cut) is not supported, so the [chain of trust](/articles/dnssec-chain-of-trust/) cannot extend to a delegated subdomain.
 
 ## Adding a DS record {#adding-a-ds-record}
 


### PR DESCRIPTION
## Summary

A recent support request revealed that customers can infer from our docs that DS records can be added for delegated subdomains (zone cuts), which is not supported. This PR states the limitation explicitly across the DNSSEC articles, as plain scope statements in the intro paragraphs and section bodies where both readers and AI answer engines look first.

## Changes

- `manage-ds-record.md`: intro now defines DS record scope (registered domain only, published at the registry in the TLD zone; zone cuts not supported)
- `add-ns-records-for-subdomain.md`: intro states subdomain delegation covers standard DNS resolution only, and DS records for the delegated subdomain are not supported
- `enabling-dnssec.md`: new prerequisites bullet stating DNSSEC applies to the whole zone at the apex
- `dnssec-management-in-dnsimple.md`: scope sentence in the Add DS Record reference section
- `dnssec-compatibility.md`: new "Subdomain delegation (zone cuts)" row in the compatibility table
- `dnssec-glossary.md`: new "Zone Cut" entry under Core Concepts, cross-linked to the subdomain delegation and compatibility articles