### PR TITLE
Fix three meta/excerpt fields that answer the wrong question

### DIFF
--- a/content/articles/dnsimple-plans.md
+++ b/content/articles/dnsimple-plans.md
@@ -1,7 +1,7 @@
 ---
 title: DNSimple Plans
-excerpt: Understand which plan fits your needs
-meta: Explore DNSimple's flexible plans to find the perfect fit for your domain management needs, ensuring seamless DNS services and exceptional support.
+excerpt: What each DNSimple plan includes, and how to work out which one you need.
+meta: What each DNSimple plan includes and what it costs. Compare plans on domains, DNS zones, email forwarding, SSL certificates, and team members before you subscribe.
 categories:
 - DNSimple
 ---

--- a/content/articles/domain-transfer.md
+++ b/content/articles/domain-transfer.md
@@ -1,6 +1,6 @@
 ---
 title: Transfer a Domain to DNSimple
-excerpt: How to transfer your registered domain to DNSimple.
+excerpt: How to transfer a domain to DNSimple from another registrar.
 meta: How to transfer a domain registration to DNSimple from another registrar. Covers authorization codes, transfer approval, timelines, and avoiding DNS downtime.
 categories:
 - Domains and Transfers

--- a/content/articles/transferring-domain-away.md
+++ b/content/articles/transferring-domain-away.md
@@ -1,7 +1,7 @@
 ---
 title: Transfer a Domain Away from DNSimple
 excerpt: How to request a transfer code and transfer a domain from DNSimple to a different registrar.
-meta: Transfer a domain from DNSimple to another registrar. Covers unlocking the domain, requesting your authorization code, and initiating the transfer.
+meta: Transfer a domain away from DNSimple to a different registrar. Covers unlocking the domain, requesting your authorization code, and initiating the outbound transfer.
 categories:
 - Domains and Transfers
 ---


### PR DESCRIPTION
Three frontmatter fields across three articles, all the same defect: `article-structure.mdc` asks for `meta` to be **a direct answer to the question the article addresses**, and these answered something else — or answered ambiguously against a sibling article. No article bodies change.

---

## 1. `dnsimple-plans` — the meta never says what a plan includes

> "Explore DNSimple's flexible plans to find the perfect fit for your domain management needs, ensuring seamless DNS services and exceptional support."

Marketing copy. It never answers the question someone landing here is asking. The `excerpt` ("Understand which plan fits your needs") had the same problem, so both are updated.

**How it showed up.** Searching **"what does my plan include"** against the support corpus:

| # | Result |
|---|---|
| 1 | Domains and Transfers at DNSimple |
| 2 | Email Services at DNSimple |
| 3 | TLDs at DNSimple |
| … | |
| 11 | **DNSimple Plans** |

The three pillar pages tie on an identical relevance score because each of their `meta` fields contains the word *"including"*, which fuzzy-matches the query's *"include"*. `dnsimple-plans` matched on **no field at all**.

So the article that should answer the question lost to three pages that merely contain a connective word.

**Why fix the article, not the pillar pages.** Stripping "including" from the 32 articles that use it would fix one query by damaging ordinary prose across the corpus — tuning content to a test rather than fixing a defect. The pillar `meta` fields are doing their job. This one wasn't.

---

## 2 & 3. The two transfer articles were competing on the same words

`domain-transfer` and `transferring-domain-away` describe **opposite operations** and used near-identical vocabulary for them:

| article | meta said |
|---|---|
| `domain-transfer` (inbound) | "…to DNSimple **from another registrar**" |
| `transferring-domain-away` (outbound) | "…from DNSimple **to another registrar**" |

Both contain "another registrar," so a search about an inbound transfer matches the outbound article roughly as well as the correct one. Searching **"transfer domains from another registrar"** put `transferring-domain-away` — the article for *leaving* — ahead of `domain-transfer`, which didn't appear in the top eight at all.

`domain-transfer`'s excerpt made it worse: *"How to transfer your registered domain to DNSimple"* never says "registrar," so the line shown in the results list omitted the word the customer searched for, while its own `meta` had it all along.

**Changes:**

- `domain-transfer` excerpt → "to DNSimple **from another registrar**", matching its meta and customer phrasing
- `transferring-domain-away` meta → "**away from** DNSimple to **a different** registrar" and "the **outbound** transfer", matching its own excerpt and no longer colliding with inbound queries

Neither is a rewrite. They say what they always said, with the direction made unambiguous.

---

## Related

Same defect class as #2074, found the same way — checking whether a field answers correctly read **on its own** rather than in the flow of the page. There, an opening sentence was wrong out of context. Here, three fields answer a different question than the one being asked.

Draft. Happy to adjust wording, particularly the features named in the plans meta, which should track whatever the pricing page currently leads with.
