### PR TITLE
Update link labels that still use old article titles

### DIFF
--- a/content/articles/add-ns-records-for-subdomain.md
+++ b/content/articles/add-ns-records-for-subdomain.md
@@ -21,7 +21,7 @@ Subdomain delegation covers standard DNS resolution only. Publishing [DS records
 
 ## Confirm the domain uses DNSimple for DNS {#confirm-the-domain-uses-dnsimple-for-dns}
 
-Before you add NS records, the parent domain must be delegated to DNSimple. If the domain is registered with DNSimple, follow [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/). If the domain is registered elsewhere but uses DNSimple for DNS, follow [Delegating a Domain registered with another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/). If you are unsure which path applies, start from [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/).
+Before you add NS records, the parent domain must be delegated to DNSimple. If the domain is registered with DNSimple, follow [Delegate a DNSimple-Registered Domain to DNSimple Name Servers](/articles/delegating-dnsimple-registered/). If the domain is registered elsewhere but uses DNSimple for DNS, follow [Delegate a Domain from Another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/). If you are unsure which path applies, start from [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/).
 
 ## Add NS records in DNSimple {#add-ns-records-in-dnsimple}
 

--- a/content/articles/disabling-dnssec.md
+++ b/content/articles/disabling-dnssec.md
@@ -37,7 +37,7 @@ If you encounter issues after disabling DNSSEC, see [Troubleshoot DNSSEC](/artic
 
 ## Learn more {#learn-more}
 
-To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For information about enabling DNSSEC, see [Enable DNSSEC](/articles/enabling-dnssec/). For information about DS records and how they work, see [What Are DS Records?](/articles/what-are-ds-records/). To understand TTL and how it affects DNS record propagation, see [What Is Time-to-Live?](/articles/what-is-ttl/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For information about enabling DNSSEC, see [Enable DNSSEC](/articles/enabling-dnssec/). For information about DS records and how they work, see [What Are DS Records?](/articles/what-are-ds-records/). To understand TTL and how it affects DNS record propagation, see [What Is Time-to-Live?](/articles/what-is-ttl/). For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 If you have any questions or need assistance disabling your DNSSEC, [contact support](https://dnsimple.com/contact), and we will be happy to help.

--- a/content/articles/dns.md
+++ b/content/articles/dns.md
@@ -108,13 +108,13 @@ Step-by-step guides for managing DNS records, zones, and DNS configuration:
 - [Export Zone File](/articles/export-records-zone-file/) - Instructions for exporting your DNS zone file from DNSimple.
 - [Import Zone File](/articles/import-records-zone-file/) - Learn how to import a zone file into DNSimple.
 - [Auto-Import DNS Records](/articles/auto-import-dns/) - Guide to automatically importing DNS records when adding a domain.
-- [Zone NS Records](/articles/zone-ns-records/) - Learn how to manage name server (NS) records for your zone.
+- [Updating Zone NS Records for a Hosted Domain](/articles/zone-ns-records/) - Learn how to manage name server (NS) records for your zone.
 - [Set Up DKIM](/articles/set-up-dkim/) - Step-by-step guide to configuring DKIM for email authentication.
 - [Set Up DMARC](/articles/set-up-dmarc/) - Instructions for setting up DMARC to protect your email domain.
 - [Query MX Records](/articles/query-mx-records/) - Learn how to query and verify MX records using various tools.
 - [Set Up Simple Dynamic DNS](/articles/set-up-simple-dynamic-dns/) - Guide to configuring Dynamic DNS for automatic IP address updates.
 - [Manage Integrated DNS Providers](/articles/integrated-dns-providers/) - Learn how to manage integrated DNS providers in DNSimple.
-- [How to Use Route 53 as an Integrated DNS Provider](/articles/amazon-route-53-integration-demo/) - Step-by-step guide to using Amazon Route 53 as an integrated provider.
+- [How to Use Amazon Route 53 as an Integrated DNS Provider](/articles/amazon-route-53-integration-demo/) - Step-by-step guide to using Amazon Route 53 as an integrated provider.
 - [How to Use CoreDNS as an Integrated DNS Provider](/articles/core-dns-tutorial/) - Instructions for using CoreDNS as an integrated DNS provider.
 - [Manage Integrated Zones for Integrated DNS Providers](/articles/integrated-dns-provider-zones/) - Guide to managing zones when using integrated DNS providers.
 - [Manage Integrated Zone Records](/articles/record-editor-integrated-zones/) - Learn how to manage DNS records in integrated zones.

--- a/content/articles/dnskey-records-explained.md
+++ b/content/articles/dnskey-records-explained.md
@@ -50,7 +50,7 @@ If a private key is compromised, an attacker could forge signatures and potentia
 
 ## Learn more {#learn-more}
 
-To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To understand how DS records connect DNSKEY records to the parent zone, see [What Are DS Records?](/articles/what-are-ds-records/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To understand how DS records connect DNSKEY records to the parent zone, see [What Are DS Records?](/articles/what-are-ds-records/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/). For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 Ready to get started with DNSSEC? Read [Enable DNSSEC](/articles/enabling-dnssec/). If you have further questions or need any assistance, [contact our support team](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/dnssec-and-secondary-dns.md
+++ b/content/articles/dnssec-and-secondary-dns.md
@@ -34,7 +34,7 @@ For a deeper dive into multi-provider DNSSEC, refer to [RFC 8901](https://datatr
 
 ## Learn more {#learn-more}
 
-To enable DNSSEC for your domain, see [Enable DNSSEC](/articles/enabling-dnssec/). If you encounter issues with your DNSSEC configuration, see [Troubleshoot DNSSEC](/articles/troubleshooting-dnssec-configurations/) for comprehensive guidance. For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To enable DNSSEC for your domain, see [Enable DNSSEC](/articles/enabling-dnssec/). If you encounter issues with your DNSSEC configuration, see [Troubleshoot DNSSEC](/articles/troubleshooting-dnssec-configurations/) for comprehensive guidance. For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 If you have additional questions or need any assistance with secondary DNS or DNSSEC, just [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/domain-contact-types-reference.md
+++ b/content/articles/domain-contact-types-reference.md
@@ -140,7 +140,7 @@ Learn more:
 
 **TLD-specific requirements:** Some TLDs may have specific requirements for contact types. For example, some ccTLDs may require contacts to be residents of the country associated with the TLD.
 
-**Regulated TLDs:** Some regulated TLDs may have additional requirements or restrictions related to contact types. For more information, see [Regulated Top-Level Domains](/articles/tlds-regulated/).
+**Regulated TLDs:** Some regulated TLDs may have additional requirements or restrictions related to contact types. For more information, see [Regulated and Highly-Regulated Top-Level Domains](/articles/tlds-regulated/).
 
 ## WHOIS and privacy {#whois-and-privacy}
 

--- a/content/articles/domain-delegation-and-name-servers.md
+++ b/content/articles/domain-delegation-and-name-servers.md
@@ -27,7 +27,7 @@ For a fuller description of the delegation chain, see [What Is Domain Delegation
 
 In everyday language, people say **name servers** when they talk about delegation because delegation lists **hostnames** (for example `ns1.dnsimple-edge.com`) that must answer DNS for your domain. Changing delegation usually means **changing which name server hostnames are listed at the registrar** for your domain.
 
-Authoritative name servers host your zone file (your A, MX, CNAME, and other records). For vocabulary and resolver basics, see [What is a name server?](/articles/what-is-a-nameserver/).
+Authoritative name servers host your zone file (your A, MX, CNAME, and other records). For vocabulary and resolver basics, see [What is a Name Server?](/articles/what-is-a-nameserver/).
 
 ## Common terms customers use {#common-terms}
 
@@ -82,7 +82,7 @@ If something still fails after delegation looks correct, propagation and caching
 | Situation | Start here |
 |-----------|------------|
 | Domain is registered **elsewhere** and you want DNS hosted **by DNSimple** | [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) |
-| Domain is registered **with DNSimple** and you want DNS hosted **by DNSimple** | [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/) |
+| Domain is registered **with DNSimple** and you want DNS hosted **by DNSimple** | [Delegate a DNSimple-Registered Domain to DNSimple Name Servers](/articles/delegating-dnsimple-registered/) |
 | Domain is registered **with DNSimple** and you want DNS hosted **by another provider** | [Setting the Name Servers for a Domain](/articles/setting-name-servers/) |
 | You need to delegate **only a subdomain** (child zone) | [Adding NS Records for a Subdomain](/articles/add-ns-records-for-subdomain/) |
 | Name servers use names **under your own domain** (for example `ns1.example.com` for `example.com`) and you need glue context | [What Are Glue Records?](/articles/what-are-glue-records/) |

--- a/content/articles/domain-registration-reference.md
+++ b/content/articles/domain-registration-reference.md
@@ -38,7 +38,7 @@ When registering a domain, you must provide accurate registrant contact informat
 - Industry classifications
 - Other TLD-specific requirements
 
-**Regulated TLDs:** Some TLDs, such as `.BANK` and `.INSURANCE`, have additional requirements and restrictions. For more information, see [Regulated Top-Level Domains](/articles/tlds-regulated/).
+**Regulated TLDs:** Some TLDs, such as `.BANK` and `.INSURANCE`, have additional requirements and restrictions. For more information, see [Regulated and Highly-Regulated Top-Level Domains](/articles/tlds-regulated/).
 
 ## Registration restrictions {#registration-restrictions}
 

--- a/content/articles/domain-transfer-code-reference.md
+++ b/content/articles/domain-transfer-code-reference.md
@@ -119,7 +119,7 @@ For step-by-step instructions, see [Transfer a Domain Away from DNSimple](/artic
 
 **Special procedures:** Some TLDs have different transfer procedures that do not require a transfer code. For example, `.UK` domains use a different transfer process.
 
-**Regulated TLDs:** Some regulated TLDs may have additional requirements or restrictions related to transfer codes. For more information, see [Regulated Top-Level Domains](/articles/tlds-regulated/).
+**Regulated TLDs:** Some regulated TLDs may have additional requirements or restrictions related to transfer codes. For more information, see [Regulated and Highly-Regulated Top-Level Domains](/articles/tlds-regulated/).
 
 ## Have more questions?
 

--- a/content/articles/domains-and-transfers.md
+++ b/content/articles/domains-and-transfers.md
@@ -67,7 +67,7 @@ Registry and ICANN requirements:
 
 ### TLDs
 
-- [Regulated Top-Level Domains](/articles/tlds-regulated/) - Information about regulated and highly-regulated TLDs.
+- [Regulated and Highly-Regulated Top-Level Domains](/articles/tlds-regulated/) - Information about regulated and highly-regulated TLDs.
 
 ## How to {#how-to}
 

--- a/content/articles/enabling-dnssec.md
+++ b/content/articles/enabling-dnssec.md
@@ -11,7 +11,7 @@ categories:
 
 To enable DNSSEC in DNSimple, open the DNSSEC tab for your domain and follow the configuration wizard. DNSimple signs the zone automatically and, for domains registered with DNSimple, provisions the DS record at the registry with no additional steps required.
 
-If you are new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/) to understand what DNSSEC is and how it works. For a comprehensive overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+If you are new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/) to understand what DNSSEC is and how it works. For a comprehensive overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Prerequisites
 

--- a/content/articles/name-server-delegation-checklist.md
+++ b/content/articles/name-server-delegation-checklist.md
@@ -41,8 +41,8 @@ Compare results to the four DNSimple hostnames above. For delays, see [How DNS C
 
 | Scenario | Article |
 |----------|---------|
-| Domain registered at DNSimple | [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/) |
-| Domain registered elsewhere | [Delegating a Domain registered with another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/) |
+| Domain registered at DNSimple | [Delegate a DNSimple-Registered Domain to DNSimple Name Servers](/articles/delegating-dnsimple-registered/) |
+| Domain registered elsewhere | [Delegate a Domain from Another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/) |
 | Mixed symptoms after a change | [Troubleshoot Email or Subdomains After Delegation Changes](/articles/troubleshoot-email-subdomains-after-delegation-changes/) |
 
 ## Have more questions?

--- a/content/articles/name-server-management-in-dnsimple.md
+++ b/content/articles/name-server-management-in-dnsimple.md
@@ -23,7 +23,7 @@ DNSimple provides full control over name server delegation for domains registere
 
 ## Understanding name servers {#understanding-name-servers}
 
-- [What is a name server?](/articles/what-is-a-nameserver/) - What authoritative name servers are and how they fit into DNS resolution.
+- [What is a Name Server?](/articles/what-is-a-nameserver/) - What authoritative name servers are and how they fit into DNS resolution.
 - [Domain Delegation and Name Servers Explained](/articles/domain-delegation-and-name-servers/) - How delegation, name servers, and DNS hosting fit together, and which guide matches your situation.
 - [What Is Domain Delegation?](/articles/what-is-domain-delegation/) - How delegation works and what it means to point a domain at a DNS provider.
 - [Recursive vs Authoritative DNS Resolvers](/articles/recursive-vs-authoritative-dns-resolvers/) - The difference between resolvers that look up answers and servers that hold them.
@@ -34,14 +34,14 @@ DNSimple provides full control over name server delegation for domains registere
 ## Pointing a domain to DNSimple {#pointing-a-domain}
 
 - [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) - Overview of the delegation process depending on where your domain is registered.
-- [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/) - How to set DNSimple as the DNS provider for a domain you registered with us.
-- [Delegating a Domain registered with another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/) - How to update delegation at an external registrar to use DNSimple name servers.
+- [Delegate a DNSimple-Registered Domain to DNSimple Name Servers](/articles/delegating-dnsimple-registered/) - How to set DNSimple as the DNS provider for a domain you registered with us.
+- [Delegate a Domain from Another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/) - How to update delegation at an external registrar to use DNSimple name servers.
 
 ## Changing delegation {#changing-delegation}
 
 - [Change delegation to another DNS provider](/articles/setting-name-servers/) - How to point a DNSimple-registered domain at a different DNS provider.
 - [Adding NS Records for a Subdomain](/articles/add-ns-records-for-subdomain/) - How to delegate a subdomain to a separate set of name servers.
-- [Zone NS Records](/articles/zone-ns-records/) - How to update the NS records published at the apex of your zone.
+- [Updating Zone NS Records for a Hosted Domain](/articles/zone-ns-records/) - How to update the NS records published at the apex of your zone.
 
 ## Name server sets and vanity name servers {#name-server-sets-and-vanity}
 

--- a/content/articles/name-servers-glossary.md
+++ b/content/articles/name-servers-glossary.md
@@ -26,7 +26,7 @@ A DNS server that holds the definitive records for a zone and answers queries fo
 Learn more:
 
 - [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034)
-- [What is a name server?](/articles/what-is-a-nameserver/)
+- [What is a Name Server?](/articles/what-is-a-nameserver/)
 - [Recursive vs Authoritative DNS Resolvers](/articles/recursive-vs-authoritative-dns-resolvers/)
 
 ### Recursive Resolver

--- a/content/articles/name-servers-interface-reference.md
+++ b/content/articles/name-servers-interface-reference.md
@@ -37,7 +37,7 @@ The Edit Delegation page controls apex delegation for domains registered with DN
 > [!NOTE]
 > Edit Delegation is only available for domains registered with DNSimple. For domains registered elsewhere, update delegation at your external registrar.
 
-For step-by-step instructions, see [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/) or [Change delegation to another DNS provider](/articles/setting-name-servers/).
+For step-by-step instructions, see [Delegate a DNSimple-Registered Domain to DNSimple Name Servers](/articles/delegating-dnsimple-registered/) or [Change delegation to another DNS provider](/articles/setting-name-servers/).
 
 ## Name Server Sets {#name-server-sets}
 
@@ -125,7 +125,7 @@ Zone NS records are the NS records published inside your DNSimple zone at the ap
 > [!NOTE]
 > Zone NS record changes only take effect if the domain is delegated to DNSimple at the registrar and has active DNS hosting. Editing these records does not change registrar-level delegation.
 
-For step-by-step instructions, see [Zone NS Records](/articles/zone-ns-records/).
+For step-by-step instructions, see [Updating Zone NS Records for a Hosted Domain](/articles/zone-ns-records/).
 
 ## Have more questions?
 

--- a/content/articles/ns-record-format.md
+++ b/content/articles/ns-record-format.md
@@ -43,7 +43,7 @@ In DNSimple, NS records for subdomains are represented by the following customiz
 
 ## Apex and subdomain NS records {#apex-and-subdomain}
 
-NS records at the apex of a zone in DNSimple are system-managed and cannot be edited through the standard record editor. They reflect either the DNSimple edge name servers or your configured [vanity name servers](/articles/what-are-vanity-name-servers/). For information on updating apex zone NS records, see [Zone NS Records](/articles/zone-ns-records/).
+NS records at the apex of a zone in DNSimple are system-managed and cannot be edited through the standard record editor. They reflect either the DNSimple edge name servers or your configured [vanity name servers](/articles/what-are-vanity-name-servers/). For information on updating apex zone NS records, see [Updating Zone NS Records for a Hosted Domain](/articles/zone-ns-records/).
 
 NS records for subdomains can be created and managed through the record editor to delegate a subdomain to a separate set of name servers. See [Adding NS Records for a Subdomain](/articles/add-ns-records-for-subdomain/) for step-by-step instructions.
 

--- a/content/articles/nsec-nsec3-records.md
+++ b/content/articles/nsec-nsec3-records.md
@@ -78,7 +78,7 @@ While both NSEC and NSEC3 provide authenticated denial of existence, they differ
 
 ## Learn more {#learn-more}
 
-To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To understand how RRSIG records work with NSEC/NSEC3, see [What Are RRSETs and RRSIGs in DNSSEC?](/articles/understanding-rrsets-rrsigs/). If you are experiencing issues with NSEC/NSEC3 records, see [Troubleshoot DNSSEC](/articles/troubleshooting-dnssec-configurations/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To understand how RRSIG records work with NSEC/NSEC3, see [What Are RRSETs and RRSIGs in DNSSEC?](/articles/understanding-rrsets-rrsigs/). If you are experiencing issues with NSEC/NSEC3 records, see [Troubleshoot DNSSEC](/articles/troubleshooting-dnssec-configurations/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/). For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 If you have further questions or need any assistance, [contact our support team](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/pointing-domain-to-dnsimple.md
+++ b/content/articles/pointing-domain-to-dnsimple.md
@@ -21,11 +21,11 @@ For how registration, delegation, and DNS hosting fit together, read [Domain Del
 
 ## Domain registered with DNSimple {#domain-registered-with-dnsimple}
 
-Follow [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/).
+Follow [Delegate a DNSimple-Registered Domain to DNSimple Name Servers](/articles/delegating-dnsimple-registered/).
 
 ## Domain registered with another provider {#domain-registered-with-another-provider}
 
-Follow [Delegating a Domain registered with another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/).
+Follow [Delegate a Domain from Another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/).
 
 For a compact reference to the DNSimple name server targets and verification commands, see the [Name Server Delegation Checklist](/articles/name-server-delegation-checklist/).
 

--- a/content/articles/recursive-vs-authoritative-dns-resolvers.md
+++ b/content/articles/recursive-vs-authoritative-dns-resolvers.md
@@ -24,7 +24,7 @@ Recursive resolvers sit close to clients (for example your router, your ISP, `8.
 
 ## Authoritative name servers {#authoritative-name-servers}
 
-Authoritative servers are the ones listed in delegation for your domain (for example [DNSimple name servers](/articles/dnsimple-nameservers/) after you [point the domain to DNSimple](/articles/pointing-domain-to-dnsimple/)). They return the source-of-truth RRsets for your zone. For a fuller introduction, see [What is a name server?](/articles/what-is-a-nameserver/) and [What Is DNS?](/articles/what-is-dns/).
+Authoritative servers are the ones listed in delegation for your domain (for example [DNSimple name servers](/articles/dnsimple-nameservers/) after you [point the domain to DNSimple](/articles/pointing-domain-to-dnsimple/)). They return the source-of-truth RRsets for your zone. For a fuller introduction, see [What is a Name Server?](/articles/what-is-a-nameserver/) and [What Is DNS?](/articles/what-is-dns/).
 
 ## How they work together {#how-they-work-together}
 

--- a/content/articles/rotate-dnssec-key.md
+++ b/content/articles/rotate-dnssec-key.md
@@ -44,7 +44,7 @@ For details, refer to our [webhooks API documentation](https://developer.dnsimpl
 
 ## Learn more {#learn-more}
 
-To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For information about DS records and how they work, see [What Are DS Records?](/articles/what-are-ds-records/). For step-by-step instructions on managing DS records, see [Add and Remove DS Records](/articles/manage-ds-record/). To understand TTL and how it affects DNS record propagation, see [What Is Time-to-Live?](/articles/what-is-ttl/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For information about DS records and how they work, see [What Are DS Records?](/articles/what-are-ds-records/). For step-by-step instructions on managing DS records, see [Add and Remove DS Records](/articles/manage-ds-record/). To understand TTL and how it affects DNS record propagation, see [What Is Time-to-Live?](/articles/what-is-ttl/). For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 If you have any questions or need assistance rotating DNSSEC keys, [contact support](https://dnsimple.com/contact), and we will be happy to help.

--- a/content/articles/secondary-dnsimple.md
+++ b/content/articles/secondary-dnsimple.md
@@ -25,7 +25,7 @@ This diagram shows how zone changes are propagated to both DNS service providers
 
 ## Configuring DNSimple alongside another DNS provider (hosted domain)
 
-To set up zone redundancy with another DNS provider on your zone, follow the steps detailed in [Updating NS Records for the Zone of a Hosted Domain](/articles/zone-ns-records/).
+To set up zone redundancy with another DNS provider on your zone, follow the steps detailed in [Updating Zone NS Records for a Hosted Domain](/articles/zone-ns-records/).
 
 
 ## Configuring DNSimple alongside another DNS provider (registered domain)

--- a/content/articles/setting-name-servers.md
+++ b/content/articles/setting-name-servers.md
@@ -21,7 +21,7 @@ If your domain is **not** registered at DNSimple, update name servers at your **
 
 If you want DNS hosted **by DNSimple**, follow [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/) so you follow the right steps for your registration setup.
 
-For vocabulary (delegation versus records in your zone), see [What Is Domain Delegation?](/articles/what-is-domain-delegation/). For what authoritative name servers do, see [What is a name server?](/articles/what-is-a-nameserver/). For an overview when you are moving **to** DNSimple DNS, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/).
+For vocabulary (delegation versus records in your zone), see [What Is Domain Delegation?](/articles/what-is-domain-delegation/). For what authoritative name servers do, see [What is a Name Server?](/articles/what-is-a-nameserver/). For an overview when you are moving **to** DNSimple DNS, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/).
 
 ## Change delegation to another DNS provider {#pointing-the-name-servers-to-another-provider}
 

--- a/content/articles/sha-2-ssl-certificates.md
+++ b/content/articles/sha-2-ssl-certificates.md
@@ -18,7 +18,7 @@ All major browsers and operating systems stopped trusting SHA-1 certificates by 
 
 ## Compatibility {#compatibility}
 
-SHA-256 certificates are supported by all modern browsers, operating systems, and server platforms. For a full comparison of DNSimple certificate features, see [SSL Certificate Product Specifications](/articles/ssl-certificate-product-specs/). If you are interested in how key algorithms (ECDSA vs RSA) complement the hash algorithm, see [Elliptic Curve Cryptography (ECC) SSL Certificates](/articles/can-elliptic-curve-key-ssl-certificates/).
+SHA-256 certificates are supported by all modern browsers, operating systems, and server platforms. For a full comparison of DNSimple certificate features, see [SSL Certificate Product Specifications](/articles/ssl-certificate-product-specs/). If you are interested in how key algorithms (ECDSA vs RSA) complement the hash algorithm, see [Do You Support Elliptic Curve Cryptography (ECC) SSL Certificates?](/articles/can-elliptic-curve-key-ssl-certificates/).
 
 Compatibility issues are limited to very old systems (pre-2006 era), such as:
 

--- a/content/articles/ssl-certificates-glossary.md
+++ b/content/articles/ssl-certificates-glossary.md
@@ -145,14 +145,14 @@ An encoded block of text containing the public key and domain information, submi
 Rivest-Shamir-Adleman. The traditional public-key algorithm, widely compatible across platforms and software. RSA keys are larger than ECDSA keys (2048+ bits).
 
 **Learn more:**
-- [Elliptic Curve Cryptography (ECC) SSL Certificates](/articles/can-elliptic-curve-key-ssl-certificates/)
+- [Do You Support Elliptic Curve Cryptography (ECC) SSL Certificates?](/articles/can-elliptic-curve-key-ssl-certificates/)
 
 ### ECDSA {#ecdsa}
 
 Elliptic Curve Digital Signature Algorithm. A key algorithm that produces smaller, faster keys than RSA at equivalent security levels. DNSimple defaults to ECDSA (`prime256v1`) for new certificates.
 
 **Learn more:**
-- [Elliptic Curve Cryptography (ECC) SSL Certificates](/articles/can-elliptic-curve-key-ssl-certificates/)
+- [Do You Support Elliptic Curve Cryptography (ECC) SSL Certificates?](/articles/can-elliptic-curve-key-ssl-certificates/)
 - [How to Switch From an ECC-Signed Certificate to RSA](/articles/i-got-an-ecc-certificate-but-i-want-a-rsa-one/)
 
 ### SHA-2 / SHA-256 {#sha2}

--- a/content/articles/tlds.md
+++ b/content/articles/tlds.md
@@ -22,7 +22,7 @@ DNSimple supports registration and transfer for many top-level domains (TLDs), i
 Understand what TLDs are and which ones have special requirements:
 
 - [What is a TLD?](/articles/what-is-tld/) - What a top-level domain is, how TLDs are grouped (gTLD, ccTLD, new gTLD), and where to see [TLDs supported by DNSimple](https://dnsimple.com/tlds).
-- [Regulated Top-Level Domains](/articles/tlds-regulated/) - Requirements for regulated and highly-regulated TLDs (e.g., .BANK, .INSURANCE) and lists of which TLDs fall into each group.
+- [Regulated and Highly-Regulated Top-Level Domains](/articles/tlds-regulated/) - Requirements for regulated and highly-regulated TLDs (e.g., .BANK, .INSURANCE) and lists of which TLDs fall into each group.
 
 ## Documentation by TLD
 

--- a/content/articles/troubleshooting-dnssec-configurations.md
+++ b/content/articles/troubleshooting-dnssec-configurations.md
@@ -8,7 +8,7 @@ categories:
 
 # Troubleshoot DNSSEC
 
-If you're new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/) to understand what DNSSEC is and how it works. For a comprehensive overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+If you're new to DNSSEC, start with [What Is DNSSEC?](/articles/what-is-dnssec/) to understand what DNSSEC is and how it works. For a comprehensive overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ### Table of Contents {#toc}
 

--- a/content/articles/types-of-dnssec-keys.md
+++ b/content/articles/types-of-dnssec-keys.md
@@ -26,7 +26,7 @@ It also connects your domain to the global [DNSSEC chain of trust](/articles/dns
 
 ## Learn more
 
-To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To understand how DS records connect your KSK to the parent zone, see [What Are DS Records?](/articles/what-are-ds-records/). For information about DNSSEC key rotation, see [Rotate DNSSEC Keys](/articles/rotate-dnssec-key/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To understand how DS records connect your KSK to the parent zone, see [What Are DS Records?](/articles/what-are-ds-records/). For information about DNSSEC key rotation, see [Rotate DNSSEC Keys](/articles/rotate-dnssec-key/). For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 If you want to explore more DNSSEC terms, take a look at our [DNSSEC Glossary](/articles/dnssec-glossary/). Ready to get started with DNSSEC? Read [Enable DNSSEC](/articles/enabling-dnssec/). If you have further questions or need any assistance, [contact our support team](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/understanding-rrsets-rrsigs.md
+++ b/content/articles/understanding-rrsets-rrsigs.md
@@ -86,7 +86,7 @@ For more in-depth troubleshooting steps and tools related to DNSSEC, read [Troub
 
 ## Learn more {#learn-more}
 
-To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/). For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 Ready to get started with DNSSEC? Read [Enable DNSSEC](/articles/enabling-dnssec/) for detailed instructions. 

--- a/content/articles/what-are-cds-and-cdnskey.md
+++ b/content/articles/what-are-cds-and-cdnskey.md
@@ -62,7 +62,7 @@ CDS and CDNSKEY help prevent this by ensuring that DS records are automatically 
 
 ## Learn more {#learn-more}
 
-To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 

--- a/content/articles/what-are-ds-records.md
+++ b/content/articles/what-are-ds-records.md
@@ -140,7 +140,7 @@ In this answer, we can see that the `howdnssec.works` zone has a DS record with 
 
 ## Learn more {#learn-more}
 
-To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For step-by-step instructions on managing DS records, see [Add and Remove DS Records](/articles/manage-ds-record/). For information about managing DS records when changing DNS providers, see [Manage DS Records When Changing DNS](/articles/ds-records-changing-dns/). For information about DNSSEC key rotation, see [Rotate DNSSEC Keys](/articles/rotate-dnssec-key/). For a complete overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/).
+To learn more about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/). For step-by-step instructions on managing DS records, see [Add and Remove DS Records](/articles/manage-ds-record/). For information about managing DS records when changing DNS providers, see [Manage DS Records When Changing DNS](/articles/ds-records-changing-dns/). For information about DNSSEC key rotation, see [Rotate DNSSEC Keys](/articles/rotate-dnssec-key/). For a complete overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Have more questions?
 If you want to explore more DNSSEC terms, take a look at our [DNSSEC Glossary](/articles/dnssec-glossary/). Ready to get started with DNSSEC? Read [Enable DNSSEC](/articles/enabling-dnssec/). If you have further questions or need any assistance, [contact our support team](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/what-are-glue-records.md
+++ b/content/articles/what-are-glue-records.md
@@ -25,7 +25,7 @@ categories:
 
 Glue records are the IP addresses, stored as A or AAAA records, for authoritative name servers when those name server hostnames live inside the domain being delegated. For example, if example.com uses ns1.example.com as one of its name servers, the parent zone, often the TLD, must publish the IP address for ns1.example.com together with the NS delegation.
 
-Resolvers need those IP addresses so they can reach the authoritative name servers before querying the child zone. This prevents the lookup from circling back on itself. For general context on authoritative servers, see [What is a name server?](/articles/what-is-a-nameserver/).
+Resolvers need those IP addresses so they can reach the authoritative name servers before querying the child zone. This prevents the lookup from circling back on itself. For general context on authoritative servers, see [What is a Name Server?](/articles/what-is-a-nameserver/).
 
 ## The circular dependency problem {#circular-dependency}
 

--- a/content/articles/what-are-vanity-name-servers.md
+++ b/content/articles/what-are-vanity-name-servers.md
@@ -15,7 +15,7 @@ categories:
 
 Vanity name servers (also called private name servers or custom name servers) are authoritative name server hostnames that use your own domain instead of your DNS provider's defaults. For example, you might publish `ns1.example.com` and `ns2.example.com` at the registry instead of hostnames such as `ns1.dnsimple.com`. Public lookups still show which servers are authoritative; only the hostnames change.
 
-For background on what authoritative name servers do in general, see [What is a name server?](/articles/what-is-a-nameserver/).
+For background on what authoritative name servers do in general, see [What is a Name Server?](/articles/what-is-a-nameserver/).
 
 ### Table of Contents {#toc}
 

--- a/content/articles/what-is-a-nameserver.md
+++ b/content/articles/what-is-a-nameserver.md
@@ -38,8 +38,8 @@ That registrar-level change is separate from editing DNS records inside your zon
 
 DNSimple does not change delegation on your behalf without your action. To point a domain at DNSimple's DNS:
 
-- If the domain is registered with DNSimple, see [Delegating a Domain registered with DNSimple to DNSimple](/articles/delegating-dnsimple-registered/).
-- If the domain is registered elsewhere, see [Delegating a Domain registered with another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/).
+- If the domain is registered with DNSimple, see [Delegate a DNSimple-Registered Domain to DNSimple Name Servers](/articles/delegating-dnsimple-registered/).
+- If the domain is registered elsewhere, see [Delegate a Domain from Another Registrar to DNSimple](/articles/delegating-dnsimple-hosted/).
 - If the domain is registered with DNSimple and you want to use another DNS provider, see [Setting the Name Servers for a Domain](/articles/setting-name-servers/).
 
 For a general overview of pointing a domain to DNSimple, see [Pointing a Domain to DNSimple](/articles/pointing-domain-to-dnsimple/). The hostnames and addresses you delegate to are listed in [DNSimple Name Servers](/articles/dnsimple-nameservers/). For the full index of name server guides, see [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/).

--- a/content/articles/what-is-dane.md
+++ b/content/articles/what-is-dane.md
@@ -84,7 +84,7 @@ DANE is particularly valuable for email security (SMTP), where it can be used to
 
 DANE is fundamentally dependent on DNSSEC. Without DNSSEC, TLSA records cannot be cryptographically verified, which means they could be spoofed or modified by attackers. DNSSEC provides the chain of trust that makes DANE records trustworthy.
 
-If you are interested in implementing DANE, you must first [enable DNSSEC](/articles/enabling-dnssec/) on your domain. For more information about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/) and [DNSSEC at DNSimple](/articles/dnssec/).
+If you are interested in implementing DANE, you must first [enable DNSSEC](/articles/enabling-dnssec/) on your domain. For more information about DNSSEC, see [What Is DNSSEC?](/articles/what-is-dnssec/) and [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/).
 
 ## Limitations and considerations {#limitations-and-considerations}
 
@@ -108,7 +108,7 @@ The TLSA record format and usage are further detailed in [RFC 7671](https://data
 - [TLSA Record Format and Components Reference](/articles/tlsa-record-format/) - Technical reference for TLSA record format
 - [What Is DNSSEC?](/articles/what-is-dnssec/) - Learn about the DNS security extensions that DANE depends on
 - [Enable DNSSEC](/articles/enabling-dnssec/) - Step-by-step guide to enabling DNSSEC on your domain
-- [DNSSEC at DNSimple](/articles/dnssec/) - Comprehensive overview of DNSSEC features
+- [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/) - Comprehensive overview of DNSSEC features
 - [SSL/TLS Certificates](/categories/ssl-certificates/) - Learn about TLS certificates and how they work
 - [DNS Glossary](/articles/dns-glossary/) - Definitions of DNS-related terms
 

--- a/content/articles/what-is-dnssec.md
+++ b/content/articles/what-is-dnssec.md
@@ -52,7 +52,7 @@ If your domain's TLD supports DNSSEC, enabling it is a recommended security best
 
 ## Learn more about DNSSEC
 
-For a comprehensive overview of DNSSEC at DNSimple, see [DNSSEC at DNSimple](/articles/dnssec/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/).
+For a comprehensive overview of DNSSEC at DNSimple, see [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/). To explore DNSSEC terms and definitions, check out our [DNSSEC Glossary](/articles/dnssec-glossary/).
 
 ## Have more questions?
 If you have any questions about DNSSEC and how it works to keep your DNS secure, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/llms.txt.erb
+++ b/content/llms.txt.erb
@@ -101,7 +101,7 @@ DNSimple Support articles offer step-by-step help for customers and teams using 
 
 ## Optional
 
-- [DNSSEC at DNSimple](https://support.dnsimple.com/articles/dnssec/): Overview of DNSSEC support in DNSimple.
+- [DNS Security Extensions (DNSSEC) at DNSimple](https://support.dnsimple.com/articles/dnssec/): Overview of DNSSEC support in DNSimple.
 - [Enable DNSSEC](https://support.dnsimple.com/articles/enabling-dnssec/): How to enable DNSSEC signing for a zone in DNSimple.
 - [What Is DNSSEC?](https://support.dnsimple.com/articles/what-is-dnssec/): An explanation of DNSSEC and how it protects DNS responses from tampering.
 - [Vanity Name Servers](https://support.dnsimple.com/articles/vanity-nameservers/): How to configure custom-branded name servers using DNSimple.


### PR DESCRIPTION
Follow-up to #2096, per @Pemacaa's review note: some articles still use an old title as the clickable text of a link. The URLs were already correct, so nothing here changes a destination. Label text only.

## Scope rule

A label was rewritten only when it matched the target article's **previous title or previous H1 verbatim**. That keeps the change mechanical and reviewable, and it leaves inline prose labels alone, where the surrounding sentence, not the page title, is what should decide the wording:

- `[name servers](/articles/what-is-a-nameserver/)` - unchanged
- `[DNSSEC](/articles/dnssec/)` - unchanged
- `[here](/articles/can-ev-ssl-certificates/)` - unchanged

## What changed

| Article | Old label text | New label text | Links |
|---|---|---|---|
| `dnssec` | DNSSEC at DNSimple | DNS Security Extensions (DNSSEC) at DNSimple | 15 |
| `delegating-dnsimple-registered` | Delegating a Domain registered with DNSimple to DNSimple | Delegate a DNSimple-Registered Domain to DNSimple Name Servers | 7 |
| `what-is-a-nameserver` | What is a name server? | What is a Name Server? | 7 |
| `zone-ns-records` | Zone NS Records | Updating Zone NS Records for a Hosted Domain | 5 |
| `delegating-dnsimple-hosted` | Delegating a Domain registered with another Registrar to DNSimple | Delegate a Domain from Another Registrar to DNSimple | 5 |
| `tlds-regulated` | Regulated Top-Level Domains | Regulated and Highly-Regulated Top-Level Domains | 5 |
| `can-elliptic-curve-key-ssl-certificates` | Elliptic Curve Cryptography (ECC) SSL Certificates | Do You Support Elliptic Curve Cryptography (ECC) SSL Certificates? | 3 |
| `amazon-route-53-integration-demo` | How to Use Route 53 as an Integrated DNS Provider | How to Use Amazon Route 53 as an Integrated DNS Provider | 1 |

48 links across 36 files (47 changed lines; one line carries two of them).

Two of those are worth calling out:

- **`delegating-dnsimple-hosted`** is stale against `main` on its own, not just against #2096. Its frontmatter title is already *Delegate a Domain from Another Registrar to DNSimple*; the stale labels were copies of the old H1, which #2096 replaces.
- **`secondary-dnsimple`** linked to `zone-ns-records` as *Updating NS Records for the Zone of a Hosted Domain*, a title older still than the one #2096 touches. Same defect, folded in.

Also updated: `content/llms.txt.erb`, which carried *DNSSEC at DNSimple* in its curated index. It uses absolute `support.dnsimple.com` URLs, so it does not show up in a relative-link search. Worth remembering for future renames.

## Deliberately not included

Labels that were **never** the old title, so they are a separate editorial call rather than staleness:

- `getting-started-ssl-certificates` lines 164-167 use short FAQ-style labels (*Do you support ECC certificates?*, *Can I upgrade a single-name certificate to wildcard?*) that have never matched their targets' titles. That list reads as a curated FAQ, so shortening looks intentional.
- `ssl-domain-validation-methods:28` uses the new EV title in sentence case rather than title case. A case-only difference, and outside the verbatim rule above.

Happy to take either in a third pass if we want strict label-equals-title everywhere.

## Verification

- Diffed every changed line and confirmed **0 URLs changed**; the link targets are byte-identical before and after
- Confirmed each new label string is an exact match for the target article's frontmatter `title` as of #2096
- Swept the whole repo (not just `content/articles`, and not just `.md`) for the old title strings. Remaining hits are only in the files #2096 itself rewrites: the article titles, the two H1s, and `categories/dns.yaml` / `categories/integrations.yaml`

⚠️ `bundle exec rake` has **not** been run against this branch either. No Ruby or Node toolchain in the environment I built this in, so the same caveat as #2096 applies.

## Merge order

Branched from `main`, so it merges cleanly on its own, but it should land **after** #2096. On its own it would point readers at titles that do not exist yet.
