### PR TITLE
Stop the support widget leaking callout styles onto host pages

### DIFF
--- a/content/assets/css/_callouts.scss
+++ b/content/assets/css/_callouts.scss
@@ -123,6 +123,3 @@
     }
   }
 }
-
-// Include at root level for support site
-@include callout-styles;

--- a/content/assets/css/style.scss
+++ b/content/assets/css/style.scss
@@ -15,3 +15,8 @@
 @use "callouts";
 @import "../../dist/tachyons/css/tachyons.min.css";
 @import "../../dist/fontawesome/css/all.min.css";
+
+// Emit the callout rules site-wide. The mixin is defined without a root-level
+// include so the widget, which also uses it (scoped under its own root), does
+// not carry an unscoped copy into the pages it is embedded on.
+@include callouts.callout-styles;

--- a/spec/_widget/styles/callouts.spec.js
+++ b/spec/_widget/styles/callouts.spec.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+import { resolve } from 'path';
+import { compile, compileString } from 'sass-embedded';
+
+// Callout styles are a shared mixin, deliberately applied both site-wide and
+// inside the widget. The widget's compiled CSS is injected into third-party
+// host pages (dnsimple.com and others), so any selector it emits at the
+// document root lands on those pages. The mixin must therefore stay inert on
+// its own: consumers include it in their own scope, and the widget's copy stays
+// under `#dnsimple-support` so it never reaches the host page.
+describe('callout styles', () => {
+  const cssDir = resolve(__dirname, '../../../content/assets/css');
+
+  // Compile the widget article stylesheet the way the build does: `@use "callouts"`
+  // resolves against content/assets/css via the same load path as vite.config.js.
+  const compileWidget = () => compile(
+    resolve(__dirname, '../../../_widget/src/components/article/style.scss'),
+    { loadPaths: [cssDir] }
+  ).css;
+
+  it('scopes every widget callout rule under the widget root', () => {
+    const css = compileWidget();
+
+    expect(css).toContain('#dnsimple-support .article .callout');
+    // A root-level `.callout {` (column 0) is an unscoped rule that would leak
+    // into the host page when the widget bundle is injected.
+    expect(css).not.toMatch(/^\.callout[\s.,{:]/m);
+  });
+
+  it('emits nothing on its own, so using it never leaks css', () => {
+    const css = compileString('@use "callouts";', { loadPaths: [cssDir] }).css;
+
+    expect(css.trim()).toBe('');
+  });
+
+  it('emits callouts where a consumer includes it, keeping the site styled', () => {
+    const css = compileString(
+      '@use "callouts"; @include callouts.callout-styles;',
+      { loadPaths: [cssDir] }
+    ).css;
+
+    expect(css).toMatch(/^\.callout \{/m);
+    expect(css).toContain('.callout-warning');
+  });
+});


### PR DESCRIPTION
## Summary

The support widget is injected into other DNSimple sites, and `vite-plugin-css-injected-by-js` appends its compiled CSS to the host page's `<head>`. The shared callout mixin (`content/assets/css/_callouts.scss`) carried a root-level `@include callout-styles;` for the support site's own pages. Because the widget's `article/style.scss` does `@use "callouts"`, that root-level include rode along into the widget bundle as an unscoped `.callout` rule — and landed on every host page. On dnsimple.com the app's own `.callout` picked it up and rendered with a stray black left border and grey wash.

This makes the mixin inert on its own: the partial no longer includes itself at root, so `@use`-ing it emits nothing. The support site now includes the mixin explicitly from its manifest (`style.scss`), and the widget keeps its own copy scoped under `#dnsimple-support .article` as before. Both places stay styled; nothing unscoped enters the widget bundle.

## Works in tandem with #2026

#2026 isolates the widget in a shadow root, which *contains* this leak — the unscoped `.callout` gets trapped in the shadow tree and can no longer reach the host page. This PR removes the leak at its *source*, so the widget bundle carries no unscoped rule in the first place. They are complementary, not competing: with both, the CSS is clean by construction and structurally isolated. This PR is worth taking regardless of whether #2026 lands, since it fixes the actual defect rather than relying on containment; if #2026 does not ship, it is the fix on its own.

## Files changed

- `content/assets/css/_callouts.scss` — drop the root-level `@include callout-styles;`, leaving a pure mixin.
- `content/assets/css/style.scss` — include the mixin explicitly so the site keeps its callouts.
- `spec/_widget/styles/callouts.spec.js` — new spec (compiles the real SCSS).

## QA

Spec compiles the widget stylesheet with `sass-embedded` and asserts every `.callout` is scoped under `#dnsimple-support` with no root-level `.callout`; it also pins that `@use "callouts"` emits nothing on its own and that including the mixin at root still emits the site-wide callouts. Verified red before the fix (root-level `.callout` present), green after.
