### PR TITLE
Add Domain Contact Field Reference article

### DIFF
--- a/categories/contacts.yaml
+++ b/categories/contacts.yaml
@@ -7,3 +7,6 @@ How-to:
 - "Managing Your Contacts"
 - "Changing Domain Contacts"
 - "NIS2 Contact Email Verification"
+
+Reference:
+- "Domain Contact Field Reference"

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -30,6 +30,8 @@ Contacts may also receive [NIS2 contact email verification](/articles/nis2-conta
 
 Use an email address that does not belong to the domain you are managing. If you own `example.business`, do not use `hello@example.business`. If your email is tied to the domain, and the domain becomes unavailable, expires, or is not configured correctly, you might not receive notifications.
 
+For what each field requires, see the [Domain Contact Field Reference](/articles/domain-contact-field-reference/).
+
 ## Creating a new contact {#create}
 
 If you are registering a domain or ordering an SSL certificate for the first time and have not created any contacts yet, you will be prompted to create one during that flow. Once a contact is created, it is available for future domain management operations.

--- a/content/articles/domain-contact-field-reference.md
+++ b/content/articles/domain-contact-field-reference.md
@@ -1,0 +1,71 @@
+---
+title: Domain Contact Field Reference
+excerpt: Which domain contact fields are required, their maximum lengths, and the formats DNSimple accepts.
+meta: "Reference for DNSimple domain contact fields: which are required, their maximum lengths, and accepted formats for phone numbers and country codes."
+categories:
+- Contacts
+---
+
+# Domain Contact Field Reference
+
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+Every domain contact in DNSimple has the same set of fields. Most are required, several have maximum lengths that are shorter than customers expect, and two have formats that must match a standard. This page lists them all.
+
+For how to create and edit contacts, see [Managing Your Contacts](/articles/contact-management/).
+
+## Field requirements {#fields}
+
+| Field | Required | Maximum length | Notes |
+|-------|----------|----------------|-------|
+| First name | Yes | 60 | |
+| Last name | Yes | 60 | |
+| Organization name | No | - | If set, job title becomes required |
+| Job title | Only with an organization | 60 | |
+| Email address | Yes | 128 | Stored in lowercase |
+| Phone | Yes | 20 | Must be a valid E.164 number |
+| Fax | No | 20 | Must be a valid E.164 number if provided |
+| Address line 1 | Yes | 60 | |
+| Address line 2 | No | 60 | |
+| City | Yes | 60 | |
+| State or province | Yes | 60 | |
+| Postal code | Yes | 16 | |
+| Country | Yes | - | Must be a valid ISO 3166 country code |
+| Label | No | - | Used to tell similar contacts apart |
+
+## Fields that depend on other fields {#dependencies}
+
+**Job title is required only when an organization name is present.** If you register domains as an individual, leave both blank. If you enter an organization name, you must also enter a job title.
+
+## Format requirements {#formats}
+
+**Phone and fax numbers must be in E.164 format.** E.164 is the international standard: a plus sign, the country code, then the subscriber number, with no spaces, dashes, or parentheses. For example, `+15551234567` rather than `(555) 123-4567`.
+
+**Country must be a valid ISO 3166 code.** The contact form presents this as a country picker, so you do not normally enter the code by hand.
+
+## How values are stored {#normalization}
+
+DNSimple normalizes contact values on save:
+
+- Leading and trailing whitespace is removed from every text field
+- Email addresses are converted to lowercase
+- Country codes are converted to uppercase
+
+A field containing only spaces is treated as blank, so it will not satisfy a required field.
+
+## How contacts are displayed {#display}
+
+A contact displays by its label when one is set, and by first and last name otherwise. Labels are useful when the same person appears as a contact more than once, for example a personal contact and a company contact with the same name.
+
+## What is not a contact field {#extended-attributes}
+
+**Extended attributes are not contact fields.** Some TLDs require additional registry-specific information, such as a registrant type or a local tax identifier. These are collected during registration and during a registrant change, they vary by TLD, and they are not stored on the contact itself. Domains using [domain trustee](/articles/what-is-domain-trustee/) show only the extended attributes that still apply for that trustee configuration.
+
+## Have more questions?
+
+If you have any questions about domain contact fields, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.


### PR DESCRIPTION
The contact form's constraints were undocumented. Support sees failures
caused by the 60-character address and city limits, the 16-character
postal code limit, and the rule that job title becomes required once an
organization name is entered.

Field requirements, maximum lengths, and format rules verified against
app/models/contact.rb. Also documents the normalization applied on save
(whitespace stripped, email lowercased, country uppercased), the label
display rule, and that extended attributes are per-TLD registry
requirements rather than contact fields.

Adds the Reference section to contacts.yaml and links from Managing
Your Contacts.

Note: categories/contacts.yaml here assumes the Contacts Diataxis
restructure has merged. Land that PR first.

Part of Phase 2 of the Category Documentation Revamp Plan (dnsimple/dnsimple-customer-success#200).

> [!IMPORTANT]
> `categories/contacts.yaml` here assumes the Contacts Diataxis restructure has merged. Land that PR first, then `git merge main` into this branch.

Closes dnsimple/dnsimple-customer-success#227