### PR TITLE
Let the embedding site set the widget's contact URL

### DIFF
--- a/_widget/index.html
+++ b/_widget/index.html
@@ -13,6 +13,7 @@
       data-dnsimple-current-site-url="https://support.dnsimple.com"
       data-dnsimple-getting-started-url="/articles/getting-started/"
       data-dnsimple-sources='[{"name": "DNSimple Support", "url": "https://support.dnsimple.com"}, {"name": "DNSimple Developer", "url": "https://developer.dnsimple.com"}]'
+      data-dnsimple-contact-url="https://dnsimple.com/contact"
       data-comment="To mimic embedding from a different site, use data-dnsimple-current-site-url=https://dnsimple.com"
     >
       Click to open the support widget. Remove this DOM element to have it load automatically in the bottom corner.

--- a/_widget/src/components/app/component.vue
+++ b/_widget/src/components/app/component.vue
@@ -48,6 +48,14 @@ export default {
       type: String,
       default: 'https://support.dnsimple.com/articles/getting-started/'
     },
+    // Where "Get in touch" sends someone who could not find their answer. The
+    // host site sets it, because only the host knows which of its own hosts
+    // carries the visitor's session: sending a signed-in customer to another
+    // host drops them onto the contact form as an anonymous visitor.
+    contactUrl: {
+      type: String,
+      default: 'https://dnsimple.com/contact'
+    },
     fetch: {
       type: Function,
       default(url) {
@@ -276,6 +284,10 @@ export default {
 
     getGettingStartedUrl() {
       return this.gettingStartedUrl;
+    },
+
+    getContactUrl() {
+      return this.contactUrl;
     },
 
     hasHistory() {

--- a/_widget/src/components/footer/component.vue
+++ b/_widget/src/components/footer/component.vue
@@ -3,7 +3,7 @@
         <p>
             <span>Can't find what you are looking for?</span>
             <a
-                href="https://dnsimple.com/contact"
+                :href="app.getContactUrl()"
                 class="button"
                 target="_blank"
             >

--- a/_widget/src/initialize.js
+++ b/_widget/src/initialize.js
@@ -41,11 +41,14 @@ export default (doc, options = {}) => {
   const sourcesAttr = doc.querySelector('[data-dnsimple-sources]')?.getAttribute('data-dnsimple-sources');
   const sources = sourcesAttr ? JSON.parse(sourcesAttr) : undefined;
 
+  const contactUrl = doc.querySelector('[data-dnsimple-contact-url]')?.getAttribute('data-dnsimple-contact-url');
+
   const app = createApp(App, Object.assign({
     showPrompt: $openers.length === 0,
     currentSiteUrl: doc.querySelector('[data-dnsimple-current-site-url]')?.getAttribute('data-dnsimple-current-site-url') || '',
     gettingStartedUrl: doc.querySelector('[data-dnsimple-getting-started-url]')?.getAttribute('data-dnsimple-getting-started-url') || '/articles/getting-started/',
     ...(sources && { sources }),
+    ...(contactUrl && { contactUrl }),
   }, options)).mount($mount);
 
   $openers.forEach(($el) => {

--- a/spec/_widget/components/app.spec.js
+++ b/spec/_widget/components/app.spec.js
@@ -41,6 +41,18 @@ describe('App', () => {
     });
   });
 
+  describe('contactUrl prop', () => {
+    it('defaults to the marketing site contact page', () => {
+      const subject = mount(App);
+      expect(subject.vm.getContactUrl()).toEqual('https://dnsimple.com/contact');
+    });
+
+    it('can be overridden via props, so a host site keeps visitors on its own host', () => {
+      const subject = mount(App, { propsData: { contactUrl: 'https://app.dnsimple.com/contact' } });
+      expect(subject.vm.getContactUrl()).toEqual('https://app.dnsimple.com/contact');
+    });
+  });
+
   describe('init', () => {
     const subject = mount(App);
 

--- a/spec/_widget/components/article.spec.js
+++ b/spec/_widget/components/article.spec.js
@@ -9,6 +9,7 @@ describe('Article', () => {
     hasHistory: () => false,
     back: () => {},
     getArticleUrl: (article) => `${article.sourceUrl}${article.id}`,
+    getContactUrl: () => 'https://dnsimple.com/contact',
     visitArticle: jest.fn(),
   };
 

--- a/spec/_widget/components/footer.spec.js
+++ b/spec/_widget/components/footer.spec.js
@@ -1,0 +1,14 @@
+import { mount } from '@vue/test-utils';
+import Footer from '../../../_widget/src/components/footer/component.vue';
+
+describe('Footer', () => {
+  const mountWith = (contactUrl) => mount(Footer, {
+    propsData: { app: { getContactUrl: () => contactUrl } }
+  });
+
+  it('points "Get in touch" at the contact url the app was given', () => {
+    const subject = mountWith('https://app.dnsimple.com/contact');
+
+    expect(subject.get('a.button').attributes('href')).toEqual('https://app.dnsimple.com/contact');
+  });
+});

--- a/spec/_widget/components/initialize.spec.js
+++ b/spec/_widget/components/initialize.spec.js
@@ -60,6 +60,15 @@ describe('Initialize', () => {
     expect(subject.getGettingStartedUrl()).toEqual(gettingStartedUrl);
   });
 
+  it('sets the contact url', () => {
+    const contactUrl = 'https://app.dnsimple.com/contact';
+    document.body.innerHTML = `<p data-dnsimple-contact-url="${contactUrl}"></p>`;
+
+    subject = initialize(document);
+
+    expect(subject.getContactUrl()).toEqual(contactUrl);
+  });
+
   describe('when there are custom openers on the page', () => {
     beforeEach(() => {
       document.body.innerHTML = `<a data-dnsimple-open-support-widget>Opener</a>`;


### PR DESCRIPTION
## Summary

The widget's "Get in touch" button hardcodes `https://dnsimple.com/contact`. That is fine while the app and the marketing site share a host, but the app is moving to `app.dnsimple.com`, and the session cookie stays scoped to the host that set it. After the split, a signed-in customer who opens the widget in the app and clicks "Get in touch" lands on the contact form as an anonymous visitor: no email prefill, no account selector, and their message routes to the generic support address instead of their account's.

The widget cannot work out the right host on its own, so this makes the URL the embedding site's call: a new `data-dnsimple-contact-url` attribute, defaulting to `https://dnsimple.com/contact` so every current embed behaves exactly as it does today. The app then points it at its own host and keeps the visitor's session.

## Files changed

- `_widget/src/components/app/component.vue` - new `contactUrl` prop and `getContactUrl()` accessor, alongside the existing `gettingStartedUrl` and `sources`
- `_widget/src/components/footer/component.vue` - "Get in touch" reads the accessor instead of a literal
- `_widget/src/initialize.js` - reads `data-dnsimple-contact-url`, omitting it when absent so the prop default applies
- `_widget/index.html` - the dev harness carries the new attribute, so it stays discoverable
- `spec/_widget/components/{footer,app,initialize}.spec.js` - cover the attribute, the prop default and override, and the rendered href
- `spec/_widget/components/article.spec.js` - its stub `app` gains `getContactUrl`, since Footer now asks for it

## QA

Specs cover the attribute to prop to rendered href chain, plus the default when no attribute is present.

Manually, with `npm run dev`:

1. Open the harness and the widget. "Get in touch" points at `https://dnsimple.com/contact`, as it does today.
2. Change `data-dnsimple-contact-url` to `https://app.dnsimple.com/contact`. The button follows.
3. Remove the attribute. The button falls back to `https://dnsimple.com/contact`.

## Deployment

Nothing to do here, and no ordering constraint. This ships the option; nothing exercises it yet. `layouts/default.html` does not set the attribute, so the support site itself keeps sending anonymous visitors to the marketing contact page, which is correct for them.

The app-side change that passes the attribute is a separate PR in `dnsimple-app`, and it needs this deployed first, otherwise the attribute is simply ignored and behavior is unchanged.

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] No smart/curly quotes or special characters from macOS
- [x] `npx jest` and `npx eslint` clean

Belongs to https://github.com/dnsimple/dnsimple-business/issues/2842
