### PR TITLE
Add .SPORT domain registration support article

### DIFF
--- a/categories/tlds.yaml
+++ b/categories/tlds.yaml
@@ -56,6 +56,7 @@ TLDs:
   - ".PT Domains"
   - ".SE Domains"
   - ".SG Domains"
+  - ".SPORT Domains"
   - ".TIROL Domains"
   - ".UK Domains"
   - ".UZ Domains"

--- a/content/articles/domains-sport.md
+++ b/content/articles/domains-sport.md
@@ -6,7 +6,7 @@ categories:
 - TLDs
 ---
 
-# .SPORT Domain Names
+# .SPORT Domains
 
 * TOC
 {:toc}
@@ -17,7 +17,8 @@ categories:
 
 ## Registering a .SPORT domain {#registering}
 
-.SPORT registrations are non-realtime. When you register a .SPORT domain through DNSimple, your application is forwarded to the .SPORT registry for review.
+.SPORT registrations are non-realtime. This means that the registry reviews .SPORT applications by hand,
+so the domain is not active the moment you order it. When you register a .SPORT domain through DNSimple, your application is forwarded to the .SPORT registry for review.
 
 The registry contacts you with a series of questions about your registration. These questions are accessible through the registry user platform at [cp.nic.sport](https://cp.nic.sport/login), where a ticket is assigned to the applicant.
 
@@ -26,6 +27,7 @@ You must complete these steps before the registry can validate or reject your ap
 <div class="section-steps" markdown="1">
 ##### Complete registry approval in the NIC.SPORT portal
 
+1. When you register the domain, complete the <label>Describe the intended use for the domain name</label> field. State what you plan to use the domain for and what claim you have to the name. If the name matches a trademark, include the trademark number.
 1. After registering your .SPORT domain through DNSimple, watch for contact from the registry about your application.
 1. Log in to the [NIC.SPORT user platform](https://cp.nic.sport/login).
 1. Open the ticket assigned to your application and answer the registry's questions.

--- a/content/articles/domains-sport.md
+++ b/content/articles/domains-sport.md
@@ -1,0 +1,40 @@
+---
+title: .SPORT Domains
+excerpt: This article explains the requirements and special procedures for .SPORT domain names.
+meta: Register .SPORT domains with DNSimple. Registrations require registry approval through the NIC.SPORT portal before the domain can be activated.
+categories:
+- TLDs
+---
+
+# .SPORT Domain Names
+
+* TOC
+{:toc}
+
+---
+
+.SPORT domain registrations require registry approval before they can be completed. After you submit a registration through DNSimple, the registry contacts you with questions you must answer in the NIC.SPORT portal before the application is validated or rejected.
+
+## Registering a .SPORT domain {#registering}
+
+.SPORT registrations are non-realtime. When you register a .SPORT domain through DNSimple, your application is forwarded to the .SPORT registry for review.
+
+The registry contacts you with a series of questions about your registration. These questions are accessible through the registry user platform at [cp.nic.sport](https://cp.nic.sport/login), where a ticket is assigned to the applicant.
+
+You must complete these steps before the registry can validate or reject your application. If no action is taken, the domain remains in a pending state.
+
+<div class="section-steps" markdown="1">
+##### Complete registry approval in the NIC.SPORT portal
+
+1. After registering your .SPORT domain through DNSimple, watch for contact from the registry about your application.
+1. Log in to the [NIC.SPORT user platform](https://cp.nic.sport/login).
+1. Open the ticket assigned to your application and answer the registry's questions.
+1. Submit your responses and wait for the registry to validate or reject the application.
+</div>
+
+> [!NOTE]
+> The domain stays in a pending state until you complete the registry questionnaire in the NIC.SPORT portal. DNSimple cannot complete this step on your behalf.
+
+## Have more questions?
+
+If you have any questions about registering, transferring, or renewing your .SPORT domain, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/domains-sport.md
+++ b/content/articles/domains-sport.md
@@ -17,8 +17,7 @@ categories:
 
 ## Registering a .SPORT domain {#registering}
 
-.SPORT registrations are non-realtime. This means that the registry reviews .SPORT applications by hand,
-so the domain is not active the moment you order it. When you register a .SPORT domain through DNSimple, your application is forwarded to the .SPORT registry for review.
+.SPORT registrations are non-realtime. This means that the registry reviews .SPORT applications by hand, so the domain is not active the moment you order it. When you register a .SPORT domain through DNSimple, your application is forwarded to the .SPORT registry for review.
 
 The registry contacts you with a series of questions about your registration. These questions are accessible through the registry user platform at [cp.nic.sport](https://cp.nic.sport/login), where a ticket is assigned to the applicant.
 

--- a/content/articles/domains-sport.md
+++ b/content/articles/domains-sport.md
@@ -15,6 +15,20 @@ categories:
 
 .SPORT domain registrations require registry approval before they can be completed. After you submit a registration through DNSimple, the registry contacts you with questions you must answer in the NIC.SPORT portal before the application is validated or rejected.
 
+## Eligibility {#eligibility}
+
+.SPORT is a restricted TLD. To register a .SPORT domain you must demonstrate a legitimate connection to the sports community and pass the registry's validation process. The registry accepts applications from a wide range of entities, including:
+
+- Individuals
+- Organisations
+- Brands
+- Clubs
+- Federations
+- Events
+- Sponsors
+
+All applications are subject to the registry's pre-validation process before allocation.
+
 ## Registering a .SPORT domain {#registering}
 
 .SPORT registrations are non-realtime. This means that the registry reviews .SPORT applications by hand, so the domain is not active the moment you order it. When you register a .SPORT domain through DNSimple, your application is forwarded to the .SPORT registry for review.
@@ -35,6 +49,12 @@ You must complete these steps before the registry can validate or reject your ap
 
 > [!NOTE]
 > The domain stays in a pending state until you complete the registry questionnaire in the NIC.SPORT portal. DNSimple cannot complete this step on your behalf.
+
+## Approval and rejections {#approval-and-rejections}
+
+The .SPORT registry does not publish an official approval timeframe. All registrations are subject to pre-validation review, and actual approval times vary depending on that review.
+
+If the registry rejects an application, they provide an explanation with the rejection.
 
 ## Have more questions?
 

--- a/content/articles/tlds.md
+++ b/content/articles/tlds.md
@@ -77,6 +77,7 @@ Requirements, eligibility, registration and transfer rules, and any special step
 - [.PL Domains](/articles/domains-pl/) - Requirements and procedures for .PL domain names.
 - [.SE Domains](/articles/domains-se/) - Requirements and procedures for .SE domain names.
 - [.SG Domains](/articles/domains-sg/) - Requirements and procedures for .SG domain names.
+- [.SPORT Domains](/articles/domains-sport/) - Non-realtime registration; registry approval and questionnaire via the NIC.SPORT portal.
 - [.TIROL Domains](/articles/domains-tirol/) - Registrant must show affinity with the Austrian federal state of Tirol.
 - [.UK Domains](/articles/domains-uk/) - Reservation policy for second-level .UK; matching .CO.UK/.ORG.UK contact required; transfer and transfer-away rules.
 - [.US Domains](/articles/domains-us/) - Transfer into DNSimple requires registrant acknowledgment; unacknowledged transfers canceled after 14 days.


### PR DESCRIPTION
This PR adds  a new support article at `/articles/domains-sport/` documenting .SPORT registration requirements as learned in https://dnsimple.groovehq.com/tickets/570772.

- Explains that .SPORT registrations require registry approval before completion
- Documents the NIC.SPORT portal (`https://cp.nic.sport/login`) where applicants receive a ticket and must answer registry questions
- Notes that domains remain in a pending state until the questionnaire is completed
- Adds the article to the TLDs category and cross-links it from the TLDs index page


## :mag: QA

<img width="371" height="545" alt="Screenshot 2026-07-21 at 6 35 01 a m" src="https://github.com/user-attachments/assets/ea85e060-a50a-4e53-91e6-fb54fa647e47" />


- Verify the article renders correctly locally
- Confirm the article appears under TLDs in the category navigation

## :clipboard: Deployment Pre/Post tasks

- N/A

## :shipit: Deployment Verification

- [x] QAd