### PR TITLE
Align article H1s with frontmatter titles and update category entries

### DIFF
--- a/categories/dns.yaml
+++ b/categories/dns.yaml
@@ -56,7 +56,7 @@ Explanation:
     - How Does Zone Verification Work?
     - What Is Zone Verification and Why Does It Matter?
     - How Long Does a New DNS Record Take to Resolve?
-    - How DNS Caching and TTL Affect Record Changes
+    - How DNS Caching and TTL Affect Delegation and Record Changes
     - Recursive vs Authoritative DNS Resolvers
     - Protection Against DDoS Attacks
     - Why DNSSEC and Secondary DNS May Not Work Together
@@ -91,7 +91,7 @@ How to:
     - Activate and Deactivate a DNS Zone
     - Export Zone File
     - Import Zone File
-    - Zone NS Records
+    - Updating Zone NS Records for a Hosted Domain
     - Check Resolution Status
     - Check DNS Cache
     - How to Use dig
@@ -116,7 +116,7 @@ How to:
     - Refresh and Import Integrated Zones
     - Sync Integrated Zone Records Between DNS Providers
     - How to Use CoreDNS as an Integrated DNS Provider
-    - How to Use Route 53 as an Integrated DNS Provider
+    - How to Use Amazon Route 53 as an Integrated DNS Provider
     - Auto-Import DNS Records
   DNSSEC Management:
     - Add and Remove DS Records
@@ -128,7 +128,7 @@ How to:
     - Troubleshoot Empty Non-Terminal Issues
     - Troubleshoot Record Resolution Issues
     - How to Fix Empty Responses from Empty Non-Terminals
-    - Email and Subdomain Issues After Delegation
+    - Troubleshoot Email or Subdomains After Delegation Changes
 
 Reference:
   - DNS Glossary

--- a/categories/dnssec.yaml
+++ b/categories/dnssec.yaml
@@ -1,5 +1,5 @@
 Getting Started:
-  - "DNSSEC at DNSimple"
+  - "DNS Security Extensions (DNSSEC) at DNSimple"
 
 Explanation:
   DNSSEC Basics:

--- a/categories/domains_and_transfers.yaml
+++ b/categories/domains_and_transfers.yaml
@@ -21,6 +21,7 @@ Explanation:
     - "Domain Masking"
     - "Activity Tracking"
     - "Domain Access Control"
+    - "Integrated Domain Providers at DNSimple"
     - "What Are Vanity Name Servers?"
     - "Web Hosting Support"
     - "DNSimple and Handshake (HNS)"
@@ -32,7 +33,7 @@ Explanation:
     - "ICANN 60-Day Lock After Change of Registrant"
     - "NIS2 Contact Email Verification"
   "TLDs":
-    - "Regulated Top-Level Domains"
+    - "Regulated and Highly-Regulated Top-Level Domains"
 
 "How to":
   "Domain Registration & Setup":

--- a/categories/emails.yaml
+++ b/categories/emails.yaml
@@ -63,7 +63,7 @@ How to:
     - "Email Forwarding Not Working"
     - "Email Forwarding Issues with Outlook and Yahoo"
     - "Troubleshoot Email Authentication"
-    - "Email and Subdomain Issues After Delegation"
+    - "Troubleshoot Email or Subdomains After Delegation Changes"
 
 Reference:
   Email Forwarding:

--- a/categories/enterprise.yaml
+++ b/categories/enterprise.yaml
@@ -6,8 +6,10 @@
 
 Security:
   - "Domain Access Control"
+  - "What is Domain Access Control?"
   - "Multi-Account Management for Enterprise Clients"
   - "Multi-Factor Authentication"
+  - "What is SSO at DNSimple"
   - "Enforce Account-Wide Multi-Factor Authentication"
   - "Entra as an Identity Provider"
   - "Okta as an Identity Provider"

--- a/categories/integrations.yaml
+++ b/categories/integrations.yaml
@@ -12,7 +12,7 @@ Integrated Domain Providers:
 Integrated DNS Providers:
 - "What Are Integrated DNS Providers and Why Use Them?"
 - "Integrated DNS Provider Amazon Route 53"
-- "How to Use Route 53 as an Integrated DNS Provider"
+- "How to Use Amazon Route 53 as an Integrated DNS Provider"
 - "Integrated DNS Provider Azure DNS"
 - "Integrated DNS Provider CoreDNS"
 - "How to Use CoreDNS as an Integrated DNS Provider"

--- a/categories/name_servers.yaml
+++ b/categories/name_servers.yaml
@@ -4,20 +4,20 @@ Getting started:
 
 Explanation:
   Name server concepts:
-    - "What is a name server?"
+    - "What is a Name Server?"
     - "What Are Vanity Name Servers?"
     - "What Are Glue Records?"
     - "Domain Delegation and Name Servers Explained"
   Resolver roles:
     - "Recursive vs Authoritative DNS Resolvers"
   Delegation and caching:
-    - "How DNS Caching and TTL Affect Record Changes"
+    - "How DNS Caching and TTL Affect Delegation and Record Changes"
 
 How-to:
   Domain delegation:
     - "Pointing a Domain to DNSimple"
     - "Delegate a Domain from Another Registrar to DNSimple"
-    - "Delegating a Domain Registered with DNSimple"
+    - "Delegate a DNSimple-Registered Domain to DNSimple Name Servers"
   Delegation settings and child zones:
     - "Change delegation to another DNS provider"
     - "Adding NS Records for a Subdomain"
@@ -27,7 +27,7 @@ How-to:
 
 Troubleshooting:
   After delegation:
-    - "Email and Subdomain Issues After Delegation"
+    - "Troubleshoot Email or Subdomains After Delegation Changes"
   DNSimple name servers:
     - "Troubleshoot DNSimple Name Servers"
 

--- a/categories/ssl_certificates.yaml
+++ b/categories/ssl_certificates.yaml
@@ -78,10 +78,10 @@ Reference:
   Certificate Authorities:
     - "SSL Certificate Authorities Used by DNSimple"
   Capabilities and Limits:
-    - "Elliptic Curve Cryptography (ECC) SSL Certificates"
-    - "Extended Validation (EV) SSL Certificates"
+    - "Do You Support Elliptic Curve Cryptography (ECC) SSL Certificates?"
+    - "Do You Support Extended Validation (EV) SSL Certificates?"
     - "Do you support multi-year SSL certificates?"
-    - "Can I Upgrade to a Wildcard SSL Certificate?"
+    - "Can I Upgrade a Single-Hostname SSL Certificate to a Wildcard SSL Certificate?"
     - "SHA-2 SSL Certificates"
   Frequently Asked Questions:
     - "SSL Certificates Frequently Asked Questions"

--- a/categories/tlds.yaml
+++ b/categories/tlds.yaml
@@ -3,7 +3,7 @@ Getting Started:
   - "TLDs at DNSimple"
 TLD Basics:
   - "What is a TLD?"
-  - "Regulated Top-Level Domains"
+  - "Regulated and Highly-Regulated Top-Level Domains"
 TLDs:
   - ".ALSACE Domains"
   - ".AIRFORCE Domains"

--- a/content/articles/a-record.md
+++ b/content/articles/a-record.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# A Records
+# What Is an A Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/aaaa-record.md
+++ b/content/articles/aaaa-record.md
@@ -6,7 +6,7 @@ categories:
   - DNS
 ---
 
-# AAAA Records
+# What Is an AAAA Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/amazon-route-53-integration-demo.md
+++ b/content/articles/amazon-route-53-integration-demo.md
@@ -1,5 +1,5 @@
 ---
-title: How to Use Route 53 as an Integrated DNS Provider
+title: How to Use Amazon Route 53 as an Integrated DNS Provider
 excerpt: An introductory tutorial to integrating Amazon Route 53 with DNSimple.
 meta: Tutorial on integrating Amazon Route 53 with DNSimple. Manage Route 53 zones and DNS records alongside your DNSimple domains in one dashboard.
 categories:

--- a/content/articles/caa-record.md
+++ b/content/articles/caa-record.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# CAA Records
+# What Is a CAA Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/can-elliptic-curve-key-ssl-certificates.md
+++ b/content/articles/can-elliptic-curve-key-ssl-certificates.md
@@ -1,5 +1,5 @@
 ---
-title: Elliptic Curve Cryptography (ECC) SSL Certificates
+title: Do You Support Elliptic Curve Cryptography (ECC) SSL Certificates?
 excerpt: All DNSimple SSL certificates use ECDSA keys by default. RSA is available as an alternative for all certificate products.
 meta: DNSimple issues SSL certificates with ECDSA (ECC) keys by default. RSA is available via the signature algorithm selector. Sectigo also supports custom CSRs.
 categories:

--- a/content/articles/can-ev-ssl-certificates.md
+++ b/content/articles/can-ev-ssl-certificates.md
@@ -1,5 +1,5 @@
 ---
-title: Extended Validation (EV) SSL Certificates
+title: Do You Support Extended Validation (EV) SSL Certificates?
 excerpt: DNSimple does not offer EV or OV SSL certificates. All DNSimple certificates are domain-validated (DV).
 meta: DNSimple does not offer EV or OV SSL certificates. All certificates are domain-validated (DV) and provide the same cryptographic security as EV and OV.
 categories:

--- a/content/articles/can-upgrade-single-hostname-ssl-certificate-to-wildcard.md
+++ b/content/articles/can-upgrade-single-hostname-ssl-certificate-to-wildcard.md
@@ -1,5 +1,5 @@
 ---
-title: Can I Upgrade to a Wildcard SSL Certificate?
+title: Can I Upgrade a Single-Hostname SSL Certificate to a Wildcard SSL Certificate?
 excerpt: You cannot upgrade a single-name SSL certificate to a wildcard. You must purchase a new wildcard certificate separately.
 meta: DNSimple does not support upgrading a single-name SSL certificate to a wildcard. Learn the refund policy and how to order a wildcard certificate.
 categories:

--- a/content/articles/cname-record.md
+++ b/content/articles/cname-record.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# CNAME Records
+# What Is a CNAME Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/delegating-dnsimple-hosted.md
+++ b/content/articles/delegating-dnsimple-hosted.md
@@ -6,7 +6,7 @@ categories:
 - Name Servers
 ---
 
-# Delegating a Domain registered with another Registrar to DNSimple
+# Delegate a Domain from Another Registrar to DNSimple
 
 ### Table of Contents {#toc}
 

--- a/content/articles/delegating-dnsimple-registered.md
+++ b/content/articles/delegating-dnsimple-registered.md
@@ -1,12 +1,12 @@
 ---
-title: Delegating a Domain Registered with DNSimple
+title: Delegate a DNSimple-Registered Domain to DNSimple Name Servers
 excerpt: How to delegate a domain registered with DNSimple to DNSimple's name servers.
 meta: Point your DNSimple-registered domain to DNSimple name servers to resolve DNS records configured in your DNSimple account.
 categories:
 - Name Servers
 ---
 
-# Delegating a Domain registered with DNSimple to DNSimple
+# Delegate a DNSimple-Registered Domain to DNSimple Name Servers
 
 Switching the [name servers](/articles/what-is-a-nameserver/) to DNSimple will cause the domain to resolve using the DNS records configured in your DNSimple account. For the full name server documentation index, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).
 

--- a/content/articles/dkim-record.md
+++ b/content/articles/dkim-record.md
@@ -7,7 +7,7 @@ categories:
 - Emails
 ---
 
-# DKIM Records
+# What Is a DKIM Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/dmarc-record.md
+++ b/content/articles/dmarc-record.md
@@ -7,7 +7,7 @@ categories:
 - Emails
 ---
 
-# DMARC Records
+# What Is a DMARC Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/dnssec.md
+++ b/content/articles/dnssec.md
@@ -1,5 +1,5 @@
 ---
-title: DNSSEC at DNSimple
+title: DNS Security Extensions (DNSSEC) at DNSimple
 excerpt: Enable, manage, and troubleshoot DNSSEC for your domains at DNSimple, with automatic key rotation and DS-data and KEY-data interface support.
 meta: DNSSEC at DNSimple. Enable, manage, and troubleshoot DNSSEC with automatic key rotation, DS record provisioning, and key lifecycle management.
 categories:

--- a/content/articles/empty-non-terminals.md
+++ b/content/articles/empty-non-terminals.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# Empty Non-Terminals
+# What Are Empty Non-Terminals (ENT)?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/how-dns-caching-and-ttl-affect-delegation-and-record-changes.md
+++ b/content/articles/how-dns-caching-and-ttl-affect-delegation-and-record-changes.md
@@ -1,5 +1,5 @@
 ---
-title: How DNS Caching and TTL Affect Record Changes
+title: How DNS Caching and TTL Affect Delegation and Record Changes
 excerpt: Why delegation and DNS record updates can look delayed worldwide, and how resolver caching, TTL, and negative caching interact with registry data.
 meta: DNS resolvers cache delegation and record answers for the duration of their TTL. Registry updates can appear before old cached NS data expires.
 categories:

--- a/content/articles/how-to-determine-certificate-authority.md
+++ b/content/articles/how-to-determine-certificate-authority.md
@@ -6,7 +6,7 @@ categories:
 - SSL Certificates
 ---
 
-# How Do I Determine the Certificate Authority That Signed My SSL Certificate?
+# How to Find Your SSL Certificate Authority
 
 You can determine which certificate authority (CA) signed your SSL certificate by checking the certificate details in your browser or using command-line tools.
 

--- a/content/articles/how-to-different-ssl-domain-validation-email.md
+++ b/content/articles/how-to-different-ssl-domain-validation-email.md
@@ -6,7 +6,7 @@ categories:
 - SSL Certificates
 ---
 
-# How to Select a Different SSL Certificate Domain Validation Email
+# Change Your SSL Certificate Validation Email
 
 ### Table of Contents {#toc}
 

--- a/content/articles/how-to-issue-new-transfer-when-transfer-denied.md
+++ b/content/articles/how-to-issue-new-transfer-when-transfer-denied.md
@@ -6,7 +6,7 @@ categories:
   - Domains and Transfers
 ---
 
-# How can I issue a new transfer order when a transfer is denied?
+# How to Retry a Denied Domain Transfer
 
 If you receive a message from your current registrar that a domain transfer was denied it is likely for one of the following reasons:
 

--- a/content/articles/integrated-dns-provider-amazon-route53.md
+++ b/content/articles/integrated-dns-provider-amazon-route53.md
@@ -7,7 +7,7 @@ categories:
 - Integrations
 ---
 
-# Amazon Route 53
+# Integrated DNS Provider Amazon Route 53
 
 ### Table of Contents {#toc}
 

--- a/content/articles/integrated-dns-provider-azure-dns.md
+++ b/content/articles/integrated-dns-provider-azure-dns.md
@@ -7,7 +7,7 @@ categories:
 - Integrations
 ---
 
-# Azure DNS
+# Integrated DNS Provider Azure DNS
 
 ### Table of Contents {#toc}
 

--- a/content/articles/integrated-dns-provider-coredns.md
+++ b/content/articles/integrated-dns-provider-coredns.md
@@ -7,7 +7,7 @@ categories:
 - Integrations
 ---
 
-# CoreDNS
+# Integrated DNS Provider CoreDNS
 
 ### Table of Contents {#toc}
 

--- a/content/articles/integrated-domain-providers.md
+++ b/content/articles/integrated-domain-providers.md
@@ -7,7 +7,7 @@ categories:
 - Integrations
 ---
 
-# Integrated Domain Providers
+# Integrated Domain Providers at DNSimple
 
 ### Table of Contents {#toc}
 

--- a/content/articles/ipv6-support.md
+++ b/content/articles/ipv6-support.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# IPv6 Support
+# IPv6 Domain Resolution Reference
 
 All [DNSimple name servers](/articles/dnsimple-nameservers/) have IPv6 addresses and are configured to respond to queries over the IPv6 protocol. This means a client's DNS query can be resolved natively over IPv6, helping ensure your domain is accessible to users on IPv6-only networks.
 

--- a/content/articles/name-servers-interface-reference.md
+++ b/content/articles/name-servers-interface-reference.md
@@ -6,7 +6,7 @@ categories:
 - Name Servers
 ---
 
-# DNSimple Interface Reference for Name Server Management
+# Name Server Management Interface Reference
 
 ### Table of Contents {#toc}
 

--- a/content/articles/ns-record.md
+++ b/content/articles/ns-record.md
@@ -5,7 +5,7 @@ meta: Learn what NS records are, their importance in DNS management, and how to 
 categories:
 - DNS
 ---
-# NS Records 
+# What Is an NS Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/pool-record.md
+++ b/content/articles/pool-record.md
@@ -5,7 +5,7 @@ meta: Discover what a POOL record is and learn how to easily create and manage P
 categories:
 - DNS
 ---
-# Pool Records
+# What Is a POOL Record?
 
 ### Table of Contents {#toc}
 * TOC

--- a/content/articles/record-editor-simple-field.md
+++ b/content/articles/record-editor-simple-field.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# Understand DNSimple's Record Editors Simple vs. Field-Specific
+# DNSimple Record Editors: Simple vs. Field-Specific
 
 DNSimple provides two distinct interfaces for adding and managing your DNS records in the [Record Editor](/articles/record-editor/), each designed to optimize for different use cases: the simple editor and the record fields editor. While both achieve the same goal of configuring your domain's DNS, they offer different levels of guidance and flexibility. Understanding when to use each can streamline your DNS management process.
 

--- a/content/articles/redirector.md
+++ b/content/articles/redirector.md
@@ -6,7 +6,7 @@ categories:
 - Domains and Transfers
 ---
 
-# Redirector
+# DNSimple Redirector
 
 ### Table of Contents {#toc}
 

--- a/content/articles/reverse-dns-ptr-records.md
+++ b/content/articles/reverse-dns-ptr-records.md
@@ -5,7 +5,7 @@ meta: Learn how reverse DNS lookups and PTR records work and why they are critic
 categories:
 - DNS
 ---
-# What are Reverse DNS Lookups and PTR Records?
+# What Are Reverse DNS Lookups and PTR Records?
 
 ### Table of Contents {#toc}
 * TOC

--- a/content/articles/service-binding-records.md
+++ b/content/articles/service-binding-records.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# Service Binding Records (SVCB and HTTPS)
+# What Are Service Binding Records (SVCB and HTTPS)?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/soa-record.md
+++ b/content/articles/soa-record.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# DNS SOA Records
+# What Is an SOA Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/spf-record.md
+++ b/content/articles/spf-record.md
@@ -7,7 +7,7 @@ categories:
 - Emails
 ---
 
-# SPF Records
+# What Is an SPF Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/srv-record.md
+++ b/content/articles/srv-record.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# SRV Records
+# What Is an SRV Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/sshfp-records.md
+++ b/content/articles/sshfp-records.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# What are SSHFP Records?
+# What Are SSHFP Records?
 
 An SSHFP (SSH FingerPrint, record type 44) record is a type of DNS resource record that is used to securely publish SSH host key fingerprints in the [Domain Name System (DNS)](/articles/what-is-dns/). The primary purpose of an SSHFP record is to provide a way for SSH clients to automatically and securely verify the authenticity of an SSH server's public key, helping to protect against man-in-the-middle (MITM) attacks during SSH connections.
 

--- a/content/articles/tlds-regulated.md
+++ b/content/articles/tlds-regulated.md
@@ -1,5 +1,5 @@
 ---
-title: Regulated Top-Level Domains
+title: Regulated and Highly-Regulated Top-Level Domains
 excerpt: Information about regulated and highly-regulated TLDs.
 meta: Regulated and highly-regulated top-level domains (TLDs), their requirements, restrictions, and implications for domain registration at DNSimple.
 categories:

--- a/content/articles/tlsa-record.md
+++ b/content/articles/tlsa-record.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# TLSA Records
+# What Is a TLSA Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/troubleshoot-email-subdomains-after-delegation-changes.md
+++ b/content/articles/troubleshoot-email-subdomains-after-delegation-changes.md
@@ -1,5 +1,5 @@
 ---
-title: Email and Subdomain Issues After Delegation
+title: Troubleshoot Email or Subdomains After Delegation Changes
 excerpt: Steps to verify delegation to DNSimple and isolate why mail or a subdomain still fails after NS updates.
 meta: After delegation changes, confirm DNSimple name servers with dig, then check MX and subdomain records on the authoritative zone. Clear resolver cache if needed.
 categories:

--- a/content/articles/txt-record-format.md
+++ b/content/articles/txt-record-format.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# TXT Record Formatting and Long Record Handling
+# TXT Record Format and Long Record Handling
 This document serves as a reference for the technical specifications, formatting rules, and validation constraints that apply to [TXT (Text) records](/articles/txt-record/)  in the [Domain Name System](/articles/what-is-dns/), with a specific focus on how DNSimple processes and manages these records, particularly for long content strings.
 
 ## TXT record format basics {#txt-record-format-basics}

--- a/content/articles/txt-record.md
+++ b/content/articles/txt-record.md
@@ -6,7 +6,7 @@ categories:
 - DNS
 ---
 
-# TXT Records
+# What Is a TXT Record?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/what-are-ds-records.md
+++ b/content/articles/what-are-ds-records.md
@@ -8,7 +8,7 @@ categories:
 - Enterprise
 ---
 
-# What are DS records?
+# What Are DS Records?
 
 A Delegation Signer (DS) record is a critical DNSSEC record that connects your domain's cryptographic identity to the global DNS system. It acts as a trusted reference from your parent zone (like .com or .org) to your domain's Key Signing Key (KSK) by containing a cryptographic digest (hash) of that key.
 

--- a/content/articles/what-is-a-nameserver.md
+++ b/content/articles/what-is-a-nameserver.md
@@ -1,5 +1,5 @@
 ---
-title: What is a name server?
+title: What is a Name Server?
 excerpt: What authoritative name servers are, how they fit into DNS resolution, and how delegation at your registrar relates to the hostnames you publish.
 meta: Name servers are the authoritative DNS servers for a zone. Resolvers query them to resolve hostnames. Your registrar's delegation points to them.
 categories:

--- a/content/articles/what-is-dane.md
+++ b/content/articles/what-is-dane.md
@@ -7,7 +7,7 @@ categories:
 - DNSSEC
 ---
 
-# What Is DANE?
+# What Is DANE and How Does It Work?
 
 ### Table of Contents {#toc}
 

--- a/content/articles/what-is-dnssec.md
+++ b/content/articles/what-is-dnssec.md
@@ -7,7 +7,7 @@ categories:
   - Enterprise
 ---
 
-# What Is DNSSEC?
+# What Is DNSSEC and How Does It Work?
 
 <div class="aspect-ratio aspect-ratio--16x9 z-0 mb4">
   <iframe loading="lazy" src="https://www.youtube.com/embed/7JWpgka8zBQ" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/articles/zone-ns-records.md
+++ b/content/articles/zone-ns-records.md
@@ -1,5 +1,5 @@
 ---
-title: Zone NS Records
+title: Updating Zone NS Records for a Hosted Domain
 excerpt: How to update zone NS records for a hosted domain.
 meta: How to update Name Server (NS) records for a hosted domain in DNSimple. Add, edit, or remove zone NS records to control DNS delegation.
 categories:


### PR DESCRIPTION
`article-structure.mdc` says the H1 matches the frontmatter `title`. 155 articles disagree. This fixes the 45 in the Diátaxis-treated categories (DNS, DNSSEC, Domains and Transfers, SSL Certificates, Name Servers).

## Why it matters beyond tidiness

The two fields feed different things:

| Field | Consumed by |
|---|---|
| frontmatter `title` | `<title>` tag → browser tab and the Google result link · `search.json` · category listings · category YAML matching |
| H1 | the rendered page heading only |

So on `caa-record`, the tab, the search result, the search index, and the category listing all said *What Is a CAA Record?* while the page heading said *CAA Records*. Readers clicked one thing and landed on another.

## Direction, per article

Not one rule applied 45 times — the side carrying more information wins, which isn't always the longer one.

- **33 articles: H1 rewritten** to match frontmatter. Includes 15 question-form conversions (`A Records` → `What Is an A Record?`), which also helps the question-shaped queries that retrieval currently handles worst
- **10 articles: frontmatter rewritten** to match the H1, where the H1 genuinely held more — `Zone NS Records` → `Updating Zone NS Records for a Hosted Domain`, `DNSSEC at DNSimple` → `DNS Security Extensions (DNSSEC) at DNSimple`
- **1 article: both rewritten** — `delegating-dnsimple-registered` was awkward either way, now `Delegate a DNSimple-Registered Domain to DNSimple Name Servers`
- **1 article skipped** — `what-is-dig`. The H1 is ``What Is `dig`?`` with code formatting; the title field is interpolated raw into `<title>` and listing links, so backticks would render literally there. The fields differ only by markup that one of them cannot carry, and that is fine

## Category YAML

`lib/sub_categories.rb` matches articles to category entries by **exact title string** — a rename without a paired YAML update silently drops the article into "Other." 16 entries updated across 8 files; several titles appear in two or three YAMLs.

Also folded in: **3 pre-existing orphans** whose titles were in no category YAML at all — `integrated-domain-providers`, `what-is-domain-access-control`, `what-is-sso-at-dnsimple`.

## Verification

Simulated the exact-string matching across the whole corpus, before and after:

- **Orphans: 3 → 0 corpus-wide**
- **Stale entries: 21 → 21, none introduced**
- All 21 category YAMLs parse
- Title mismatches in the five categories: 45 → 1 (the deliberate `what-is-dig` exception)

⚠️ `bundle exec rake` has **not** been run against this branch — worth doing before review.

## Not included

The 57 `.XXX Domains` / `.XXX Domain Names` TLD articles. That's one decision repeated 57 times rather than 57 decisions, and it needs a product-voice call since the app's own nav label is *Domain Names*.