### PR TITLE
Isolate the support widget in a shadow root

### DIFF
--- a/_widget/src/components/app/component.vue
+++ b/_widget/src/components/app/component.vue
@@ -24,11 +24,6 @@ import Articles from '../articles/component.vue';
 import Prompt from '../prompt/component.vue';
 import Search from './search.js';
 
-import "./variables.scss";
-import "./reset.scss";
-import "./style.scss";
-import "./animate.scss";
-
 const RECENTLY_VISITED_KEY = "recentlyVisitedUrls";
 const RECENTLY_VISITED_LIMIT = 6;
 
@@ -155,7 +150,10 @@ export default {
 
       if (isHash) {
         event.preventDefault();
-        document.getElementById(url.split('#')[1])?.scrollIntoView();
+        // The anchor is the widget's own, and the widget lives in a shadow
+        // root, so it is not in the document. getElementById exists on the
+        // shadow root; the optional call tolerates a detached mount in tests.
+        this.$el.getRootNode().getElementById?.(url.split('#')[1])?.scrollIntoView();
         return;
       }
 
@@ -311,7 +309,7 @@ export default {
 
     scrollToSelectedItem() {
       nextTick(() => {
-        const selectedDiv = document.querySelector('.selected-article');
+        const selectedDiv = this.$el.getRootNode().querySelector('.selected-article');
         selectedDiv && selectedDiv.scrollIntoView({ behavior: 'instant', block: 'nearest' });
       });
     },

--- a/_widget/src/components/app/reset.scss
+++ b/_widget/src/components/app/reset.scss
@@ -3,7 +3,9 @@ v2.0 | 20110126
 License: none (public domain)
 */
 
-#dnsimple-support-widget {
+// The shadow root keeps the host page's selectors out, but not the browser's
+// own stylesheet, so this still has to normalise the UA defaults.
+:host {
   box-sizing: border-box;
 
   div, span, applet, object, iframe,

--- a/_widget/src/components/app/style.scss
+++ b/_widget/src/components/app/style.scss
@@ -1,4 +1,6 @@
-#dnsimple-support-widget {
+// The mount element itself. From inside the shadow root the host's own id is
+// not matchable, so this cannot go back to `#dnsimple-support-widget`.
+:host {
   position: fixed;
   z-index: 999;
   bottom: 0;

--- a/_widget/src/components/app/variables.scss
+++ b/_widget/src/components/app/variables.scss
@@ -1,4 +1,5 @@
-#dnsimple-support-widget {
+// On :host, so the tokens inherit down into the shadow tree.
+:host {
   --dnsimple-support-widget-medium-gray: #7e7e7e;
   --dnsimple-support-widget-yellow: #f8c939;
   --dnsimple-support-widget-orange: #ff7f2a;

--- a/_widget/src/components/article/component.vue
+++ b/_widget/src/components/article/component.vue
@@ -18,11 +18,6 @@
 import { backIcon, externalLink, trustyIcon } from '../../assets/svgs';
 import Footer from '../footer/component.vue';
 
-import "./style.scss";
-import "./resolving.scss";
-import "./syntax.scss";
-import "./tables.scss";
-
 const NO_TRAILING_SLASH = /\/?$/;
 
 export default {

--- a/_widget/src/components/articles/component.vue
+++ b/_widget/src/components/articles/component.vue
@@ -80,8 +80,6 @@
 import Footer from '../footer/component.vue';
 import { spinnerIcon, externalLink, trustyIcon } from '../../assets/svgs';
 
-import "./style.scss";
-
 export default {
   props: {
     app: Object,

--- a/_widget/src/components/footer/component.vue
+++ b/_widget/src/components/footer/component.vue
@@ -15,8 +15,6 @@
 </template>
 
 <script>
-import "./style.scss";
-
 export default {
   props: ['app']
 };

--- a/_widget/src/components/header/component.vue
+++ b/_widget/src/components/header/component.vue
@@ -15,8 +15,6 @@
 <script>
 import { minimizeIcon } from '../../assets/svgs';
 
-import "./style.scss";
-
 export default {
   props: ['app'],
   data () {

--- a/_widget/src/components/prompt/component.vue
+++ b/_widget/src/components/prompt/component.vue
@@ -10,8 +10,6 @@
 <script>
 import { trustyIcon } from '../../assets/svgs';
 
-import "./style.scss";
-
 export default {
   props: ['app'],
   data () {

--- a/_widget/src/initialize.js
+++ b/_widget/src/initialize.js
@@ -1,17 +1,42 @@
 import { createApp } from 'vue';
 import App from './components/app/component.vue';
+import styles from './styles.scss?inline';
+
+// Puts the widget's CSS in its own shadow root rather than the host's <head>.
+// adoptedStyleSheets where it exists, a <style> inside the root otherwise.
+const adoptStyles = (root, doc) => {
+  if ('adoptedStyleSheets' in Document.prototype && 'replaceSync' in CSSStyleSheet.prototype) {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(styles);
+    root.adoptedStyleSheets = [sheet];
+    return;
+  }
+
+  const $style = doc.createElement('style');
+  $style.textContent = styles;
+  root.appendChild($style);
+};
 
 export default (doc, options = {}) => {
   const elementId = 'dnsimple-support-widget';
   const $openers = [...doc.querySelectorAll('[data-dnsimple-open-support-widget]')];
 
-  let $target = doc.querySelector(`#${elementId}`);
+  let $host = doc.querySelector(`#${elementId}`);
 
-  if (!$target) {
-    $target = doc.createElement('div');
-    $target.id = elementId;
-    doc.body.insertBefore($target, doc.body.firstChild);
+  if (!$host) {
+    $host = doc.createElement('div');
+    $host.id = elementId;
+    doc.body.insertBefore($host, doc.body.firstChild);
   }
+
+  // The widget is embedded in sites we do not control, and its markup and CSS
+  // are no business of theirs. A shadow root is the isolation: nothing here
+  // matches their selectors, and nothing of theirs matches ours.
+  const root = $host.shadowRoot || $host.attachShadow({ mode: 'open' });
+  adoptStyles(root, doc);
+
+  const $mount = doc.createElement('div');
+  root.appendChild($mount);
 
   const sourcesAttr = doc.querySelector('[data-dnsimple-sources]')?.getAttribute('data-dnsimple-sources');
   const sources = sourcesAttr ? JSON.parse(sourcesAttr) : undefined;
@@ -21,7 +46,7 @@ export default (doc, options = {}) => {
     currentSiteUrl: doc.querySelector('[data-dnsimple-current-site-url]')?.getAttribute('data-dnsimple-current-site-url') || '',
     gettingStartedUrl: doc.querySelector('[data-dnsimple-getting-started-url]')?.getAttribute('data-dnsimple-getting-started-url') || '/articles/getting-started/',
     ...(sources && { sources }),
-  }, options)).mount($target);
+  }, options)).mount($mount);
 
   $openers.forEach(($el) => {
     $el.addEventListener('click', () => {

--- a/_widget/src/styles.scss
+++ b/_widget/src/styles.scss
@@ -1,0 +1,24 @@
+// Every stylesheet the widget ships, in one place.
+//
+// initialize.js imports this with `?inline` and puts the result in the widget's
+// shadow root. Nothing here reaches the host page, which is the point: the
+// widget is injected into other sites and used to append its CSS to their
+// <head>, so a bare selector here landed on their pages.
+//
+// The order is the one the module graph used to produce, back when each
+// component imported its own stylesheet: components first, then app, whose
+// rules are meant to win. Keep it that way. `article/style` pulls in the
+// support site's callouts, which is why they land where they do.
+
+@use "./components/footer/style" as footer;
+@use "./components/header/style" as header;
+@use "./components/article/style" as article;
+@use "./components/article/resolving" as article-resolving;
+@use "./components/article/syntax" as article-syntax;
+@use "./components/article/tables" as article-tables;
+@use "./components/articles/style" as articles;
+@use "./components/prompt/style" as prompt;
+@use "./components/app/variables" as app-variables;
+@use "./components/app/reset" as app-reset;
+@use "./components/app/style" as app-style;
+@use "./components/app/animate" as app-animate;

--- a/_widget/vite.config.js
+++ b/_widget/vite.config.js
@@ -1,10 +1,12 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
-import includeCss from 'vite-plugin-css-injected-by-js';
 
+// No CSS-injection plugin: the widget owns a shadow root now, and initialize.js
+// imports the styles with `?inline` and adopts them into it, so nothing reaches
+// the host page's <head>. See _widget/src/initialize.js.
 export default defineConfig(({ command }) => ({
-  plugins: [vue(), includeCss()],
+  plugins: [vue()],
   resolve: {
     alias: {
       vue: command === 'build'

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ export default {
   testEnvironmentOptions: {
     customExportConditions: ["node", "node-addons"],
   },
+  setupFilesAfterEnv: ['<rootDir>/spec/utils/setup.js'],
   transform: {
     '.*\\.(js)$': 'babel-jest',
     '.*\\.(vue)$': '@vue/vue3-jest',
@@ -13,6 +14,7 @@ export default {
   moduleFileExtensions: ['js', 'vue', 'yml'],
   moduleDirectories: ['node_modules'],
   moduleNameMapper: {
+    '\\.(css|less|sass|scss)\\?inline$': '<rootDir>/spec/utils/inlineStyleMock.js',
     '\\.(css|less|sass|scss)$': '<rootDir>/spec/utils/styleMock.js',
     '^(.+\\.yml)\\?raw$': '$1'
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "sass-embedded": "^1.100.0",
     "tachyons": "^4.12.0",
     "vite": "^8.1.0",
-    "vite-plugin-css-injected-by-js": "^5.0.1",
     "vue-eslint-parser": "^10.4.1",
     "webpack": "^5.108.3",
     "webpack-cli": "^7.2.1"

--- a/spec/_widget/components/initialize.spec.js
+++ b/spec/_widget/components/initialize.spec.js
@@ -6,6 +6,11 @@ describe('Initialize', () => {
   let goExternal;
   let fetch;
 
+  // The widget lives in a shadow root now, so its markup is not in
+  // document.body.innerHTML. Read it, and query it, through the root.
+  const root = () => document.querySelector('#dnsimple-support-widget').shadowRoot;
+  const widgetHtml = () => root().innerHTML;
+
   beforeEach(() => {
     goExternal = jest.fn();
     fetch = jest.fn(() => Promise.resolve(ARTICLES));
@@ -16,7 +21,7 @@ describe('Initialize', () => {
       document.body.innerHTML = `<div id="dnsimple-support-widget"></div>`;
       subject = initialize(document);
 
-      expect(document.body.innerHTML).toContain('Need Help?');
+      expect(widgetHtml()).toContain('Need Help?');
     });
   });
 
@@ -25,8 +30,16 @@ describe('Initialize', () => {
       document.body.innerHTML = ``;
       subject = initialize(document);
 
-      expect(document.body.innerHTML).toContain('Need Help?');
+      expect(widgetHtml()).toContain('Need Help?');
     });
+  });
+
+  it('keeps its markup out of the host document', () => {
+    document.body.innerHTML = ``;
+    subject = initialize(document);
+
+    expect(document.body.innerHTML).not.toContain('Need Help?');
+    expect(document.querySelector('#dnsimple-support-widget').shadowRoot).not.toBeNull();
   });
 
   it('sets the current site url', () => {
@@ -59,7 +72,7 @@ describe('Initialize', () => {
     it('opens when clicking on the openers', async () => {
       await document.body.querySelector('[data-dnsimple-open-support-widget]').click();
 
-      expect(document.body.innerHTML).toContain('Try some keywords');
+      expect(widgetHtml()).toContain('Try some keywords');
     });
   });
 
@@ -73,9 +86,9 @@ describe('Initialize', () => {
     });
 
     it('opens when clicking on the default opener', async () => {
-      await document.body.querySelector('[aria-label="Open widget"]').click();
+      await root().querySelector('[aria-label="Open widget"]').click();
 
-      expect(document.body.innerHTML).toContain('Try some keywords');
+      expect(widgetHtml()).toContain('Try some keywords');
     });
   });
 });

--- a/spec/utils/inlineStyleMock.js
+++ b/spec/utils/inlineStyleMock.js
@@ -1,0 +1,3 @@
+// Mocks a Vite `?inline` stylesheet import: the real one returns the compiled
+// CSS as a string, so the stub returns an empty string rather than an object.
+module.exports = '';

--- a/spec/utils/setup.js
+++ b/spec/utils/setup.js
@@ -1,0 +1,5 @@
+// jsdom does not implement scrollIntoView. The widget calls it to bring the
+// selected article into view; in a real browser it works, in jsdom it is a
+// no-op stub so the code under test can run.
+if (!Element.prototype.scrollIntoView)
+  Element.prototype.scrollIntoView = () => {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,11 +5125,6 @@ varint@^6.0.0:
   resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
   integrity sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==
 
-vite-plugin-css-injected-by-js@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-5.0.1.tgz#d123b68e4d15e5a7835d01cd64bf795f8e7d6d5a"
-  integrity sha512-JSB0jjN4VCKqG7XTUdrwiIl5gA+z2yi/tAl9WHo0X4sdyJ1yrmbLOEjf95TDoDIIuKr4GJIc7lMJG0CT88eEUQ==
-
 vite@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/vite/-/vite-8.1.0.tgz#0734dc1a48faeb2bd5f5b16b66dcbfae484fec55"


### PR DESCRIPTION
The support widget is injected into other DNSimple sites, and its CSS was appended to their `<head>` by `vite-plugin-css-injected-by-js`. Every bare selector the widget ships then applied to the host page. On dnsimple.com the app's own `.callout` component picked up the widget's unrelated `.callout` rules and rendered with a stray black left border and a grey wash.

This isolates the widget in a **shadow root** so the boundary is structural rather than a naming convention the next rule can forget. Nothing the widget ships reaches the host page, and nothing the host ships reaches the widget, permanently.

**No change to the support site itself**, its own callouts and pages render identically.
