### PR TITLE
Add AI content policy rule and correct GEO framing

### DIFF
--- a/.cursor/rules/ai-content-policy.mdc
+++ b/.cursor/rules/ai-content-policy.mdc
@@ -1,0 +1,39 @@
+---
+description: Rules for publishing AI-drafted support articles, and the AI-optimization tactics Google says are unnecessary.
+globs: content/articles/**/*.md
+alwaysApply: false
+---
+
+# AI-Drafted Content
+
+AI assistance in drafting is expected and allowed. Publishing AI output as-is is not.
+
+Google's position is that generative AI is fine for research and structuring original work, but generating pages without adding value for users can violate the spam policy on scaled content abuse. The test Google applies is whether content shows "little to no effort, little to no originality, and little to no added value."
+
+## Before opening a PR on an AI-drafted article
+
+1. Verify every product claim, price, limit, and syntax example against the app, the developer docs, or an SME. Never publish product behavior asserted from model memory.
+2. Do not generate batches of articles to cover keyword variations. One article per real user job.
+3. If the article does not contain at least one thing that required access to DNSimple to know, it probably should not be published.
+
+Rule 3 is the working test for "added value." An article that any model could produce without our systems, our support history, or our SMEs is a summary of the internet, not a support article. Add the DNSimple-specific behavior, the verified specifics, and the first-hand support experience, or drop the article.
+
+## Disclosure
+
+DNSimple does not add AI-disclosure banners to support articles. Google treats disclosure as optional context, not a requirement, and a banner adds nothing for a reader looking up how to add a CAA record. Accuracy is the obligation, not attribution.
+
+# Tactics You Do Not Need
+
+Google has explicitly stated the following are unnecessary for appearing in AI Overviews and other generative AI features. Do not spend effort on them, and do not act on outside advice recommending them without checking here first.
+
+- **No `llms.txt` or AI-specific files.** Google: "You don't need to create new machine readable files, AI text files, markup, or Markdown." This repo has no `llms.txt` and should not gain one.
+- **No content chunking.** There is no requirement to fragment articles into small pieces for retrieval.
+- **No synonym rewriting.** Google handles synonyms. Do not force keyword variations into the text.
+- **No citation or mention chasing.** Seeking mentions of DNSimple across other sites to influence AI answers does not work.
+- **Structured data is not required.** It supports rich results and is worth having for that reason, but it is not required for generative AI search.
+
+## What does matter technically
+
+Pages must stay indexed and snippet-eligible. A page excluded from snippets is excluded from AI features, so never add `nosnippet`, `data-nosnippet`, or a restrictive `max-snippet` to article content without a deliberate reason. Beyond that, the existing crawlability, semantic HTML, and page experience practices already in place are the whole requirement.
+
+Measure visibility through the Search Console generative AI performance report. Third-party tools claiming access to internal Google AI metrics do not have it.

--- a/.cursor/rules/article-structure.mdc
+++ b/.cursor/rules/article-structure.mdc
@@ -154,6 +154,8 @@ Place in `/files/` and use descriptive alt text:
 
 Articles should be optimized for both traditional search engines and AI answer engines (ChatGPT, Perplexity, Google AI Overviews). These two goals mostly reinforce each other.
 
+Google's guidance is that generative AI features run on its core Search ranking systems, so "you don't need to write in a specific way just for generative AI search." Read the rest of this section as writing advice that happens to serve both audiences, not as writing for the machine. Anything below that would make an article worse for a human reader is being applied wrong. See `.cursor/rules/ai-content-policy.mdc` for the tactics Google says are unnecessary, and for the rules on publishing AI-drafted articles.
+
 ### Opening paragraph as extractable answer
 
 The first 1–3 sentences after the H1 should directly answer the core question the article addresses. AI engines use this as their primary citation source. Keep it under 80 words.
@@ -169,7 +171,7 @@ Each H2 section should be self-contained enough that an AI engine could extract 
 
 ### Specific claims over vague statements
 
-AI engines prefer content with concrete, citable facts. Include specifics wherever possible.
+Concrete, citable facts make an article more useful to a reader and more quotable by an answer engine. Include specifics wherever possible, and verify them before publishing.
 
 - Good: "Sectigo certificates are valid for a maximum of 200 days."
 - Bad: "Sectigo certificates have a limited validity period."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Most AI-assisted work on this project is writing and editing support articles. T
 
 - **`.cursor/rules/article-writing.mdc`** — Voice, tone, anti-patterns, cross-linking, review checklist
 - **`.cursor/rules/article-structure.mdc`** — Frontmatter, page skeleton, callouts, links, SEO/GEO, Diataxis types
+- **`.cursor/rules/ai-content-policy.mdc`** — Publishing rules for AI-drafted articles, and the AI-optimization tactics Google says are unnecessary
 - **`.cursor/rules/git-workflow.mdc`** — Interactive checkpoints (branch, commit, PR), filename/character rules, PR hygiene
 
 Follow these rules when working on any file in `content/articles/`. They cover everything from sentence-level writing style to when you must stop and ask the user before proceeding.
@@ -22,7 +23,8 @@ Follow these rules when working on any file in `content/articles/`. They cover e
 
 - All articles follow **APA Style** and the **Diataxis framework**
 - Cross-link related articles automatically — both from the new article and back from existing articles
-- Optimize for both SEO and GEO (AI answer engines)
+- Optimize for both SEO and GEO (AI answer engines), but never in ways that make the article worse for a human reader
+- AI may draft; AI output is never published as-is. Verify every product claim before opening a PR
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for the full content writing guidelines, PR review process, and category management
 
 ## Project Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 @AGENTS.md
 @.cursor/rules/article-writing.mdc
 @.cursor/rules/article-structure.mdc
+@.cursor/rules/ai-content-policy.mdc
 @.cursor/rules/git-workflow.mdc


### PR DESCRIPTION
## Summary

Adds a rules file covering two things Google documents but our rules did not, and corrects one piece of framing in the existing GEO guidance.

**Publishing rules for AI-drafted articles.** AI may draft; AI output is never published as-is. Google's spam policy on scaled content abuse targets content showing "little to no effort, little to no originality, and little to no added value," so the new rule requires verifying every product claim before a PR, forbids generating batches of articles for keyword variations, and sets a working test for added value: if the article contains nothing that required access to DNSimple to know, it should not be published. It also records that we do not add AI-disclosure banners, since Google treats disclosure as optional context rather than a requirement.

**The tactics Google says are unnecessary.** No `llms.txt` or other AI-specific files, no content chunking, no synonym rewriting, no citation chasing, and structured data is not required for generative AI search. This half is meant to save work and to give us something to point at when outside GEO advice recommends these. It also records the one thing that does matter technically: pages must stay snippet-eligible, because a page excluded from snippets is excluded from AI features.

**GEO framing correction.** The SEO/GEO section in `article-structure.mdc` framed its advice as writing for AI engines, and one line asserted that "AI engines prefer content with concrete, citable facts" as fact. Google's actual position is that generative AI features run on core Search ranking, so "you don't need to write in a specific way just for generative AI search." The advice all stays; the framing now points at the reader, which is also the guard against drifting into the scaled-content territory the first half of this PR warns about.

Sources:

- https://developers.google.com/search/docs/fundamentals/using-gen-ai-content
- https://developers.google.com/search/docs/fundamentals/ai-optimization-guide

## Files changed

- `.cursor/rules/ai-content-policy.mdc` (new) - both halves of the policy
- `.cursor/rules/article-structure.mdc` - GEO section reframed, pointer to the new rule
- `AGENTS.md` - lists the new rule file, two lines added to key content principles
- `CLAUDE.md` - `@`-includes the new rule so Claude Code loads it alongside the other three

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] No smart/curly quotes or special characters from macOS
- [x] N/A - no articles in this PR (frontmatter, opening paragraph, cross-links, callouts, `rake run`)

## Review

Agent rules rather than customer-facing content, so the usual SME and Customer Success tagging may not apply. Worth a look from anyone who writes articles with AI assistance, since this sets the bar for what ships.