### PR TITLE
Fix broken images in support search widget

### DIFF
--- a/_widget/src/components/article/component.vue
+++ b/_widget/src/components/article/component.vue
@@ -62,6 +62,15 @@ export default {
       });
     },
 
+    fixImages () {
+      [...this.$el.querySelectorAll('.article img')].forEach((img) => {
+        const src = img.getAttribute('src');
+
+        if (src && src[0] === '/')
+          img.setAttribute('src', `${this.article.sourceUrl}${src}`);
+      });
+    },
+
     fixTables () {
       [...this.$el.querySelectorAll('table')].forEach((table) => {
         const wrapper = document.createElement('div');
@@ -75,6 +84,7 @@ export default {
       this.$nextTick(() => {
         this.$el.scrollTop = 0;
         this.fixLinks();
+        this.fixImages();
         this.fixTables();
       });
     }

--- a/spec/_widget/components/article.spec.js
+++ b/spec/_widget/components/article.spec.js
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import Article from '../../../_widget/src/components/article/component.vue';
+
+const flushNextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('Article', () => {
+  const app = {
+    hasHistory: () => false,
+    back: () => {},
+    getArticleUrl: (article) => `${article.sourceUrl}${article.id}`,
+    visitArticle: jest.fn(),
+  };
+
+  const mountArticle = (body) => mount(Article, {
+    props: {
+      app,
+      article: {
+        id: '/articles/getting-started/',
+        title: 'Getting Started',
+        sourceUrl: 'https://support.dnsimple.com',
+        body,
+      },
+    },
+  });
+
+  it('rewrites root-relative image sources to the article source', async () => {
+    const subject = mountArticle('<img src="/files/getting-started-account-get-started.png" alt="Get Started">');
+    await nextTick();
+    await flushNextTick();
+
+    const img = subject.find('img');
+    expect(img.attributes('src')).toBe('https://support.dnsimple.com/files/getting-started-account-get-started.png');
+  });
+
+  it('leaves absolute image sources untouched', async () => {
+    const subject = mountArticle('<img src="https://cdn.example.com/logo.png" alt="Logo">');
+    await nextTick();
+    await flushNextTick();
+
+    const img = subject.find('img');
+    expect(img.attributes('src')).toBe('https://cdn.example.com/logo.png');
+  });
+
+  it('rewrites root-relative anchor hrefs to the article source', async () => {
+    const subject = mountArticle('<a href="/articles/other/">Other</a>');
+    await nextTick();
+    await flushNextTick();
+
+    const link = subject.find('.article a');
+    expect(link.attributes('href')).toBe('https://support.dnsimple.com/articles/other/');
+  });
+});


### PR DESCRIPTION
## Summary

Images embedded in support articles rendered as broken-image icons in the search widget. The article body is injected with `v-html`, and the article component already rewrites root-relative `<a href="/…">` links to absolute URLs via `fixLinks()`, but images had no equivalent. So `<img src="/files/…">` resolved against the origin of the page *embedding* the widget rather than the support site, and 404'd whenever the widget ran anywhere other than support.dnsimple.com.


## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Fix mirrors the existing `fixLinks()` pattern (root-relative guard + `sourceUrl` prefix)
- [x] Absolute image sources left untouched; existing anchor rewriting unaffected
- [x] Covered by a unit spec (root-relative rewritten, absolute untouched, anchor path still rewritten)
- [x] Lint + JS specs pass (pre-commit hook)

## 👓 QA

On the `<a data-dnsimple-open-support-widget …>` element near the top of the `<body>` on `_widget/index.html`. Currently it reads `data-dnsimple-current-site-url="https://support.dnsimple.com"` — swap the value to `https://dnsimple.com`, save, and reload the dev server (`npm run widget`).

- Open the widget, then open the **Getting Started** article. On `main`, the "Get Started" and "Dashboard with Multiple Accounts" images show as broken icons; on this branch they load, with `src` resolved to `https://support.dnsimple.com/files/…`.

## Verification

- [ ] sandbox: Verify a successful deploy
- [ ] production: Verify a successful deploy

## Deployment PRE/POST tasks

N / A
