### PR TITLE
Add missing H2 anchors to DNS, DNSSEC, and expiration articles

### DIFF
--- a/content/articles/aaaa-record.md
+++ b/content/articles/aaaa-record.md
@@ -19,25 +19,25 @@ categories:
   <iframe loading="lazy" src="https://www.youtube.com/embed/4SGgO5MSQLg?si=I5Hu7dj7-uuwA-xs" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-## What is an AAAA record?
+## What is an AAAA record? {#definition}
 
 An AAAA record (record type 28) does the same job as an [A record](/articles/a-record/), except it points to **IPv6 addresses** instead of IPv4. It connects a domain name like `api.example.com` to the **IPv6 address** of the server that hosts it.
 
 If you know how A records work, AAAA records are pretty similar. A records point to IPv4 addresses. AAAA records point to IPv6 addresses. Same concept, different address format.
 
-## IPv6 adoption and AAAA records
+## IPv6 adoption and AAAA records {#ipv6-adoption}
 
 We've been running out of IPv4 addresses for a while now. That's why more of the internet is moving to IPv6 (Internet Protocol Version 6). IPv6 gives us way more addresses to work with, plus some improvements to how the internet works.
 
 As more networks and devices support IPv6, AAAA records are getting more common. All of DNSimple's name servers have IPv6 addresses, so they can handle queries over IPv4 or IPv6. This dual-stack setup means they work with either protocol.
 
-## How AAAA records work
+## How AAAA records work {#how-aaaa-records-work}
 
 Here's what happens when your device tries to reach a domain. If your device and network support IPv6, the DNS resolver will look for an AAAA record first. If it finds one, the connection uses IPv6. If not, it falls back to checking for an A record and uses IPv4 instead.
 
 You don't have to pick one or the other. You can set up both A and AAAA records on the same domain. That way, clients can connect using whichever protocol they support.
 
-## Common uses for AAAA records
+## Common uses for AAAA records {#common-uses}
 
 AAAA records work just like A records, but for IPv6:
 
@@ -51,7 +51,7 @@ AAAA records work just like A records, but for IPv6:
 
 The technical details are in [RFC 3596, Section 2.1](https://datatracker.ietf.org/doc/html/rfc3596#section-2.1) if you want to dig into the specification.
 
-## Managing AAAA records in DNSimple
+## Managing AAAA records in DNSimple {#managing}
 
 You can manage AAAA records using DNSimple's [record editor](/articles/record-editor/). Add new ones, remove old ones, or update IPv6 addresses as needed.
 

--- a/content/articles/announcement-change-ent-behavior.md
+++ b/content/articles/announcement-change-ent-behavior.md
@@ -22,11 +22,11 @@ As part of our ongoing commitment to DNS standards compliance and improved resol
 
 Following this update, DNSimple name servers will respond correctly to ENT queries, returning `NOERROR` with an empty answer section (a `NODATA` response) instead of incorrectly applying wildcard records. This change ensures full compliance with DNS standards and improves predictability for DNSSEC-compliant zones.
 
-## Who's impacted?
+## Who's impacted? {#impacted}
 
 This announcement impacts customers with zones that contain an Empty Non-Terminal (ENT) which is a descendant of a wildcard record.
 
-## What are Empty Non-Terminals?
+## What are Empty Non-Terminals? {#what-are-ents}
 
 In DNS, an *Empty Non-Terminal* is an intermediate domain name in a DNS hierarchy that exists only because it is a path to a deeper name, but has no records of its own. For example, in the following zone `b.c.example.com` is an Empty Non-Terminal. It has no records itself, but exists because of `a.b.c.example.com`.
 
@@ -38,7 +38,7 @@ a.b.c.example.com.   IN  CNAME   two.test.
 
 A typical example is represented by [DKIM records](https://support.dnsimple.com/articles/dkim-record/), that often generate an ENT due to their specific naming structure.
 
-## What's changing?
+## What's changing? {#changing}
 
 Let's take the previous zone as a reference:
 
@@ -59,7 +59,7 @@ Once the correct behavior is rolled out, DNSimple name servers will respond with
 
 According to the RFC, `b.c.example.com` exists as an ENT (because of `a.b.c.example.com`) and should return `NOERROR` with an empty answer section, not a wildcard response.
 
-## What you need to do
+## What you need to do {#what-to-do}
 
 Unless you are relying on the non-compliant behavior, you don't need to take any action. Instead, if you rely on the name servers returning the content of the wildcard for an ENT, you will need to create an explicit record to return the desired value **by November 30, 2025**.
 

--- a/content/articles/announcement-ns1-ns3-ip-addresses.md
+++ b/content/articles/announcement-ns1-ns3-ip-addresses.md
@@ -22,7 +22,7 @@ As part of our multi-year effort to modernize our DNS infrastructure and improve
 
 Following [the expansion of our cache edge infrastructure in 2024](https://blog.dnsimple.com/2024/10/expanding-cache-edge-network/) and the discontinuation of the legacy NS2 and NS4 IP addresses in June 2025, NS1 and NS3 are the final two name servers still pointing to the older infrastructure. The legacy IPs will be fully decommissioned on **July 6, 2026**.
 
-## What's changing
+## What's changing {#changing}
 
 The table below summarizes the IP addresses that will be deprecated, along with their replacements in the cache edge layer:
 
@@ -40,7 +40,7 @@ As part of this change, the canonical name server hostnames for NS1 and NS3 are 
 
 The legacy `ns1.dnsimple.com` and `ns3.dnsimple.com` hostnames will continue to resolve after the migration, but they will point to the new edge infrastructure.
 
-## Timeline
+## Timeline {#timeline}
 
 | Date                | Milestone                                                                                     |
 |---------------------|-----------------------------------------------------------------------------------------------|
@@ -53,7 +53,7 @@ The legacy `ns1.dnsimple.com` and `ns3.dnsimple.com` hostnames will continue to 
 | **June 22, 2026**   | Cloudflare brownout #2 — legacy IPs temporarily stop answering to surface remaining traffic.  |
 | **July 6, 2026**    | **Legacy Cloudflare IPs fully decommissioned.** Any configuration still pointing at the old IPs will stop resolving. |
 
-## Am I impacted?
+## Am I impacted? {#impacted}
 
 There are three groups of customers affected by this migration, each with a different level of action required.
 
@@ -74,7 +74,7 @@ If you independently maintain a copy of your zone at another DNS provider (not t
 
 **You must self-migrate before July 6, 2026.** If you use vanity name servers (for example `ns1.yourdomain.com`), the glue records at your registrar currently point at the legacy Cloudflare IPs. We cannot update glue records on your behalf — only your registrar can do that. If you take no action, your domains will stop resolving when the legacy IPs are decommissioned.
 
-## How to verify if you're impacted
+## How to verify if you're impacted {#verify}
 
 If you use a vanity name server, you can check whether your glue records are still on the legacy IPs by running:
 
@@ -87,11 +87,11 @@ If the response contains `162.159.24.4` or `162.159.26.4` (or the matching IPv6 
 
 For non-vanity setups, you can check which name servers your domain uses at its registrar — if they reference `ns1.dnsimple.com` or `ns3.dnsimple.com`, you fall under Group 1 or Group 2 and no action is strictly required.
 
-## What about the brownouts?
+## What about the brownouts? {#brownouts}
 
 On **June 15, 2026** and **June 22, 2026** we will briefly pause answering queries on the legacy Cloudflare IPs. Any traffic still landing on the old infrastructure will temporarily fail, making it easy to identify configurations that still need attention. If you notice intermittent resolution failures on those dates, treat it as a strong signal that you still have glue records or delegations pointing at the legacy IPs and should complete your migration before July 15, 2026.
 
-## What you need to do
+## What you need to do {#what-to-do}
 
 - **Group 1 — registered with DNSimple:** No action required. We'll handle the migration between May 1 and May 29, 2026.
 - **Group 2 — hosted at DNSimple, registered elsewhere:** Optional but recommended: update your delegation at your registrar to `ns1.dnsimple-edge.com` and `ns3.dnsimple-edge.io` any time after May 1, 2026. Otherwise, you will be migrated transparently on June 26, 2026.
@@ -101,7 +101,7 @@ You can always refer to the latest list of official DNSimple name servers here:
 
 👉 [DNSimple Name Server Reference](/articles/dnsimple-nameservers/)
 
-## Questions or concerns?
+## Questions or concerns? {#questions}
 
 If you have any questions or need help with the transition, don't hesitate to [reach out to our support team](https://dnsimple.com/contact).
 

--- a/content/articles/cloudflare-ds-record.md
+++ b/content/articles/cloudflare-ds-record.md
@@ -23,7 +23,7 @@ If you want to use Cloudflare's DNSSEC with a domain registered through DNSimple
 > [!NOTE]
 > Not all TLDs support DNSSEC. If you receive an error while adding your DS record at DNSimple, please [contact our support team](https://dnsimple.com/contact).
 
-## Enable DNSSEC at Cloudflare
+## Enable DNSSEC at Cloudflare {#enable}
 
 To use Cloudflare's DNSSEC, you will need to [change delegation to Cloudflare's name servers in DNSimple](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider). To prevent downtime, make sure to set up all of the appropriate DNS records at Cloudflare before delegating the domain to them.
 
@@ -31,7 +31,7 @@ Once the delegation is changed, you can start the process of enabling DNSSEC at 
 
 You can learn how to enable DNSSEC in Cloudflare in their [documentation](https://developers.cloudflare.com/dns/dnssec/#enable-dnssec).
 
-## Configure your DS record
+## Configure your DS record {#configure}
 Once DNSSEC is enabled at Cloudflare, you will see information about the DS record.
 
 We have field-by-field entry, so you will need to copy/paste or select the information from the drop-down menu for each field in DNSimple. Cloudflare will provide you with all of the necessary information.

--- a/content/articles/enabling-dnssec.md
+++ b/content/articles/enabling-dnssec.md
@@ -13,13 +13,13 @@ To enable DNSSEC in DNSimple, open the DNSSEC tab for your domain and follow the
 
 If you are new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/) to understand what DNSSEC is and how it works. For a comprehensive overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
 
-## Prerequisites
+## Prerequisites {#prerequisites}
 
 - The DNS resolution service must be enabled for your zone.
 - DNSimple as Secondary DNS cannot be enabled on the zone. You can read more about it in our [Why DNSSEC and Secondary DNS May Not Work Together](/articles/dnssec-and-secondary-dns/).
 - DNSSEC is applied to the whole zone, with signing keys published at the domain apex. DS records for [subdomains delegated with NS records](/articles/add-ns-records-for-subdomain/) (zone cuts) are not supported. See [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/).
 
-## Enable DNSSEC
+## Enable DNSSEC {#enable}
 1. Use the **account switcher** at the top of the page to select the appropriate account.
   ![screenshot of switching accounts](/files/switch-account.png)
 1. In your **Domain Names** list, click the name of the domain you want to enable DNSSEC on.
@@ -33,7 +33,7 @@ If you are new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/
 > [!NOTE]
 > To see how to enable DNSSEC with the API, check out our [developer documentation](https://developer.dnsimple.com/v2/domains/dnssec/#enableDomainDnssec).
 
-## What Happens Next?
+## What Happens Next? {#next}
 **If the domain is registered with DNSimple:**
 - The zone will be signed automatically.
 - The DS record will be provisioned directly at the registry. No additional action is needed.
@@ -42,7 +42,7 @@ If you are new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/
 - The zone will be signed automatically.
 - You'll receive an email with instructions to provision the DS record with your domain's registrar. This information will also be available on the **DNSSEC** tab during the setup process.
 
-## Troubleshooting
+## Troubleshooting {#troubleshooting}
 
 If you encounter issues after enabling DNSSEC, see [Troubleshoot DNSSEC](/articles/troubleshooting-dnssec-configurations/) for comprehensive guidance on diagnosing and resolving common DNSSEC problems.
 

--- a/content/articles/export-domain-names-to-file.md
+++ b/content/articles/export-domain-names-to-file.md
@@ -17,7 +17,7 @@ You can export your domain names from DNSimple to a .CSV or .ZIP file for backup
 
 ---
 
-## How to export your domain names list as a .CSV file
+## How to export your domain names list as a .CSV file {#export}
 
 1. Visit the Domain Names page for your account.
 1. Click **Export** in the top right.
@@ -28,7 +28,7 @@ You can export your domain names from DNSimple to a .CSV or .ZIP file for backup
 > [!NOTE]
 > If you have more than 10k domains in your account, you'll receive the attachment as a .ZIP file.
 
-## What's in the .CSV file?
+## What's in the .CSV file? {#contents}
 
 We include domain registration and DNS zone details in the exported file:
 

--- a/content/articles/heroku-error-ssl.md
+++ b/content/articles/heroku-error-ssl.md
@@ -18,7 +18,7 @@ categories:
 
 SSL certificate errors on Heroku typically occur when the certificate does not match the domain or when it is not properly installed. For general SSL error guidance, see [Troubleshooting SSL Certificate Errors](/articles/troubleshooting-ssl-certificate-errors/).
 
-## Invalid Common Name (*.heroku.com or *.herokuapp.com)
+## Invalid Common Name (*.heroku.com or *.herokuapp.com) {#invalid-common-name}
 
 You pointed your domain to Heroku to use an SSL certificate but you are receiving an error such as _Troubleshooting Heroku SSL errors_, _Invalid common name_ or _The certificate for this website is invalid_.
 

--- a/content/articles/setting-up-null-mx-records.md
+++ b/content/articles/setting-up-null-mx-records.md
@@ -174,7 +174,7 @@ After removing the null MX record, you can set up email forwarding or email host
 
 **Plan for future needs:** If there is any possibility you will need email in the future, do not use null MX records.
 
-## Related topics
+## Related topics {#related}
 
 - [What Are Null MX Records?](/articles/what-are-null-mx-records/) - Explanation of null MX records and their purpose
 - [What Is an MX Record?](/articles/mx-record/) - General information about MX records

--- a/content/articles/setting-up-spf.md
+++ b/content/articles/setting-up-spf.md
@@ -123,7 +123,7 @@ If you are experiencing issues with your SPF record, [contact support](https://d
 
 The specification for the Sender Policy Framework is primarily defined in [RFC 7208](https://datatracker.ietf.org/doc/html/rfc7208), which supersedes RFC 4408.
 
-## Related topics
+## Related topics {#related}
 
 ### Email authentication
 - [What Is an SPF Record?](/articles/spf-record/) - Introduction to SPF records

--- a/content/articles/system-records.md
+++ b/content/articles/system-records.md
@@ -12,7 +12,7 @@ System records are a specific set of DNS records that DNSimple automatically cre
 
 These records are managed directly by the DNSimple system to ensure optimal performance, reliability, and adherence to DNS standards. Because of their critical nature, they cannot be directly edited or removed from the standard record editor within your DNSimple account.
 
-## What system records include and why they are necessary
+## What system records include and why they are necessary {#what-they-include}
 
 When your domain is actively resolving using DNSimple's name servers, the system records typically include:
 
@@ -32,7 +32,7 @@ You can typically view these system records in your domain's **Manage** page wit
 
 ![screenshot of managing system records](/files/manage-system-records.png)
 
-## Why system records cannot be edited
+## Why system records cannot be edited {#not-editable}
 
 System records are non-editable in the standard record editor for several key reasons:
 

--- a/content/articles/troubleshooting-dnssec-configurations.md
+++ b/content/articles/troubleshooting-dnssec-configurations.md
@@ -16,7 +16,7 @@ If you're new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/)
 {:toc}
 ---
 
-## Is DNSSEC active for your DNSimple domain?
+## Is DNSSEC active for your DNSimple domain? {#is-active}
 
 There are two ways to check this:
 
@@ -31,7 +31,7 @@ See [External DNSSEC Diagnostic Tools](/articles/external-dnssec-diagnostic-tool
 
 After identifying the reported error, return here and follow the resolution steps below.
 
-## Common DNSSEC issues and their resolutions
+## Common DNSSEC issues and their resolutions {#common-issues}
 This section details the most frequent problems identified by the tools and provides actionable steps to fix them, ensuring your DNSSEC is properly set up with DNSimple.
 
 ### Incorrect or missing DS records in the parent zone (registrar not DNSimple)
@@ -53,7 +53,7 @@ This section details the most frequent problems identified by the tools and prov
 **Resolution steps**:
 1. **Check your email inbox**: Check your email for any automated DNSSEC notifications, and follow the included instructions. Our system will automatically notify you when a DNSSEC operation doesn't complete successfully.
 
-## Contact DNSimple support
+## Contact DNSimple support {#contact}
 Please reach out to our [expert support team](https://www.dnsimple.com/contact) at DNSimple about any DNSSEC-related issues.
 
 Before contacting support, please gather the following information:

--- a/content/articles/types-of-dnssec-keys.md
+++ b/content/articles/types-of-dnssec-keys.md
@@ -9,12 +9,12 @@ categories:
 # What Are the Types of DNSSEC Keys?
 When you enable DNSSEC, your domain is protected using two types of keys that work together to keep your DNS information trusted and secure.
 
-## Zone Signing Key (ZSK)
+## Zone Signing Key (ZSK) {#zone-signing-key-zsk}
 The Zone Signing Key is used to sign your domain's DNS records, like A, MX, and CNAME records.
 
 This allows DNS resolvers to check that your DNS information hasn't been tampered with and is coming from the correct source.
 
-## Key Signing Key (KSK)
+## Key Signing Key (KSK) {#key-signing-key-ksk}
 The Key Signing Key signs your [DNSKEY record](/articles/dnskey-records-explained/), which contains the public part of both your ZSK and KSK.
 
 This signature allows DNS resolvers to verify that the keys protecting your domain can be trusted.
@@ -24,7 +24,7 @@ It also connects your domain to the global [DNSSEC chain of trust](/articles/dns
 - When a DNS resolver looks up your domain, it first checks this DS record to confirm it can trust your KSK.
 - Once the resolver trusts your KSK, it can then trust your ZSK and, in turn, trust your DNS records.
 
-## Learn more
+## Learn more {#learn-more}
 
 To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To understand how DS records connect your KSK to the parent zone, see [What Are DS Records?](/articles/what-are-ds-records/). For information about DNSSEC key rotation, see [Rotate DNSSEC Keys](/articles/rotate-dnssec-key/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
 

--- a/content/articles/url-record-format-details.md
+++ b/content/articles/url-record-format-details.md
@@ -10,7 +10,7 @@ categories:
 
 This document serves as a reference for the structure and underlying technical implementation of DNSimple's proprietary [URL record type](/articles/url-record/). This record type facilitates web (HTTP/HTTPS) redirects directly through DNSimple's services.
 
-## URL record format
+## URL record format {#format}
 
 The URL record is a special record type developed by DNSimple and is **not defined by any standard RFC**. Its functionality is proprietary to DNSimple's name servers and redirector service.
 
@@ -22,7 +22,7 @@ In DNSimple's record editor, the URL record is represented by the following conf
 | TTL | The time-to-live in seconds. This is the amount of time the record is allowed to be cached by a DNS resolver.| An unsigned 32-bit integer. Standard DNS TTL values apply. |
 | URL | The full destination URL to which the source hostname should redirect.|Must be a valid, complete URL including the scheme (e.g., `https://www.example.com/new-page`). |
 
-## Technical implementation: how DNSimple exposes URL records
+## Technical implementation: how DNSimple exposes URL records {#implementation}
 
 You configure a URL record in the DNSimple interface, and DNSimple handles its technical implementation at the DNS level. The URL record itself does not exist as a standard DNS record type that is directly served to clients.
 

--- a/content/articles/what-are-null-mx-records.md
+++ b/content/articles/what-are-null-mx-records.md
@@ -115,7 +115,7 @@ In DNSimple's Record Editor, you would create this as:
 
 The single dot (`.`) represents the root of the DNS hierarchy and is the standard way to represent "no mail server" in DNS.
 
-## Related topics
+## Related topics {#related}
 
 - [Set Up Null MX Records](/articles/setting-up-null-mx-records/) - Step-by-step guide to configuring null MX records
 - [What Is an MX Record?](/articles/mx-record/) - General information about MX records

--- a/content/articles/what-happens-when-domain-expires.md
+++ b/content/articles/what-happens-when-domain-expires.md
@@ -17,7 +17,7 @@ categories:
 
 When a domain expires it becomes inactive immediately and all the services attached to it cease to function. You can't make any updates to the domain while it is expired. The domain will remain available for reactivation at your regular domain rate under your list of Expired Domains.
 
-## Why domains expire
+## Why domains expire {#why}
 
 Domain registrations are time-limited contracts between you and the domain registry. When the registration period ends, the domain expires unless it has been renewed. This expiration mechanism ensures that abandoned or unused domains can eventually return to the available pool for others to register. The expiration process also protects registrants by providing recovery periods before a domain is permanently released.
 
@@ -26,7 +26,7 @@ To reactivate an expired domain, take a look at our [article on how to renew a d
 > [!WARNING]
 > Certain domain names are [auto-renew only](/articles/domain-auto-renewal/) and cannot be renewed manually. For these domains there is no grace period. Once they've expired it's not possible to recover them.
 
-## ICANN TLDs
+## ICANN TLDs {#icann-tlds}
 
 ### Grace period
 
@@ -65,7 +65,7 @@ To reactivate a domain in redemption status, please take a look at our [article 
 
 The deletion period is the final stage before a domain is permanently released. This period allows registries to process the deletion and update their systems. Once a domain enters this period, there is no way to recover it, even by the original registrant. After deletion, the domain becomes available for registration by anyone, and there is no guarantee that the previous owner will be able to register it again.
 
-## Non-ICANN TLDs
+## Non-ICANN TLDs {#non-icann-tlds}
 
 TLDs outside ICANN regulations, such as `.UK`, `.IO`, `.SH`, etc. may not follow the rules mentioned above. They may or may not provide a grace period and a redemption period. If they do, the length of the period may be different.
 

--- a/content/articles/what-is-dnssec.md
+++ b/content/articles/what-is-dnssec.md
@@ -13,7 +13,7 @@ categories:
   <iframe loading="lazy" src="https://www.youtube.com/embed/7JWpgka8zBQ" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-## The meaning of DNSSEC
+## The meaning of DNSSEC {#meaning}
 
 DNSSEC stands for Domain Name System Security Extensions. It's part of DNS security best practices, because it adds a layer of security to DNS by allowing DNS records to be digitally signed. This helps ensure that the responses users receive from a DNS lookup are authentic and haven't been tampered with along the way.
 
@@ -21,13 +21,13 @@ Without DNSSEC, attackers can exploit vulnerabilities in DNS to redirect users t
 
 Want to learn about DNSSEC from a taco? Check out our [DNSSEC comic](https://howdnssec.works) for a fun explanation, and get answers to your burning questions on what DNS security is and how DNSSEC helps ensure DNS protection. 
 
-## Why DNSSEC is a good DNS security tool
+## Why DNSSEC is a good DNS security tool {#why}
 
 Although DNS is a fundamental part of the Internet's infrastructure, it lacks built-in security to verify that the information it returns is authentic or unchanged. This makes it possible for attackers to manipulate DNS responses and redirect users without them ever knowing.
 
 DNSSEC addresses this by allowing resolvers to validate the origin of DNS data. It ensures that what you receive genuinely comes from the correct source and hasn't been altered in transit. If you want to use secure DNS, we recommend [enabling DNSSEC](/articles/enabling-dnssec/).
 
-## How does DNSSEC work?
+## How does DNSSEC work? {#how-it-works}
 
 When DNSSEC is enabled for a domain, it adds an extra layer of information to DNS responses, allowing resolvers to verify that each answer is authentic. To learn more about the concepts mentioned here, see [The DNSSEC Chain of Trust](/articles/dnssec-chain-of-trust/).
 
@@ -50,7 +50,7 @@ DNSSEC is not outdated. The protocol is actively maintained by the IETF, with [R
 
 If your domain's TLD supports DNSSEC, enabling it is a recommended security best practice. DNSSEC protects your visitors from being redirected to malicious sites through DNS tampering. At DNSimple, enabling DNSSEC is straightforward - see [Enable DNSSEC](/articles/enabling-dnssec/) for step-by-step instructions. Before enabling, review [DNSSEC Compatibility With Other DNSimple Features](/articles/dnssec-compatibility/) to confirm your setup is compatible.
 
-## Learn more about DNSSEC
+## Learn more about DNSSEC {#learn-more}
 
 For a comprehensive overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/).
 


### PR DESCRIPTION
`article-structure.mdc` requires an explicit `{#anchor}` on every H2 so cross-links stay stable when a heading is reworded. 249 H2s across the corpus don't have one. This covers the 45 in the Diátaxis-treated categories (DNS, DNSSEC, Domains and Transfers, SSL Certificates, Name Servers).

## What changed

16 articles, 45 anchors. Every changed line is an H2 heading — nothing else was touched.

Boilerplate H2s (`Have more questions?`, `Before starting`) are deliberately excluded, since the rule says those must *not* carry an explicit anchor.

## Anchor naming

Short, meaningful names where nothing links to the heading yet (`#prerequisites`, `#troubleshooting`, `#what-to-do`).

**Where something already links to a heading, the anchor adopts the existing kramdown auto-slug** rather than a shorter name. Adding an explicit anchor replaces the auto-generated fragment id, so a shorter name would silently break inbound links. That applies to `#zone-signing-key-zsk`, `#key-signing-key-ksk`, and `#how-aaaa-records-work`.

## Verification

- Audited every fragment link in the corpus before and after: **0 broken links**, 36 new stable fragments
- No duplicate anchors within any file
- Banned-character, link-format, and filename checks clean across all 16 files

⚠️ `bundle exec rake` has **not** been run against this branch — worth doing before review.