### PR TITLE
Update gradual DMARC policy for RFC 9989

### DIFF
--- a/content/articles/dmarc-record-reference.md
+++ b/content/articles/dmarc-record-reference.md
@@ -12,7 +12,7 @@ This article serves as a reference for the formal structure, tags, and key techn
 
 ## DMARC record format {#dmarc-record-format}
 
-A DMARC record is a special type of [TXT record](/articles/txt-record/) published at the `_dmarc` subdomain. The record's format and tags are specified in [RFC 7489](https://datatracker.ietf.org/doc/html/rfc7489).
+A DMARC record is a special type of [TXT record](/articles/txt-record/) published at the `_dmarc` subdomain. The record's format and tags are specified in [RFC 9989](https://www.rfc-editor.org/rfc/rfc9989.html), which obsoletes RFC 7489.
 
 The value of the TXT record is a single string containing a series of semicolon-separated tags, where each tag is a key/value pair. All DMARC records must begin with the `v` tag.
 
@@ -36,17 +36,18 @@ In the DNSimple [record editor](/articles/record-editor/), a DMARC record is rep
 |:----|:-----|:---|
 | `v` | **Version**: Must be the first tag in the record. | `DMARC1` |
 | `p` | **Policy**: The policy for the organizational domain. | `none` (monitor only), `quarantine` (treat as suspicious), `reject` (block message). |
-| `pct` | **Percentage**: The percentage of messages to which the DMARC policy applies.| A number from `0` to `100`. |
+| `sp` | **Subdomain policy**: The policy to apply to subdomains. | `none`, `quarantine`, `reject` |
+| `np` | **Non-existent subdomain policy**: The policy for subdomains that do not exist in DNS. | `none`, `quarantine`, `reject` |
 | `rua` | **Reporting URI for aggregate reports**: An email address to which aggregate reports are sent. | `mailto:address@example.com` |
 | `ruf` | **Reporting URI for failure reports**: An email address to which forensic reports are sent. | `mailto:address@example.com` |
 | `adkim` | **DKIM alignment mode** | `r` (relaxed), `s` (strict) |
 | `aspf` | **SPF alignment mode**| `r` (relaxed), `s` (strict) |
 | `fo` | **Forensic options**: Controls when forensic reports are generated.| `0` (all failures), `1` (any failure), `d` (DKIM failure), `s` (SPF failure) |
-| `sp` | **Subdomain policy**: The policy to apply to subdomains. | `none`, `quarantine`, `reject` |
-| `ri` | **Report interval**: The interval in seconds between aggregate reports.| A number representing seconds. The default is `86400` (1 day). |
-| `rf` | **Report format**: The format for failure reports.| `afrf` (Authentication Failure Reporting Format) |
-| `rfmt` | **Reporting format**| `afrf` (Authentication Failure Reporting Format) |
-| `fo` | **Forensic reporting mode**| `b0`, `1`, `d`, `s` |
+| `t` | **Testing mode**: Asks receivers that support RFC 9989 to apply a softer policy while you test. | `n` (default, apply published policy), `y` (one level softer) |
+| `psd` | **Public suffix domain**: Indicates whether the record is published for a public suffix domain. | `y`, `n` |
+
+> [!NOTE]
+> RFC 9989 removes the historic `pct`, `rf`, and `ri` tags. Do not use `pct` for staged rollout. See [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for the current monitoring-to-enforcement path.
 
 ## Have more questions?
 If you have additional questions or need any assistance with your DMARC records, just [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/dmarc-record-reference.md
+++ b/content/articles/dmarc-record-reference.md
@@ -44,7 +44,7 @@ In the DNSimple [record editor](/articles/record-editor/), a DMARC record is rep
 | `aspf` | **SPF alignment mode**| `r` (relaxed), `s` (strict) |
 | `fo` | **Forensic options**: Controls when forensic reports are generated.| `0` (all failures), `1` (any failure), `d` (DKIM failure), `s` (SPF failure) |
 | `t` | **Testing mode**: Asks receivers that support RFC 9989 to apply a softer policy while you test. | `n` (default, apply published policy), `y` (one level softer) |
-| `psd` | **Public suffix domain**: Indicates whether the record is published for a public suffix domain. | `y`, `n` |
+| `psd` | **Public suffix domain**: Indicates whether the record is published for a public suffix domain. | `y`, `n`, `u` (default) |
 
 > [!NOTE]
 > RFC 9989 removes the historic `pct`, `rf`, and `ri` tags. Do not use `pct` for staged rollout. See [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for the current monitoring-to-enforcement path.

--- a/content/articles/email-dns-records-quick-reference.md
+++ b/content/articles/email-dns-records-quick-reference.md
@@ -122,7 +122,6 @@ Content: v=DMARC1; p=none; rua=mailto:dmarc@example.com
 - `ruf=mailto:address@example.com` - Forensic reports
 - `aspf=r` - Relaxed SPF alignment (default)
 - `adkim=r` - Relaxed DKIM alignment (default)
-- `pct=25` - Apply policy to 25% of emails
 
 > [!NOTE]
 > See [Set Up DMARC](/articles/set-up-dmarc/) and [Implement a Gradual DMARC Policy](/articles/implementing-a-gradual-dmarc-policy/) for details.

--- a/content/articles/implementing-a-gradual-dmarc-policy.md
+++ b/content/articles/implementing-a-gradual-dmarc-policy.md
@@ -1,7 +1,7 @@
 ---
 title: Implement a Gradual DMARC Policy
 excerpt: Step-by-step guide to gradually implementing DMARC policies, starting with monitoring and moving to quarantine and reject.
-meta: Learn how to implement DMARC gradually, starting with monitoring, then moving to quarantine, and finally to reject policies safely.
+meta: Learn how to implement DMARC gradually under RFC 9989, starting with monitoring, then quarantine, then reject, without percentage-based rollout.
 categories:
 - Emails
 ---
@@ -15,7 +15,10 @@ categories:
 
 ---
 
-Implementing DMARC gradually is a best practice that helps you identify and fix authentication issues before they affect email delivery. This guide covers the gradual implementation process, from monitoring to full enforcement.
+Implementing DMARC gradually helps you identify and fix authentication issues before they affect email delivery. Start with monitoring (`p=none`), then move to quarantine, then reject, only after reports show legitimate mail is aligned.
+
+> [!NOTE]
+> [RFC 9989](https://www.rfc-editor.org/rfc/rfc9989.html) (published May 2026) obsoletes RFC 7489 and removes the `pct` tag. Percentage-based rollout is no longer part of the DMARC specification, because receivers did not apply partial percentages consistently. Do not rely on `pct=25`, `pct=50`, or similar values for a staged rollout.
 
 ## Why implement DMARC gradually? {#why}
 
@@ -23,7 +26,7 @@ Implementing DMARC gradually helps you:
 
 - **Identify issues early:** Discover authentication problems before they affect delivery
 - **Fix problems safely:** Address issues without impacting legitimate email
-- **Build confidence:** Gradually increase enforcement as you verify everything works
+- **Build confidence:** Increase enforcement only after you verify everything works
 - **Minimize disruption:** Avoid blocking legitimate emails during implementation
 - **Learn your email ecosystem:** Understand all services sending email from your domain
 
@@ -91,7 +94,7 @@ During the monitoring phase:
 
 ## Step 2: Move to quarantine (p=quarantine) {#quarantine}
 
-Once you have fixed authentication issues and verified everything is working, move to quarantine.
+After `p=none` reporting shows that legitimate sources are aligned, start enforcement. Prefer a low-volume or low-complexity domain first if you manage more than one.
 
 ### Update DMARC record {#update-quarantine}
 
@@ -103,22 +106,14 @@ Once you have fixed authentication issues and verified everything is working, mo
 1. Find the DMARC TXT record at `_dmarc`.
 1. Update the <label>Content</label> field to:
    ```
-   v=DMARC1; p=quarantine; pct=25; rua=mailto:dmarc@yourdomain.com
+   v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com
    ```
-   `pct=25` means only 25% of failing emails will be quarantined initially.
 1. Click <label>Save</label>.
 </div>
 
-### Start with percentage enforcement
-
-Using `pct=25` (or even lower) means:
-- Only 25% of emails that fail DMARC will be quarantined
-- 75% will still be delivered (monitoring mode)
-- Helps you test the impact before full enforcement
-
 ### Monitor closely
 
-During quarantine phase:
+During the quarantine phase:
 
 1. **Monitor reports daily:**
    - Check DMARC reports more frequently
@@ -130,24 +125,13 @@ During quarantine phase:
    - Check if legitimate emails are being quarantined
    - Fix any issues immediately
 
-3. **Gradually increase percentage:**
-   - After a week with no issues, increase to `pct=50`
-   - Then `pct=75`
-   - Finally `pct=100` (full quarantine)
-
-### Full quarantine policy
-
-Once you are confident, move to full quarantine:
-
-```
-v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com
-```
-
-(Removing `pct=100` means 100% enforcement)
+3. **Revert if needed:**
+   - If legitimate mail is affected, change the policy back to `p=none` while you correct the sender
+   - Return to quarantine only after reports look clean again
 
 ## Step 3: Move to reject (p=reject) {#reject}
 
-Only move to reject after thorough testing with quarantine.
+Move to reject only after results remain clean under quarantine.
 
 ### Update DMARC record {#update-reject}
 
@@ -159,22 +143,14 @@ Only move to reject after thorough testing with quarantine.
 1. Find the DMARC TXT record at `_dmarc`.
 1. Update the <label>Content</label> field to:
    ```
-   v=DMARC1; p=reject; pct=25; rua=mailto:dmarc@yourdomain.com
+   v=DMARC1; p=reject; rua=mailto:dmarc@yourdomain.com
    ```
-   Start with `pct=25` again for safety.
 1. Click <label>Save</label>.
 </div>
 
-### Start with percentage enforcement
-
-Again, start with a low percentage:
-- Only 25% of failing emails will be rejected
-- 75% will still be quarantined
-- Allows you to test impact before full enforcement
-
 ### Monitor closely
 
-During reject phase:
+During the reject phase:
 
 1. **Monitor very closely:**
    - Check reports daily
@@ -186,20 +162,16 @@ During reject phase:
    - Verify no legitimate emails are being rejected
    - Fix any issues immediately
 
-3. **Gradually increase percentage:**
-   - After confirming no issues, increase to `pct=50`
-   - Then `pct=75`
-   - Finally `pct=100` (full reject)
+3. **Revert if needed:**
+   - If legitimate mail is affected, temporarily move back to `p=quarantine` or `p=none` while you fix authentication
+   - Return to reject only after delivery looks stable again
 
-### Full reject policy
+## About testing mode (t=y) {#testing-mode}
 
-Once you are completely confident, move to full reject:
+RFC 9989 introduces a `t` (testing mode) tag. With `t=y`, receivers that support RFC 9989 are asked to apply a policy one level softer than the published `p` value (for example, `p=reject; t=y` is treated like quarantine for failing messages).
 
-```
-v=DMARC1; p=reject; rua=mailto:dmarc@yourdomain.com
-```
-
-(Removing `pct=100` means 100% enforcement)
+> [!WARNING]
+> Do not treat `t=y` as a guaranteed delivery-impact control during the transition. Receivers that still follow older DMARC behavior may ignore an unknown `t` tag and apply the published `p` policy fully. Use monitoring reports and careful policy changes as your primary rollout controls.
 
 ## Timeline example {#timeline}
 
@@ -210,23 +182,17 @@ Here is a typical timeline for gradual DMARC implementation:
 - Identify all legitimate email sources
 - Configure SPF and DKIM for all sources
 
-**Week 5-6: Quarantine with percentage (`p=quarantine; pct=25`)**
-- Start with 25% quarantine
-- Monitor closely
-- Gradually increase to 100%
+**Week 5-6: Quarantine (`p=quarantine`)**
+- Apply quarantine for failing messages
+- Monitor reports and spam folders closely
+- Revert to `p=none` if legitimate mail is affected
 
-**Week 7-8: Full quarantine (`p=quarantine`)**
-- 100% quarantine enforcement
-- Monitor for any issues
-- Ensure everything works correctly
+**Week 7-8: Confirm quarantine is stable**
+- Keep quarantine in place while reports stay clean
+- Fix any remaining authentication gaps
 
-**Week 9-10: Reject with percentage (`p=reject; pct=25`)**
-- Start with 25% reject
-- Monitor very closely
-- Gradually increase to 100%
-
-**Week 11+: Full reject (`p=reject`)**
-- 100% reject enforcement
+**Week 9+: Reject (`p=reject`)**
+- Move to reject only after quarantine stays clean
 - Continue monitoring
 - Maintain configuration
 
@@ -267,7 +233,8 @@ Here is a typical timeline for gradual DMARC implementation:
 ## Best practices {#best-practices}
 
 - Always start with `p=none` (monitoring)
-- Use percentage enforcement (`pct`) when moving to stricter policies
+- Move to `p=quarantine`, then `p=reject`, only after reports look clean
+- Do not rely on `pct` for staged rollout
 - Monitor reports regularly throughout the process
 - Fix all authentication issues before moving forward
 - Test thoroughly at each stage
@@ -278,6 +245,7 @@ Here is a typical timeline for gradual DMARC implementation:
 ## Related articles {#related}
 
 - [Set Up DMARC](/articles/set-up-dmarc/) - Initial DMARC setup
+- [DMARC Record Reference](/articles/dmarc-record-reference/) - DMARC tags and record format
 - [SPF, DKIM, and DMARC Alignment](/articles/understanding-spf-dkim-dmarc-alignment/) - Alignment requirements
 
 ## Have more questions?

--- a/content/articles/verifying-dmarc.md
+++ b/content/articles/verifying-dmarc.md
@@ -21,15 +21,15 @@ dig +short _dmarc.hostname.com TXT
 ```
 This will return a result like:
 ```
-"v=DMARC1; p=quarantine; pct=100; rua=mailto:aggrep@hostname.com; sp=reject; aspf=r;"
+"v=DMARC1; p=quarantine; rua=mailto:aggrep@hostname.com; sp=reject; aspf=r;"
 ```
 If no result is returned, verify that you added the TXT record with the correct subdomain. Remember, the **Name** field in DNSimple should not include your domain name, otherwise it would create a record at `subdomain.yourdomain.com.yourdomain.com`.
 
 ## Verifying your DMARC with an online tool {#verifying-your-dmarc-with-an-online-tool}
-Verify your DMARC with an online tool like [this one from MX Toolbox](https://mxtoolbox.com/dmarc.aspxk). This verifies that you have set up a DMARC record, lets you know which tags and values your record contains, and alerts you to any problems with your record.
+Verify your DMARC with an online tool like [this one from MX Toolbox](https://mxtoolbox.com/dmarc.aspx). This verifies that you have set up a DMARC record, lets you know which tags and values your record contains, and alerts you to any problems with your record.
 
 ## Monitoring DMARC {#monitoring-dmarc}
-DMARC sends daily reports to the email specified in the RUA tag to provide an overview of email traffic. These reports are sent in XML format, and can be difficult to read &mdash; we recommend using a free tool, like [Postmark's reporting](https://dmarc.postmarkapp.com/), to provide a weekly, human-readable report.
+DMARC sends daily reports to the email specified in the RUA tag to provide an overview of email traffic. These reports are sent in XML format, and can be difficult to read - we recommend using a free tool, like [Postmark's reporting](https://dmarc.postmarkapp.com/), to provide a weekly, human-readable report.
 
 If your DMARC record is published correctly but messages are still failing, the problem is often an alignment issue. See [Troubleshoot Email Authentication](/articles/troubleshooting-email-authentication/) for how to diagnose alignment failures and other common causes.
 


### PR DESCRIPTION
## Summary

A [customer](https://dnsimple.groovehq.com/tickets/579190) pointed out that [Implement a Gradual DMARC Policy](https://support.dnsimple.com/articles/implementing-a-gradual-dmarc-policy/) still tells people to roll out with pct=25, then 50, 75, and 100.

[RFC 9989](https://www.rfc-editor.org/rfc/rfc9989.html) (May 2026) replaces RFC 7489 and removes the pct tag. In practice, receivers never applied those partial percentages consistently, so the old steps can make it sound safer than it really is.

This PR updates the guide to move from p=none to p=quarantine to p=reject, adds a short note on t=y (and why it is not a guaranteed soft rollout yet), and cleans up related DMARC examples/reference pages.

## Files changed

- `content/articles/implementing-a-gradual-dmarc-policy.md` — remove `pct`-based stages; update timeline and best practices; document RFC 9989 and `t=y` caveats
- `content/articles/dmarc-record-reference.md` — cite RFC 9989; remove historic `pct` / `rf` / `ri`; add `t`, `np`, `psd`; clean duplicate tags
- `content/articles/verifying-dmarc.md` — remove `pct=100` from dig example; fix MX Toolbox URL typo; replace em dash
- `content/articles/email-dns-records-quick-reference.md` — remove `pct=25` from common tags

## Verification

- Confirmed against [RFC 9989](https://www.rfc-editor.org/rfc/rfc9989.html) Abstract / Appendix A.6: `pct` removed; `t` introduced; partial percentages unreliable
- Repo search: no remaining instructional `pct=` rollout guidance under `content/articles/`
- No category YAML, redirects, or slug changes in this PR

## Notes / merge order

- Ready for review (not draft) so reviewers can be tagged before publish
- No dependent sibling PRs

## Needs SME confirmation

- None for the `pct` removal claim (primary source: RFC 9989)
- Optional: whether we should expand `np` / `psd` guidance beyond the reference table in a follow-up

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [x] Cross-links added on first mention of related concepts
- [x] Existing articles updated to link back (if applicable)
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`
- [x] Tested locally with `rake run`

## Review

- [x] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)