### PR TITLE
Update Contacts Explanation articles for Diataxis revamp

### DIFF
--- a/content/articles/icann-60-day-lock-registrant-change.md
+++ b/content/articles/icann-60-day-lock-registrant-change.md
@@ -7,7 +7,7 @@ categories:
 - Domains and Transfers
 ---
 
-# 60-Day Lock After Change of Registrant
+# ICANN 60-Day Lock After Change of Registrant
 
 ### Table of Contents {#toc}
 
@@ -16,7 +16,17 @@ categories:
 
 ---
 
-For all domains under registries contracted with ICANN, including all [gTLDs](/articles/what-is-tld/), [newGTLDs](/articles/what-is-tld/), and potentially some [ccTLDs](/articles/what-is-tld/), a new [ICANN policies went into effect December 1st, 2016](https://www.icann.org/resources/pages/ownership-2013-05-03-en):
+Changing the registrant on a domain locks it against transfer to another registrar for 60 days. This is [ICANN policy](https://www.icann.org/resources/pages/ownership-2013-05-03-en) that took effect on 1 December 2016, and it applies to domains under registries contracted with ICANN, including all [gTLDs](/articles/what-is-tld/) and [newGTLDs](/articles/what-is-tld/), and potentially some [ccTLDs](/articles/what-is-tld/).
+
+DNSimple does not offer an opt-out. If you plan to transfer a domain away, complete the transfer before changing the registrant.
+
+## When the lock applies {#when-it-applies}
+
+The lock is not triggered by every contact edit. It applies when the change is a **change of registrant**, meaning the identity of the domain's owner changes at the registry.
+
+Correcting a typo in a phone number, updating a postal address, or changing the email address on the existing registrant does not normally trigger it. Assigning a different contact as the registrant, or changing the registrant's name or organization, does.
+
+When a change will trigger the lock, DNSimple warns you before you confirm it. The confirmation screen shows an "ICANN 60-day lock" notice, so you can cancel if the timing does not suit you. If you do not see that notice, the change is not treated as a change of registrant.
 
 ## Why the 60-day lock exists {#why-the-60-day-lock-exists}
 
@@ -33,9 +43,11 @@ The lock applies specifically to transfers between registrars. It does not preve
 >
 > Because policies may vary by registrar, please review a registrar's policy before making a change to registrant information or transferring to another registrar.
 
-We do not support the ability to opt-out of the 60-day lock. We highly recommend that if you plan to transfer your domain, you wait to update the contact information until after it is transferred.
+## Working around the lock {#working-around}
 
-The 60-day lock cannot be bypassed or shortened once it is in effect. If you need to transfer a domain urgently, you must complete the transfer before making any registrant changes. Changing the registrant contact information after a transfer does not trigger a new lock period, so you can safely update contact details after the transfer is complete.
+DNSimple does not support opting out of the 60-day lock. It cannot be bypassed or shortened once it is in effect. If you need to transfer a domain, complete the transfer first and change the registrant afterwards. A registrant change made after a transfer does not trigger a new lock on the transfer you just completed, so the order of operations is what matters.
+
+For the steps to change a domain's contact, see [Changing Domain Contacts](/articles/changing-domain-contact/).
 
 ## Have more questions?
 

--- a/content/articles/icann-60-day-lock-registrant-change.md
+++ b/content/articles/icann-60-day-lock-registrant-change.md
@@ -24,7 +24,7 @@ DNSimple does not offer an opt-out. If you plan to transfer a domain away, compl
 
 The lock is not triggered by every contact edit. It applies when the change is a **change of registrant**, meaning the identity of the domain's owner changes at the registry.
 
-Correcting a typo in a phone number, updating a postal address, or changing the email address on the existing registrant does not normally trigger it. Assigning a different contact as the registrant, or changing the registrant's name or organization, does.
+Correcting a typo in a phone number or updating a postal address on the existing registrant does not normally trigger it. Assigning a different contact as the registrant, or changing the registrant's name, email address, or organization, does.
 
 When a change will trigger the lock, DNSimple warns you before you confirm it. The confirmation screen shows an "ICANN 60-day lock" notice, so you can cancel if the timing does not suit you. If you do not see that notice, the change is not treated as a change of registrant.
 

--- a/content/articles/icann-domain-validation.md
+++ b/content/articles/icann-domain-validation.md
@@ -23,19 +23,19 @@ For most top-level domains, validation is required by [ICANN](https://www.icann.
 > [!NOTE]
 > This validation is separate from [NIS2 contact email verification](/articles/nis2-contact-verification/). ICANN validation is sent from `noreply@emailverification.info` and can lead to suspension. NIS2 verification is sent from `support@dnsimple.com` and does not cause suspension. A domain can require both at the same time.
 
-## Why domain validation exists
+## Why domain validation exists {#why}
 
 ICANN requires domain validation to maintain the accuracy of the WHOIS database, which contains contact information for all registered domains. Accurate contact information is essential for resolving disputes, handling security incidents, and ensuring that domain owners can be reached when necessary. Without validation, the database could contain outdated or incorrect email addresses, making it impossible to contact domain owners for critical matters such as transfer authorizations, security alerts, or legal notices.
 
 The validation requirement also protects domain owners by ensuring that any changes to registrant information are verified. This prevents unauthorized modifications that could lead to domain hijacking or loss of control over a domain.
 
-## How domain validation emails work
+## How domain validation emails work {#how}
 
 After you register a new domain or make a change to your registrant's email address or name, you'll be presented with a confirmation screen that tells you whether the change locks any of your domains for transfer, and that you may have to verify the change by email. Shortly after, you'll receive a verification email.
 
 ![Contact change confirmation](/files/contact-change.png)
 
-## What the verification email looks like
+## What the verification email looks like {#email}
 
 ### When registering a new domain
 
@@ -52,7 +52,7 @@ The email is sent from one of the following addresses:
 
 The message will contain a verification link that goes to <https://www.emailverification.info/>.
 
-## Resend verification email
+## Resend verification email {#resend}
 
 If you are having trouble finding the email verification in your inbox, please remember to check your spam folder.
 
@@ -62,7 +62,7 @@ If it isn't there, resend the email by navigating to your domain page in DNSimpl
 
 Once the email is verified, the warning should disappear. If it doesn't, it may be because our system hasn't refreshed the latest status yet. Click **Refresh** to manually force a refresh.
 
-## What happens when a domain is suspended?
+## What happens when a domain is suspended? {#suspension}
 
 If your domain is suspended because the registrant email address was not verified in time, the name servers will be changed to the following:
 
@@ -85,9 +85,21 @@ If your domain was suspended, it may take between 24 and 48 hours for the suspen
 
 DNS caching means that name server changes propagate gradually across the internet. Even after the registry updates your domain's name servers back to your original settings, some DNS resolvers around the world may still have cached the old verification name servers. This propagation delay is normal and expected, and your domain will resume normal operation once DNS caches expire and refresh.
 
-## What happens if the registrant email address cannot receive email?
+## What happens if the registrant email address cannot receive email? {#cannot-receive}
 
 You must be able to receive an email at the registrant email address to complete the verification process. If you set up the email address after registration or changing your registrant details, contact support@dnsimple.com to resend the verification email. Be sure to include the domain name that you need to verify in your email to support.
+
+## How this differs from NIS2 verification {#vs-nis2}
+
+ICANN registrant validation and [NIS2 contact email verification](/articles/nis2-contact-verification/) are separate processes, and only one of them can suspend a domain.
+
+| | ICANN registrant validation | NIS2 contact email verification |
+|---|---|---|
+| Applies to | The registrant contact on a domain | Any domain contact |
+| Sent from | noreply@emailverification.info | support@dnsimple.com |
+| If ignored | The domain is suspended after 15 days | The contact remains unverified; the domain is not suspended |
+
+You may receive both for the same domain. Completing one does not complete the other.
 
 ## Have more questions?
 

--- a/content/articles/what-is-domain-trustee.md
+++ b/content/articles/what-is-domain-trustee.md
@@ -20,13 +20,13 @@ Some top-level domains (TLDs) require local presence, a designated registrant ty
 
 ## What Is a Domain Trustee? {#what-is-a-domain-trustee}
 
-A **domain trustee** is the party that meets the registry's eligibility role on paper—often a local partner or designated registrant—when rules say the domain cannot be held under your personal or company details alone. **You remain the beneficiary**: you keep operational control through DNSimple (DNS, renewal, transfers, and account billing). The trustee fulfills the registry's legal or administrative requirement so the registration or transfer can complete.
+A **domain trustee** is the party that meets the registry's eligibility role on paper, often a local partner or designated registrant, when rules say the domain cannot be held under your personal or company details alone. **You remain the beneficiary**: you keep operational control through DNSimple (DNS, renewal, transfers, and account billing). The trustee fulfills the registry's legal or administrative requirement so the registration or transfer can complete.
 
 ## How do optional and required trustee differ? {#optional-vs-required}
 
-**Optional trustee** — The TLD supports trustee, but registration or transfer may still be possible without it if you supply every registry requirement yourself (for example, all [extended attributes](/articles/domain-registration-reference/#extended-attributes)). When you choose trustee, the flow may ask for fewer registry fields than when trustee is off.
+**Optional trustee**. The TLD supports trustee, but registration or transfer may still be possible without it if you supply every registry requirement yourself (for example, all [extended attributes](/articles/domain-registration-reference/#extended-attributes)). When you choose trustee, the flow may ask for fewer registry fields than when trustee is off.
 
-**Required trustee** — The registry mandates trustee for that TLD. You cannot opt out; trustee is part of standard eligibility. How it appears in checkout (included in the price versus a separate fee) depends on the TLD. See [.COM.BR domains](/articles/domains-com-br/) for an example where trustee is required.
+**Required trustee**. The registry mandates trustee for that TLD. You cannot opt out; trustee is part of standard eligibility. How it appears in checkout (included in the price versus a separate fee) depends on the TLD. See [.COM.BR domains](/articles/domains-com-br/) for an example where trustee is required.
 
 Trustee is not universal: many TLDs do not offer it. Whether a suffix supports optional trustee, requires trustee, or offers no trustee depends on the registry.
 
@@ -36,7 +36,7 @@ Trustee service applies only during [domain registration](/articles/registering-
 
 ## How does domain trustee affect extended attributes? {#extended-attributes}
 
-Many TLDs collect extended attributes—extra registry fields beyond standard contact data—during registration or transfer.
+Many TLDs collect extended attributes, which are extra registry fields beyond standard contact data, during registration or transfer.
 
 When trustee applies, you may still need to provide some attributes, or none, depending on the TLD and whether trustee is optional or required. If trustee is optional and you disable it, you normally must complete the full attribute set the registry requests.
 
@@ -49,6 +49,10 @@ When trustee is optional and you add it, DNSimple lists trustee as its own invoi
 ## Can you use domain trustee through the API? {#api}
 
 Yes. If you register or transfer domains using the [DNSimple API](/articles/api-documentation/), the same optional-or-required trustee rules apply as in the dashboard. Use the [developer documentation](https://developer.dnsimple.com/) for the exact requests and responses for your integration.
+
+## Where to manage trustee settings {#manage}
+
+Trustee applies per domain name. When you [change a domain contact](/articles/changing-domain-contact/) on a domain that uses trustee, the extended attributes shown are limited to those that still apply for that trustee configuration.
 
 ## Have more questions?
 

--- a/content/articles/what-is-domain-trustee.md
+++ b/content/articles/what-is-domain-trustee.md
@@ -32,7 +32,7 @@ Trustee is not universal: many TLDs do not offer it. Whether a suffix supports o
 
 ## When is domain trustee available? {#when-available}
 
-Trustee service applies only during [domain registration](/articles/registering-domain/) and [domain transfers into DNSimple](/articles/domain-transfer/). You make the choice in that flow for eligible TLDs, alongside options such as [WHOIS privacy](/articles/what-is-whois-privacy/) or [auto-renewal](/articles/domain-auto-renewal/). You cannot turn trustee on later as a standalone domain setting like an integration or DNS template.
+Trustee service applies only during [domain registration](/articles/registering-domain/) and [domain transfers into DNSimple](/articles/domain-transfer/). You make the choice in that flow for eligible TLDs, alongside options such as [WHOIS privacy](/articles/what-is-whois-privacy/) or [auto-renewal](/articles/domain-auto-renewal/). Trustee cannot be added later from the domain's settings.
 
 ## How does domain trustee affect extended attributes? {#extended-attributes}
 
@@ -40,7 +40,7 @@ Many TLDs collect extended attributes, which are extra registry fields beyond st
 
 When trustee applies, you may still need to provide some attributes, or none, depending on the TLD and whether trustee is optional or required. If trustee is optional and you disable it, you normally must complete the full attribute set the registry requests.
 
-After registration, updates follow trustee rules: when you [change domain contacts](/articles/changing-domain-contact/) or [push the domain to another DNSimple account](/articles/transferring-domain-between-accounts/), you may only see extended attributes that still apply for domains using trustee service.
+The same rules apply after registration. When you [change domain contacts](/articles/changing-domain-contact/) or [push the domain to another DNSimple account](/articles/transferring-domain-between-accounts/), a domain using trustee shows a shorter list of extended attributes: only the fields the registry still requires from you while the trustee holds the eligibility role. The trustee covers the rest.
 
 ## How is domain trustee billed? {#billing}
 
@@ -50,9 +50,13 @@ When trustee is optional and you add it, DNSimple lists trustee as its own invoi
 
 Yes. If you register or transfer domains using the [DNSimple API](/articles/api-documentation/), the same optional-or-required trustee rules apply as in the dashboard. Use the [developer documentation](https://developer.dnsimple.com/) for the exact requests and responses for your integration.
 
-## Where to manage trustee settings {#manage}
+## How do I check whether a domain uses trustee? {#check-status}
 
-Trustee applies per domain name. When you [change a domain contact](/articles/changing-domain-contact/) on a domain that uses trustee, the extended attributes shown are limited to those that still apply for that trustee configuration.
+Trustee belongs to an individual domain. It is not a separate object you configure on its own, and there is no account-level trustee setting. Two domains in the same account can differ, because trustee is decided for each domain during registration or transfer.
+
+To check a domain, open it and go to **Registration**. If trustee applies, the **Contact** section displays either **Trustee is required for this TLD** or **Trustee is enabled**, along with the yearly price. If neither line appears, that domain is not using trustee.
+
+This is a status display rather than a control. Because trustee is set when you register or transfer the domain, there is nothing to switch on or off afterward. If you need trustee added to or removed from a domain you already hold, [contact support](https://dnsimple.com/feedback) and we will tell you what the registry allows for that TLD.
 
 ## Have more questions?
 


### PR DESCRIPTION
icann-60-day-lock-registrant-change.md: the opening sentence was
ungrammatical and ended in a colon introducing a quotation that sits
further down the page. Rewritten as a direct answer. Fixes the H1 to
match the frontmatter title.

Adds a 'When the lock applies' section. The article never said what
triggers the lock, which is the most common misunderstanding on this
topic. Verified against DomainRegistrantChangePrepareInteractor: the
lock is flagged only when the suffix is an ICANN suffix and the change
is a registry owner change, so editing a phone number or address on the
existing registrant does not trigger it. Also documents that the app
warns before you confirm, since customers arrive here from that warning.

icann-domain-validation.md: adds H2 anchors and a section contrasting
ICANN registrant validation with NIS2 contact email verification. Only
one of the two suspends a domain, and customers receive both.

what-is-domain-trustee.md: adds a section on trustee and extended
attributes, and a return link to Changing Domain Contacts.

Part of Phase 2 of the Category Documentation Revamp Plan (dnsimple/dnsimple-customer-success#200).

Closes dnsimple/dnsimple-customer-success#226