### PR TITLE
Add Digital Wallet to Account pillar page

### DIFF
--- a/content/articles/your-dnsimple-account.md
+++ b/content/articles/your-dnsimple-account.md
@@ -45,6 +45,7 @@ For a guided first login, see [First Steps With Your DNSimple Account](/articles
 - [Billing Settings](/articles/billing-settings/) - Customize invoice details and billing email.
 - [Changing Payment Details](/articles/changing-payment-details/) - Update the card on file.
 - [Changing Subscription Plan](/articles/changing-plans/) - Upgrade or downgrade your plan.
+- [Digital Wallet Replenishment](/articles/wallet-replenishment/) - Add funds to your digital wallet for future purchases.
 - [Account Invoice History](/articles/account-invoice-history/) - View invoices and retry failed payments.
 
 ## Account setup and profile {#account-setup-and-profile}


### PR DESCRIPTION
## Summary
- Adds Digital Wallet Replenishment to the Billing and subscriptions section of Your DNSimple Account (missed when the pillar landed in #2042).

## Test plan
- [ ] Preview shows the new bullet under Billing and subscriptions
- [ ] Link resolves to /articles/wallet-replenishment/
- [ ] Check Links / Test pass