### PR TITLE
Fix contact deletion rule and registrant change gaps in Contacts how-tos

### DIFF
--- a/content/articles/changing-domain-contact.md
+++ b/content/articles/changing-domain-contact.md
@@ -19,10 +19,10 @@ For domains registered with DNSimple, [Domain Managers](/articles/what-is-domain
 
 Domains that use [domain trustee](/articles/what-is-domain-trustee/) may show only the extended attributes that still apply for that trustee configuration when you update contacts.
 
-> [!NOTE] Domains not registered with DNSimple
+> [!NOTE]
 > These instructions apply only to domains registered with DNSimple. If you are hosting the domain with us, and the domain is registered elsewhere, you will have to update the contact information at your current registrar, or transfer the domain to DNSimple.
 
-## Assigning a new domain contact
+## Assigning a new domain contact {#assigning-a-new-domain-contact}
 
 To assign a new contact to one of your domains, create the new contact record, then associate the domain to the new contact.
 
@@ -46,9 +46,9 @@ To assign a new contact to one of your domains, create the new contact record, t
     ![screenshot of editing a contact](/files/confirm-contact-change.png)
 </div>
 
-## Updating a domain contact
+## Updating a domain contact {#updating}
 
-You can update the contact details to change existing contact information. DNSimple will immediately update the registry data and the WHOIS record with the new information.
+You can update the contact details to change existing contact information. For most TLDs, DNSimple submits the change to the registry immediately. Some TLDs require the registry to confirm the change first, so the update is not instant. See [registrant changes that need registry confirmation](#registry-confirmation).
 <div class="section-steps" markdown="1">
 ##### To change the contact information
 
@@ -60,23 +60,43 @@ You can update the contact details to change existing contact information. DNSim
 
 </div>
 
-## Monitoring a contact change
+## Monitoring a contact change {#monitoring}
 
 > [!NOTE]
 > When a domain contact has been changed, you will receive a confirmation email from noreply@emailverification.info. You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
 
-Some TLDs require extra steps before authorizing a registrant change.
+<div class="section-steps" markdown="1">
+##### Check the status of a registrant change
 
-1.  On the domain details page, click the **Registration** tab on the left side.
+1. On the domain details page, click the <label>Registration</label> tab on the left side.
 
     ![Domain registration details](/files/domain-registration-details.png)
 
-1.  If action is required, the card displaying the contact information of your domain will show a list of instructions that need to be completed for the registrant change to succeed. If you want to cancel the change, click **Cancel change**.
+1. If action is required, the card displaying the contact information of your domain shows a list of instructions that must be completed for the registrant change to succeed.
 
     ![Contact change pending](/files/contact-change-monitor.png)
 
+1. To stop a change that has not completed yet, click <label>Cancel change</label>.
 
-## Special WHOIS policies
+</div>
+
+A registrant change can be cancelled while it is still new or pending. Once it completes, it cannot be reversed from this page; you would need to start a new change.
+
+## Registrant changes that need registry confirmation {#registry-confirmation}
+
+Most registrant changes complete without any extra steps. The following TLDs require the registry to confirm the change, so the request does not finish in the app on its own:
+
+| TLD |
+|-----|
+| .at |
+| .au |
+| .es |
+| .nu |
+| .se |
+
+For these TLDs, the contact card shows the instructions that apply, and completing the change requires us to act with the registry. [Contact support](https://dnsimple.com/feedback) and we will finish the registrant change for you.
+
+## Special WHOIS policies {#whois-policies}
 
 Some registries adopt specific contact update policies that may cause the WHOIS update task to fail. View [this article](/articles/changing-whois-contact/) for a list of the most common registrar-specific policies.
 

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Your Contacts
-excerpt: This article explains how to manage your contacts for your domains and SSL certificates.
+excerpt: How to create, update, and delete the domain contacts in your DNSimple account.
 meta: Create, update, and delete domain contacts in your DNSimple account. Keep contact information accurate to avoid ICANN verification issues.
 categories:
 - Contacts
@@ -8,57 +8,70 @@ categories:
 
 # Managing Your Contacts
 
+### Table of Contents {#toc}
+
 * TOC
 {:toc}
+
+---
+
+Domain contacts hold the registrant details required to register a domain or order an SSL certificate. Contacts belong to your account rather than to an individual user, so adding someone as a contact does not give them access to your DNSimple account. You manage them from the <label>Contacts</label> tab in the header.
 
 > [!NOTE]
 > These instructions apply only to domains registered with DNSimple. If you are hosting the domain with us, and the domain is registered elsewhere, you will have to manage the contact information at your current registrar, or transfer the domain to DNSimple.
 
-## Why domain contacts are important
+## Why domain contacts are important {#why}
 
 For domains registered with DNSimple, [Domain Managers](/articles/what-is-domain-access-control/#domain-manager) and anyone with [Full Access](/articles/what-is-domain-access-control/#full-access) can manage contacts associated with domains.
 
-Domain contacts are required for registering a new domain or purchasing a new SSL certificate. Domain contact information is associated with accounts rather than individual users. Adding someone as a domain contact does not give them access to your DNSimple account or user.
+A contact must have correct, up-to-date information, because it may be used for [ICANN contact verification](/articles/icann-domain-validation/) after you register a domain. If the information is incorrect, the contact may not receive the validation request. Failure to validate the registrant email address results in suspension of the domain name after 15 days of non-compliance.
 
-A contact must have correct, up-to-date information, as it may be used by [ICANN for contact verification](/articles/icann-domain-validation/) after purchasing a domain. If the information is incorrect the contact  may not recieve the validation request. Failure to validate the registrant email address will result in suspension of the domain name after 15 days of non-compliance.
+Contacts may also receive [NIS2 contact email verification](/articles/nis2-contact-verification/), which confirms the address is reachable but does not suspend the domain.
 
-Use an email address that does not belong to the custom domain you're managing (e.g. if you own `example.buisness`, don't use `Hello@example.business`). If your email is tied to the domain, and it becomes unavailable, expires, or is not configured correctly, you might not be able to receive notifications.
+Use an email address that does not belong to the domain you are managing. If you own `example.business`, do not use `hello@example.business`. If your email is tied to the domain, and the domain becomes unavailable, expires, or is not configured correctly, you might not receive notifications.
 
-Read this list of [8 tips for domain management](https://blog.dnsimple.com/2017/05/domain-management-tips/) for more ways to avoid potential issues with your domains.
+For what each field requires, see the [domain contact field reference](/articles/domain-contact-field-reference/).
 
-## Creating a new contact
+## Creating a new contact {#create}
 
-If this is the first time you're registering a domain or ordering a new SSL certificate, and you haven't created any contacts yet, you'll be prompted to create one during this flow. Once a contact is created, it's available for future domain management operations.
+If you are registering a domain or ordering an SSL certificate for the first time and have not created any contacts yet, you will be prompted to create one during that flow. Once a contact is created, it is available for future domain management operations.
 
 ![creating a contact during domain registration](/files/contact-creation.png)
 
-You can also create a new contact at any time through the **Contacts** page.
+You can also create a contact at any time from the <label>Contacts</label> tab.
 
 ![creating a new contact](/files/change-contact-1.png)
 
 > [!NOTE]
 > If the email address on the contact has not been verified to comply with [NIS2 regulations](https://nis2directive.eu/what-is-nis2/), you will receive a verification email. Follow the link in the email to complete the verification. For details, see [NIS2 Contact Email Verification](/articles/nis2-contact-verification/).
 
-## Updating contacts
+## Updating contacts {#update}
 
-If a contact is associated with multiple domains, updating that contact also updates all the contact information associated with these domains. You don't need to individually update these domains if they're associated with the same contact.
+If a contact is associated with multiple domains, updating that contact updates the contact information for all of those domains. You do not need to update each domain individually when they share the same contact.
 
-To update the contact for a specific domain, you will need to [replace the domain contact](/articles/changing-domain-contact/#assigning-a-new-domain-contact) with a new one.
+To change which contact a specific domain uses, [replace the domain contact](/articles/changing-domain-contact/#assigning-a-new-domain-contact) instead.
 
 > [!NOTE]
 > When you update a domain contact:
 > - You will receive a confirmation email from noreply@emailverification.info.
 > - You may also see a message that the contact change results in the domain being [locked from transfers for 60 days](/articles/icann-60-day-lock-registrant-change/).
-> - If you update the contact's email address you may also receive an specific email to verify the new email address.
+> - If you update the contact's email address, you may also receive a separate email to verify the new address.
 
-### Deleting a contact
+## Deleting a contact {#delete}
 
-If a contact is associated with at least one domain or SSL certificate, this contact cannot be deleted. You must remove all associated domains or SSL certificates with the contact before you can delete it.
-
-If you can delete a contact, you will see a trash can icon next to their name.
+You can delete a contact from the <label>Contacts</label> tab. If a contact can be deleted, a trash can icon appears next to its name.
 
 ![contact deletion](/files/contact-delete.png)
 
+A contact cannot be deleted while either of the following is true:
+
+- **The contact is the registrant of at least one domain.** Assign a different contact to those domains first. See [Changing Domain Contacts](/articles/changing-domain-contact/).
+- **The contact has a registrant change still in progress.** Wait for the change to complete, or cancel it from the <label>Registration</label> tab of the affected domain.
+
+The second case is easy to miss. A contact can look unused because no domain currently lists it as the registrant, and still refuse to delete because a registrant change naming it has not finished.
+
+Contacts used on an SSL certificate order are not blocked from deletion.
+
 ## Have more questions?
 
-If you have any further questions or need assistance with your domain contacts, [contact our support team](https://dnsimple.com/contact), and we'll be happy to help.
+If you have any further questions or need assistance with your domain contacts, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -30,8 +30,6 @@ Contacts may also receive [NIS2 contact email verification](/articles/nis2-conta
 
 Use an email address that does not belong to the domain you are managing. If you own `example.business`, do not use `hello@example.business`. If your email is tied to the domain, and the domain becomes unavailable, expires, or is not configured correctly, you might not receive notifications.
 
-For what each field requires, see the [domain contact field reference](/articles/domain-contact-field-reference/).
-
 ## Creating a new contact {#create}
 
 If you are registering a domain or ordering an SSL certificate for the first time and have not created any contacts yet, you will be prompted to create one during that flow. Once a contact is created, it is available for future domain management operations.

--- a/content/articles/nis2-contact-verification.md
+++ b/content/articles/nis2-contact-verification.md
@@ -1,7 +1,7 @@
 ---
 title: NIS2 Contact Email Verification
 excerpt: Learn what NIS2 contact email verification is, how to complete it, and how it differs from ICANN registrant validation.
-meta: NIS2 contact email verification at DNSimple confirms that the email address on a domain contact is valid. It is sent from support@dnsimple.com and, unlike ICANN registrant validation, does not cause domain suspension.
+meta: NIS2 contact email verification at DNSimple confirms a domain contact's email is valid. Unlike ICANN registrant validation, it does not suspend your domain.
 categories:
 - Domains and Transfers
 - Contacts
@@ -36,7 +36,7 @@ The email has these characteristics:
 - **Subject:** Action Required: Verify your contact email address
 - **Link:** a `https://dnsimple.com/email_verification/...` address unique to that contact email
 
-The link is time-limited. The message states the exact date and time it expires, so complete the verification before then. If you cannot find the email, check your spam folder.
+The link expires 7 days after the verification email is sent. The message states the exact date and time it expires, so complete the verification before then. If you cannot find the email, check your spam folder.
 
 ## How to verify your contact email address {#verify}
 


### PR DESCRIPTION
contact-management.md: the stated deletion rule was wrong. It said a
contact tied to a domain or SSL certificate cannot be deleted. Per
ContactRules#ensure_contact_deletable, deletion is blocked when the
contact is the registrant of a domain, or has an open registrant
change. SSL certificate association does not block it. The open
registrant change condition was undocumented. Also fixes the TOC,
adds H2 anchors, removes contractions, fixes the recieve/buisness
typos, and points the CTA at /feedback instead of /contact.

changing-domain-contact.md: names the five TLDs that need registry
confirmation (.at, .au, .es, .nu, .se) instead of 'some TLDs',
qualifies the claim that registry data updates immediately, documents
that a pending change can be cancelled, fixes the callout syntax, and
wraps the monitoring steps in section-steps.

nis2-contact-verification.md: states the 7-day link expiry rather than
'time-limited'.

Part of Phase 2 of the Category Documentation Revamp Plan (dnsimple/dnsimple-customer-success#200).

Closes dnsimple/dnsimple-customer-success#229