### PR TITLE
Index the meta field in support site search

### DIFF
--- a/_widget/src/components/app/search.js
+++ b/_widget/src/components/app/search.js
@@ -4,7 +4,7 @@ import { trackSearch } from './analytics.js';
 const MAX_RESULTS = 7;
 
 const fuseOptions = {
-  keys: ['title', 'excerpt', 'searchBody'],
+  keys: ['title', 'meta', 'excerpt', 'searchBody'],
   threshold: 0.4,
   ignoreLocation: true,
   includeScore: true

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -42,6 +42,7 @@ module Search
           id: item.path,
           title: item.attributes[:title],
           excerpt: item[:excerpt],
+          meta: item[:meta],
           categories: item[:categories],
           body: item.compiled_content
         }


### PR DESCRIPTION
## The problem

`meta` is set on **508 of our 516 articles**, and `article-structure.mdc` tells every author to write it as a direct answer to the question the article addresses:

> "`meta`: Can differ from excerpt — optimized for search engines and AI answer engines… Write it as a direct answer to the question the article addresses."

Nothing reads it. It isn't emitted into `search.json`, and it isn't in the Fuse `keys`. Authors have been following the rule and the output has been going nowhere.

## The change

Two lines, and both are needed — either alone is a no-op:

- `lib/search.rb` — emit `meta` into the search feed, alongside `excerpt` and `categories`
- `_widget/src/components/app/search.js` — add `meta` to the Fuse `keys`

No new content. This makes reachable what 508 articles already say.

## Measurement

Scored against 46 questions built from support tickets and hand-verified, phrased as 2–6 word searches — the shape people actually type into the search box:

| config | recall@1 | recall@3 | recall@5 |
|---|---|---|---|
| current | 26% | 43% | 52% |
| **with `meta`** | 26% | **48%** | **57%** |

## Why only this change

Two other tweaks were ablated in the same run and both were rejected on the evidence:

| change | effect |
|---|---|
| key weights (`title:3 / meta:2 / excerpt:2 / searchBody:1`) | **−2 pts** recall@1, **−3 pts** recall@5 |
| `minMatchCharLength: 3` | inert — identical on every metric |
| all three bundled | **worse** than `meta` alone |

The weighting looks obviously correct and measurably isn't, so this PR deliberately changes one thing.