### PR TITLE
Restructure WHOIS Privacy category into Diataxis sections

### DIFF
--- a/categories/whois_privacy.yaml
+++ b/categories/whois_privacy.yaml
@@ -1,9 +1,7 @@
-Getting started:
+Explanation:
 - "What is WHOIS Privacy Service?"
-- "WHOIS Privacy Protection"
-
-GDPR:
 - "Domain privacy after GDPR"
-
-Troubleshooting:
 - "Whois Privacy and Transfer Approval Emails"
+
+How-to:
+- "WHOIS Privacy Protection"


### PR DESCRIPTION
Reorganize whois_privacy.yaml from Getting started / GDPR /
Troubleshooting into Explanation and How-to.

The old Getting started section held one Explanation article and one
How-to article rather than an entry point. Domain privacy after GDPR
moves out of a section named after a regulation. Whois Privacy and
Transfer Approval Emails moves from Troubleshooting to Explanation,
since the explanation is the substance and the fix is one line.

No meta description change: the whois_privacy entry already states
what the category covers.

Part of Phase 2 of the Category Documentation Revamp Plan (dnsimple/dnsimple-customer-success#200).

Closes dnsimple/dnsimple-customer-success#223