### PR TITLE
Fix incorrect new-owner prerequisite in ownership transfer

### DIFF
--- a/content/articles/transfer-account-ownership.md
+++ b/content/articles/transfer-account-ownership.md
@@ -19,7 +19,15 @@ Transfer account ownership when a different person should own and manage the acc
 
 ## Before you start {#before-you-start}
 
-The new owner must have (or create) their own DNSimple user. Account ownership is tied to the user email on the account owner.
+Account ownership is tied to the user email on the account owner. You transfer the account by changing that user email to the new owner's address.
+
+The new owner must not already have a DNSimple user with that email address. Each email address can belong to only one DNSimple user, so DNSimple rejects the change with the error "Email has already been taken."
+
+If the new owner already has a DNSimple user at the address you want to use, they have a few options:
+
+* Use a different email address for the account, one that is not already tied to a DNSimple user.
+* [Change the user email](/articles/changing-email/#changing-the-user-email) on their existing DNSimple user to a different address. This frees the original address for the transfer.
+* [Delete their existing user](/articles/close-account/) if they no longer need it. Deleting a user permanently removes every account, domain, and record under it, so only do this if there is nothing on that user you want to keep.
 
 > [!WARNING]
 > Transferring ownership gives the new owner full control of the account, including domains, billing, and settings. Make sure you trust the recipient and have exported any information you need to keep. If they need to update the card on file, follow the steps in [Changing Payment Details](/articles/changing-payment-details/).
@@ -27,7 +35,7 @@ The new owner must have (or create) their own DNSimple user. Account ownership i
 ## Transfer ownership {#transfer-ownership}
 
 <div class="section-steps" markdown="1">
-##### To transfer account ownership to another DNSimple user
+##### To transfer account ownership to another person
 
 1. [Change the user email](/articles/changing-email/#changing-the-user-email) on the account owner to the new owner's user email address.
 1. Ask the new owner to [request a password reset](/articles/forgot-password/) if they need to set or update their password.

--- a/content/articles/transfer-account-ownership.md
+++ b/content/articles/transfer-account-ownership.md
@@ -37,7 +37,7 @@ If the new owner already has a DNSimple user at the address you want to use, the
 <div class="section-steps" markdown="1">
 ##### To transfer account ownership to another person
 
-1. [Change the user email](/articles/changing-email/#changing-the-user-email) on the account owner to the new owner's user email address.
+1. [Change the user email](/articles/changing-email/#changing-the-user-email) on the account owner to the new owner's email address.
 1. Ask the new owner to [request a password reset](/articles/forgot-password/) if they need to set or update their password.
 1. Confirm the new owner can sign in and access the account from the account switcher.
 


### PR DESCRIPTION
A customer flagged that the "Before you start" section of [Transfer Account Ownership](https://support.dnsimple.com/articles/transfer-account-ownership/) told them the new owner "must have (or create) their own DNSimple user." That is backwards, and following it walks straight into an error.

Ownership is transferred by changing the user email on the account owner. `UserChangeEmailInteractor` rejects the change if any user identity already exists for the target email, returning "Email has already been taken" (`interactor.message_error_user_emailtaken`). `User` also validates email uniqueness. So the new owner must *not* already have a DNSimple user at that address.

Changes:

- Rewrote "Before you start" to explain that ownership is tied to the user email, that the new owner must not already have a DNSimple user at that address, and to name the exact error they will hit.
- Added the three ways out: use a different address, change the email on their existing user to free the address, or delete that user (with the data-loss caveat).
- Retitled the steps heading from "To transfer account ownership to another DNSimple user" to "...to another person," since the whole point is that they are not a separate user.

No cross-link changes needed. The two articles that link here describe it accurately.