### PR TITLE
Fix CI: guard scrollIntoView shim for node-environment specs

### DIFF
--- a/spec/utils/setup.js
+++ b/spec/utils/setup.js
@@ -1,5 +1,7 @@
 // jsdom does not implement scrollIntoView. The widget calls it to bring the
 // selected article into view; in a real browser it works, in jsdom it is a
-// no-op stub so the code under test can run.
-if (!Element.prototype.scrollIntoView)
+// no-op stub so the code under test can run. This file runs for every spec
+// via setupFilesAfterEnv, including ones that opt into the node environment
+// (e.g. `@jest-environment node`), where Element does not exist.
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView)
   Element.prototype.scrollIntoView = () => {};


### PR DESCRIPTION
## Summary

Main CI was red: `spec/_widget/styles/callouts.spec.js` (added in #2027) opts into the `node` test environment since it compiles Sass rather than touching the DOM. `spec/utils/setup.js` runs for every spec via `setupFilesAfterEnv` regardless of that per-file override, and it unconditionally referenced `Element` to install a `scrollIntoView` stub — so the suite failed with `ReferenceError: Element is not defined` instead of running. This guards the reference so it's a no-op outside jsdom.

Ref: https://github.com/dnsimple/dnsimple-support/actions/runs/29750625661/job/88379862057

## Files changed

- `spec/utils/setup.js` — guard the `Element` reference with a `typeof` check

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- N/A — code fix, not a content change (frontmatter/cross-link/callout items don't apply)
- [x] Tested locally: `bundle exec rake compile && yarn test` — 7 suites, 57 tests passing

## Review

- N/A — mechanical test-infra fix