### PR TITLE
Fix Phase 2 pillar follow-ups

### DIFF
--- a/categories/integrations.yaml
+++ b/categories/integrations.yaml
@@ -1,5 +1,6 @@
 Connectors:
 - "Connectors at DNSimple"
+- "What Are Connectors?"
 
 Integrated Domain Providers:
 - "Integrated Domain Providers at DNSimple"

--- a/content/articles/changing-domain-contact.md
+++ b/content/articles/changing-domain-contact.md
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-For domains registered with DNSimple, [Domain Managers](/articles/what-is-domain-access-control/#domain-manager) and anyone with [Full Access](/articles/what-is-domain-access-control/#full-access) can change the contact associated with a domain at any time.
+For domains registered with DNSimple, [Domain Managers](/articles/what-is-domain-access-control/#domain-manager) and anyone with [Full Access](/articles/what-is-domain-access-control/#full-access) can change the contact associated with a domain at any time. For an overview of domain contact documentation, see [Domain Contacts at DNSimple](/articles/domain-contacts-at-dnsimple/).
 
 Domains that use [domain trustee](/articles/what-is-domain-trustee/) may show only the extended attributes that still apply for that trustee configuration when you update contacts.
 

--- a/content/articles/contact-management.md
+++ b/content/articles/contact-management.md
@@ -15,7 +15,7 @@ categories:
 
 ---
 
-Domain contacts hold the registrant details required to register a domain or order an SSL certificate. Contacts belong to your account rather than to an individual user, so adding someone as a contact does not give them access to your DNSimple account. You manage them from the <label>Contacts</label> tab in the header.
+Domain contacts hold the registrant details required to register a domain or order an SSL certificate. Contacts belong to your account rather than to an individual user, so adding someone as a contact does not give them access to your DNSimple account. You manage them from the <label>Contacts</label> tab in the header. For an overview of domain contact documentation, see [Domain Contacts at DNSimple](/articles/domain-contacts-at-dnsimple/).
 
 > [!NOTE]
 > These instructions apply only to domains registered with DNSimple. If you are hosting the domain with us, and the domain is registered elsewhere, you will have to manage the contact information at your current registrar, or transfer the domain to DNSimple.

--- a/content/articles/domain-contacts-at-dnsimple.md
+++ b/content/articles/domain-contacts-at-dnsimple.md
@@ -46,7 +46,7 @@ These live in other categories but come up often alongside contacts:
 - [What is WHOIS Privacy Service?](/articles/what-is-whois-privacy/) - What the privacy service replaces, and what it costs.
 - [Domain privacy after GDPR](/articles/domain-privacy-after-gdpr/) - What is published today, and how redaction differs from privacy.
 - [What is Domain Access Control?](/articles/what-is-domain-access-control/) - Which roles can manage contacts and domains.
-- [Changing the WHOIS contact](/articles/changing-whois-contact/) - Registry-specific contact update policies.
+- [Change WHOIS Information](/articles/changing-whois-contact/) - Registry-specific contact update policies.
 
 ## Have more questions?
 

--- a/content/articles/heroku-connector.md
+++ b/content/articles/heroku-connector.md
@@ -16,7 +16,7 @@ categories:
 
 ---
 
-The Heroku Connector links a domain in your DNSimple account to an app on [Heroku](https://www.heroku.com) and creates the DNS records the app needs. For what a connector is and how it differs from an integration, see [What Are Connectors?](/articles/what-are-connectors/).
+The Heroku Connector links a domain in your DNSimple account to an app on [Heroku](https://www.heroku.com) and creates the DNS records the app needs. For an overview of connector documentation, see [Connectors at DNSimple](/articles/connectors-at-dnsimple/). For what a connector is and how it differs from one-click services, see [What Are Connectors?](/articles/what-are-connectors/).
 
 > [!NOTE]
 > The <label>Connections</label> tab appears only for users who can manage the account. If you do not see it, you have domain-level access rather than account-level access.

--- a/content/articles/netlify-connector.md
+++ b/content/articles/netlify-connector.md
@@ -16,7 +16,7 @@ categories:
 
 ---
 
-The Netlify Connector links a domain in your DNSimple account to a site on [Netlify](https://www.netlify.com) and creates the DNS records and Netlify configuration the site needs. For what a connector is and how it differs from an integration, see [What Are Connectors?](/articles/what-are-connectors/).
+The Netlify Connector links a domain in your DNSimple account to a site on [Netlify](https://www.netlify.com) and creates the DNS records and Netlify configuration the site needs. For an overview of connector documentation, see [Connectors at DNSimple](/articles/connectors-at-dnsimple/). For what a connector is and how it differs from one-click services, see [What Are Connectors?](/articles/what-are-connectors/).
 
 > [!NOTE]
 > The <label>Connections</label> tab appears only for users who can manage the account. If you do not see it, you have domain-level access rather than account-level access.

--- a/content/articles/template-record-variables.md
+++ b/content/articles/template-record-variables.md
@@ -21,8 +21,6 @@ For what templates are and how to apply them, see [How DNS Templates Work](/arti
 
 ## The {{domain}} variable {#domain-variable}
 
-## The {{domain}} variable {#domain-variable}
-
 `{{domain}}` is a value you type into a template record's content field. DNSimple does not insert it for you. When you apply the template to a domain, `{{domain}}` is replaced with that domain's name.
 
 A template record with the content `{{domain}}` applied to `example.com` produces `example.com`. It can also appear inside a longer value, such as `www.{{domain}}`, which becomes `www.example.com`.


### PR DESCRIPTION
### Summary

A quick follow-up after merging the Phase 2 pillar pages for Contacts, WHOIS Privacy, Templates, and Connectors (#2062-#2065).

This PR fixes a few small issues found after the merge:

- Adds What Are Connectors? to the Connectors section in integrations.yaml, so the article does not appear under Other
- Removes the duplicated ## The {{domain}} variable heading from the Templates reference article
- Adds the missing backlinks from the Contacts how-to articles to Domain Contacts at DNSimple
- Adds the missing backlinks from the Connectors how-to articles to Connectors at DNSimple
- Updates the link text in the Contacts pillar to match the article title, Change WHOIS Information

## Files changed

- `categories/integrations.yaml` - add What Are Connectors? to the Connectors section
- `content/articles/template-record-variables.md` - remove duplicate H2
- `content/articles/contact-management.md` - backlink to Domain Contacts at DNSimple
- `content/articles/changing-domain-contact.md` - backlink to Domain Contacts at DNSimple
- `content/articles/heroku-connector.md` - backlink to Connectors at DNSimple
- `content/articles/netlify-connector.md` - backlink to Connectors at DNSimple
- `content/articles/domain-contacts-at-dnsimple.md` - Related link text fix

## Verification

- [x] Category YAML titles match article frontmatter titles for touched Integrations listings
- [x] Backlink targets resolve to live pillar articles on main
- [x] No `redirect_from` involved
- [x] Scope limited to the five follow-ups from the post-merge audit (NIS2 H2 grouping left as-is)

## Notes

Follow-up to dnsimple/dnsimple-customer-success#221 Phase 2 pillars. Does not reopen pillar scope; only closes gaps the pillar PRs left on main.