### PR TITLE
Update Account Invoice History for rules consistency

### DIFF
--- a/content/articles/account-invoice-history.md
+++ b/content/articles/account-invoice-history.md
@@ -40,7 +40,7 @@ Invoice filters provide quick, reliable access to invoices for auditing, reconci
 
 ![Enterprise Invoice Filter](/files/enterprise-invoice-filters.png)
 
-## Payment states
+## Payment states {#payment-states}
 
 Your invoices may be in certain states depending on different circumstances:
 
@@ -54,9 +54,9 @@ An invoice in the `collected` state indicates it has been paid.
 
 ### `failed` {#invoice-state-failed}
 
-When you make a [purchase](/articles/understanding-invoice/#purchases), like a domain registration or an SSL certificate, and we're unable to collect the payment, we'll notify the account owner via email. The invoice will be marked as `failed`.
+When you make a [purchase](/articles/understanding-invoice/#purchases), like a domain registration or an SSL certificate, and we are unable to collect the payment, we will notify the account owner via email. The invoice will be marked as `failed`.
 
-While the invoice is in this state, you won't be able to make other purchases. You can [retry the payment](#retrying) yourself, and our systems will also try to collect it every few hours.
+While the invoice is in this state, you will not be able to make other purchases. You can [retry the payment](#retrying) yourself, and our systems will also try to collect it every few hours.
 
 ### `dunned` {#invoice-state-dunned}
 
@@ -87,4 +87,4 @@ While our system occasionally retries failed invoices automatically, you may wan
 
 ## Have more questions?
 
-You can [contact our support team](https://dnsimple.com/feedback) any time with questions about your account invoice history — we're here to help.
+You can [contact our support team](https://dnsimple.com/feedback) any time with questions about your account invoice history, and we're here to help.


### PR DESCRIPTION
## Summary

Consistency and terminology pass on the existing Account Invoice History reference article, to bring it in line with the repo rules. Completes the Reference phase of the #217 Account revamp.

- Removed a banned em-dash (and a hidden non-breaking space) from the closing CTA.
- Expanded two body-text contractions (`we're`/`we'll`/`won't`) to the formal forms the rules require in body text.
- Added an explicit `{#payment-states}` anchor to the Payment states heading.

This PR is independent of the three new Reference article PRs (#2032, #2033, #2034) and is safe to merge in any order.

## Files

- `content/articles/account-invoice-history.md`

## Test plan

- [ ] Preview on Netlify deploy
- [ ] Confirm the `#payment-states` anchor resolves