### PR TITLE
Add web vs dns hosting video to Web Hosting page

### DIFF
--- a/content/articles/web-hosting.md
+++ b/content/articles/web-hosting.md
@@ -16,6 +16,10 @@ categories:
 
 ---
 
+<div class="aspect-ratio aspect-ratio--16x9 z-0 mb4">
+  <iframe loading="lazy" src="https://www.youtube.com/embed/wBYK-IOAXek" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 ## Does DNSimple provide web hosting services? {#does-dnsimple-provide-web-hosting-services}
 
 No, we do not. DNSimple focuses on simplifying your domain and DNS management. We offer a variety of features that let you set up and connect your domains to popular services that already exist, rather than trying to create our own solution. With DNSimple, you can have the best of both worlds, instead of mediocre products for each one.


### PR DESCRIPTION
## Summary

Embeds the "Web Hosting vs. DNS Hosting" YouTube video at the top of the Web Hosting Support article. The article explains that DNSimple does not provide web hosting and how DNS hosting differs from web hosting, so a short video reinforces that distinction for readers before they dig into the text.

## Files changed

- `content/articles/web-hosting.md` — added a responsive 16x9 YouTube iframe embed (video ID `wBYK-IOAXek`) just below the table of contents

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [ ] Cross-links added on first mention of related concepts (n/a - no new concepts)
- [ ] Existing articles updated to link back (n/a)
- [x] No smart/curly quotes or special characters from macOS
- [ ] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]` (n/a - no callouts changed)
- [x] Tested locally with `rake run`

## Review

- [x] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)

***NOTE** that the video is Unlisted right now, so the preview may be inaccurate until the video is made Public on YouTube.*

Closes https://github.com/dnsimple/dnsimple-marketing/issues/1103