### PR TITLE
Point app links at app.dnsimple.com

### DIFF
--- a/.cursor/rules/article-structure.mdc
+++ b/.cursor/rules/article-structure.mdc
@@ -140,6 +140,7 @@ The certificate covers:
 - Internal articles: `/articles/article-slug/`
 - Developer docs: `https://developer.dnsimple.com/v2/...`
 - Product pages: `https://dnsimple.com/...`
+- Application pages: `https://app.dnsimple.com/...`
 - Link text should describe the destination: `[SSL certificate types](/articles/ssl-certificates-types/)` not `[click here](/articles/ssl-certificates-types/)`
 
 ### Images

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ When submitting a pull request:
    - Tag a second expert with knowledge of the feature/product
    - Use AI (Cursor or Claude Code) for proofreading, clarity, and voice/tone — the project rules in `.cursor/rules/` enforce the DNSimple editorial voice automatically
    - Tag Customer Success for review (required for substantial updates, optional for minor updates)
-4. **Testing:** If reviewers need to test a process, they should use https://sandbox.dnsimple.com
+4. **Testing:** If reviewers need to test a process, they should use https://app.sandbox.dnsimple.com
 5. Ensure all approvals are received
 6. Verify the pipeline is green
 7. Merge the PR yourself

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,7 @@ Every article should link to related articles. Cross-linking helps readers navig
 - Internal articles: use relative paths — `/articles/article-slug/`
 - Developer docs: `https://developer.dnsimple.com/v2/...`
 - Product/marketing pages: `https://dnsimple.com/...`
+- Application pages (anything behind login, plus `/login` and `/signup`): `https://app.dnsimple.com/...`
 - External references: include where helpful (e.g., Wikipedia, ICANN, RFC documents)
 - Use descriptive link text — `[SSL certificate types](/articles/ssl-certificates-types/)` not `[click here](/articles/ssl-certificates-types/)`
 - Ensure all links are current and functional

--- a/content/articles/account-creation.md
+++ b/content/articles/account-creation.md
@@ -40,7 +40,7 @@ Follow these steps to create a DNSimple account. You can create an account and e
 Until your user email is verified, some sensitive actions will be unavailable, including subscribing to a plan, registering or transferring domains, and purchasing SSL certificates. Check your inbox and complete the verification to get full access to your account.
 
 > [!NOTE]
-> Verification links expire after 7 days. If yours has expired, you can request a new one from your [user settings page](https://dnsimple.com/user).
+> Verification links expire after 7 days. If yours has expired, you can request a new one from your [user settings page](https://app.dnsimple.com/user).
 
 ## Adding additional accounts {#adding-additional-accounts}
 

--- a/content/articles/changing-email.md
+++ b/content/articles/changing-email.md
@@ -24,7 +24,7 @@ Your user email is tied to your personal DNSimple login. Changing it does not ch
 <div class="section-steps" markdown="1">
 ##### To change your user email
 
-1. Go to your [user page](https://dnsimple.com/user) by clicking the account switcher at the top-right corner of the screen, then select <label>User settings</label>.
+1. Go to your [user page](https://app.dnsimple.com/user) by clicking the account switcher at the top-right corner of the screen, then select <label>User settings</label>.
 
     ![Screenshot of link to user settings](/files/user-settings-menu.png)
 

--- a/content/articles/close-account.md
+++ b/content/articles/close-account.md
@@ -29,7 +29,7 @@ Deleting yourself as a user permanently removes your DNSimple user and all accou
 ##### To permanently delete yourself as a user
 
 1. [Unsubscribe your accounts from your plan at DNSimple](/articles/cancel-subscription/).
-1. Go to your [User Settings page](https://dnsimple.com/user):
+1. Go to your [User Settings page](https://app.dnsimple.com/user):
 
     ![screenshot of user settings menu link](/files/user-settings-menu.png)
 

--- a/content/articles/dns-hosting.md
+++ b/content/articles/dns-hosting.md
@@ -45,7 +45,7 @@ For streamlined management, you can transfer both your domain's registration and
 ### Register a new domain with DNSimple
 If you do not yet have a domain name, you can register a new domain directly through DNSimple. When you register a domain with us, you can manage your DNS by using DNSimple's name servers from day one, giving you immediate control over your DNS records.
 
-**How to proceed**: [Sign up or log in](https://dnsimple.com/login) to your DNSimple account and proceed with the domain registration process.
+**How to proceed**: [Sign up or log in](https://app.dnsimple.com/login) to your DNSimple account and proceed with the domain registration process.
 
 **Instructions**: For detailed steps, please refer to [Register a Domain](/articles/registering-domain/)
 

--- a/content/articles/entra-identity-provider.md
+++ b/content/articles/entra-identity-provider.md
@@ -44,9 +44,13 @@ For now, you can use Entra as an Identity Provider by [creating your own custom 
 ### Adding Redirect URIs
 
 After creating your app, add the [Redirect URIs](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-redirect-uri) for your new web app using the following URIs:
-1. https://app.dnsimple.com/identity_providers/entra/callbacks/users/login
-1. https://app.dnsimple.com/identity_providers/entra/callbacks/accounts/link
-1. https://app.dnsimple.com/identity_providers/entra/callbacks/users/link
+
+1. https://dnsimple.com/identity_providers/entra/callbacks/users/login
+1. https://dnsimple.com/identity_providers/entra/callbacks/accounts/link
+1. https://dnsimple.com/identity_providers/entra/callbacks/users/link
+
+> [!NOTE]
+> Use `dnsimple.com` in these Redirect URIs, not `app.dnsimple.com`. DNSimple sends `dnsimple.com` as the redirect URI in the sign-in request, and then forwards you to `app.dnsimple.com`. Entra rejects the sign-in if the registered URI does not match the one DNSimple sends.
 
 ### Adding API permissions
 

--- a/content/articles/entra-identity-provider.md
+++ b/content/articles/entra-identity-provider.md
@@ -44,9 +44,9 @@ For now, you can use Entra as an Identity Provider by [creating your own custom 
 ### Adding Redirect URIs
 
 After creating your app, add the [Redirect URIs](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-redirect-uri) for your new web app using the following URIs:
-1. https://dnsimple.com/identity_providers/entra/callbacks/users/login
-1. https://dnsimple.com/identity_providers/entra/callbacks/accounts/link
-1. https://dnsimple.com/identity_providers/entra/callbacks/users/link
+1. https://app.dnsimple.com/identity_providers/entra/callbacks/users/login
+1. https://app.dnsimple.com/identity_providers/entra/callbacks/accounts/link
+1. https://app.dnsimple.com/identity_providers/entra/callbacks/users/link
 
 ### Adding API permissions
 
@@ -98,7 +98,7 @@ To link a DNSimple user to an Entra identity:
 ## Logging in via Entra {#logging-in-via-entra}
 
 You'll need to [link an Entra organization to your DNSimple account](#linking-entra-organization) before your team members can log in via Entra SSO.
-1. To log in to DNSimple using Entra, visit [https://dnsimple.com/login](https://dnsimple.com/login).
+1. To log in to DNSimple using Entra, visit [https://app.dnsimple.com/login](https://app.dnsimple.com/login).
 1. Click **Sign in using Entra**.
 1. Enter the [organization Entra domain or tenant ID](https://learn.microsoft.com/en-us/partner-center/account-settings/find-ids-and-domain-names#find-the-microsoft-entra-tenant-id-and-primary-domain-name) and click **Sign in**. The Entra domain is the default/primary domain in the Entra account.
 1. If you are prompted for your Entra username and password, enter them.

--- a/content/articles/finding-missing-domain.md
+++ b/content/articles/finding-missing-domain.md
@@ -39,7 +39,7 @@ If you have [multiple DNSimple accounts](/articles/account-multi/) or created a 
 To check:
 
 1. Open the **account switcher** in the top-right corner of the dashboard and look at each account listed. The domain may be in an account you are not currently viewing.
-2. If you think you may have used a different email address, try logging in at [dnsimple.com/login](https://dnsimple.com/login) with that email. Use the [password reset](/articles/forgot-password/) flow if you do not remember the password.
+2. If you think you may have used a different email address, try logging in at [app.dnsimple.com/login](https://app.dnsimple.com/login) with that email. Use the [password reset](/articles/forgot-password/) flow if you do not remember the password.
 3. If you still cannot locate the domain, [contact support](https://dnsimple.com/feedback) with the domain name, and we can help you find which account it belongs to.
 
 ## Have more questions?

--- a/content/articles/forgot-password.md
+++ b/content/articles/forgot-password.md
@@ -28,7 +28,7 @@ Reset your password when you cannot sign in with your current credentials. Use t
 <div class="section-steps" markdown="1">
 ##### To request a password reset link
 
-1. Go to the [login page](https://dnsimple.com/login), and click <label>Forgot Password</label>.
+1. Go to the [login page](https://app.dnsimple.com/login), and click <label>Forgot Password</label>.
 
     ![screenshot of forgot password link](/files/forgot-password-link.png)
 

--- a/content/articles/getting-started-clickfunnels.md
+++ b/content/articles/getting-started-clickfunnels.md
@@ -51,7 +51,7 @@ ClickFunnels will reply when the domain has been moved. You will also receive an
 ## Accept the domain push {#accept-push}
 
 <div class="section-steps" markdown="1">
-1. [Log in to DNSimple](https://dnsimple.com/login). You will see a notification on your dashboard about the pending push.
+1. [Log in to DNSimple](https://app.dnsimple.com/login). You will see a notification on your dashboard about the pending push.
 1. Click <label>View</label> to see the pending domain push, then click <label>Accept</label>.
 1. You will be prompted to assign a [contact](/articles/changing-domain-contact/) to the domain. This updates the registrant information from ClickFunnels to you.
 1. Click <label>Accept Push</label> to complete the transfer.

--- a/content/articles/google-identity-provider.md
+++ b/content/articles/google-identity-provider.md
@@ -19,7 +19,7 @@ Use Google as an identity provider to streamline login for you and your team. Fo
 
 ## Registering a new DNSimple account via Google {#registering-via-google}
 
-[Signing up](https://dnsimple.com/signup) for a DNSimple account using Google as your identity provider is straightforward.
+[Signing up](https://app.dnsimple.com/signup) for a DNSimple account using Google as your identity provider is straightforward.
 
 1. Click **Sign up using Google**.
 1. Select your Google account.

--- a/content/articles/multi-factor-authentication.md
+++ b/content/articles/multi-factor-authentication.md
@@ -34,7 +34,7 @@ When you enable MFA for your user profile, DNSimple logs you out of all currentl
 <div class="section-steps" markdown="1">
 ##### To enable multi-factor authentication with one-time password
 
-1. Go to your [user page](https://dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
+1. Go to your [user page](https://app.dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
     ![screenshot: user settings menu item](/files/user-settings-menu.png)
 
 1. In the **2-Step Verification** card, click **Add** next to "Connect an authenticator app that generates verification codes".
@@ -60,7 +60,7 @@ When you enable MFA for your user profile, DNSimple logs you out of all currentl
 <div class="section-steps" markdown="1">
 ##### To enable multi-factor authentication with a security key
 
-1. Go to your [user page](https://dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
+1. Go to your [user page](https://app.dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
     ![screenshot: user settings menu item](/files/user-settings-menu.png)
 
 1. In the **2-Step Verification** card, click **Add** next to "Connect a security key to your user" to connect a new security key to your user profile.
@@ -88,7 +88,7 @@ You can remove a one-time password authenticator application or any security key
 <div class="section-steps" markdown="1">
 ##### To disable a one-time password authenticator application
 
-1. Go to your [user page](https://dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
+1. Go to your [user page](https://app.dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
   ![screenshot: user settings menu item](/files/user-settings-menu.png)
 
 1. In the **2-Step Verification** card, click **Delete** next to the displayed authenticator app configuration. This will take you to the confirmation page.
@@ -101,7 +101,7 @@ You can remove a one-time password authenticator application or any security key
 <div class="section-steps" markdown="1">
 ##### To disable a security key
 
-1. Go to your [user page](https://dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
+1. Go to your [user page](https://app.dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
   ![screenshot: user settings menu item](/files/user-settings-menu.png)
 
 1. In the **2-Step Verification** card, click **Delete** next to the security key you would like to disable. This will take you to the confirmation page.
@@ -196,7 +196,7 @@ Recovery codes can be regenerated. When a recovery code is regenerated, you cann
 <div class="section-steps" markdown="1">
 ##### Regenerating a recovery code
 
-1. Go to your [user page](https://dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
+1. Go to your [user page](https://app.dnsimple.com/user) by selecting **User settings** in the account switcher at the top-right corner of the screen.
   ![screenshot: user settings menu item](/files/user-settings-menu.png)
 
 1. In the **2-Step Verification** card, click **Re-generate** next to the existing recovery code.

--- a/content/articles/nis2-contact-verification.md
+++ b/content/articles/nis2-contact-verification.md
@@ -34,7 +34,7 @@ The email has these characteristics:
 
 - **From:** `DNSimple <support@dnsimple.com>`
 - **Subject:** Action Required: Verify your contact email address
-- **Link:** a `https://dnsimple.com/email_verification/...` address unique to that contact email
+- **Link:** a `https://app.dnsimple.com/email_verification/...` address unique to that contact email
 
 The link expires 7 days after the verification email is sent. The message states the exact date and time it expires, so complete the verification before then. If you cannot find the email, check your spam folder.
 

--- a/content/articles/okta-identity-provider.md
+++ b/content/articles/okta-identity-provider.md
@@ -106,7 +106,7 @@ To link a DNSimple user to an Okta identity:
 
 You'll need to [link an Okta organization to your DNSimple account](#linking-okta-organization) before your team members can log in via Okta SSO.
 
-1. To log in to DNSimple using Okta, visit [https://dnsimple.com/login](https://dnsimple.com/login).
+1. To log in to DNSimple using Okta, visit [https://app.dnsimple.com/login](https://app.dnsimple.com/login).
 1. Click **Sign in using Okta**.
 1. Enter the company's Okta domain and click **Sign in**.
 1. If you are prompted for your Okta username and password, enter them.

--- a/content/articles/reactivate-subscription.md
+++ b/content/articles/reactivate-subscription.md
@@ -38,7 +38,7 @@ For what happens when payment stops, see [What Happens If You Stop Paying for DN
 ##### To reactivate from the dashboard
 
 1. Log in to DNSimple with your user credentials.
-1. Go to [your dashboard](https://dnsimple.com/dashboard).
+1. Go to [your dashboard](https://app.dnsimple.com/dashboard).
 1. In the accounts section, find the card for the account you want to reactivate.
 1. Click <label>Unlock advanced features</label> on that card.
 
@@ -72,7 +72,7 @@ For what happens when payment stops, see [What Happens If You Stop Paying for DN
 ##### To reactivate from the alert banner
 
 1. Log in to DNSimple with your user credentials.
-1. Go to your [dashboard](https://dnsimple.com/dashboard).
+1. Go to your [dashboard](https://app.dnsimple.com/dashboard).
 1. If your account still has domains stored in it, click <label>Choose plan</label> in the alert banner at the top of the screen.
 1. Choose the plan that fits your needs, and click <label>Get started</label>.
 1. Enter your payment information and click <label>Create new subscription</label>.

--- a/content/articles/reasons-hosting-dns.md
+++ b/content/articles/reasons-hosting-dns.md
@@ -24,7 +24,7 @@ We also believe in choosing the best tooling to get the job done. With no vendor
 
 Explore DNSimple's variety of [services](/articles/services/), read what other companies [have to say](https://dnsimple.com/customers) about their experiences using DNSimple, and delve into our [API](https://dnsimple.com/api) with video tutorials for each supported language. If you are one of those customers, [leave a review](/articles/leave-a-review/) and help others find DNSimple.
 
-You can even try DNSimple [free for 30 days](https://dnsimple.com/signup), and explore our simple, secure DNS solutions for yourself. Whether you're registering your first domain name or you've got a business with a portfolio of domains, we've got a plan to fit your needs.
+You can even try DNSimple [free for 30 days](https://app.dnsimple.com/signup), and explore our simple, secure DNS solutions for yourself. Whether you're registering your first domain name or you've got a business with a portfolio of domains, we've got a plan to fit your needs.
 
 If you want to learn more about how we simplify your domain management, or have questions about your specific DNS and domain management needs, feel free to [contact us](https://dnsimple.com/sales).
 

--- a/content/articles/sandbox-pitfalls.md
+++ b/content/articles/sandbox-pitfalls.md
@@ -37,7 +37,7 @@ Sandbox data and systems are generally treated like production, but DNSimple may
 
 Your production account and Sandbox account are completely independent. Your production [API access token](/articles/api-access-token/) will not work in the Sandbox, and your Sandbox token will not work in production. If API calls are returning authentication errors, verify you are using the correct token for the environment.
 
-The Sandbox web interface is at `https://sandbox.dnsimple.com`, and the Sandbox API is at `https://api.sandbox.dnsimple.com`.
+The Sandbox web interface is at `https://app.sandbox.dnsimple.com`, and the Sandbox API is at `https://api.sandbox.dnsimple.com`.
 
 ## The Sandbox is a shared system {#shared-system}
 

--- a/content/articles/sandbox-tutorial.md
+++ b/content/articles/sandbox-tutorial.md
@@ -28,7 +28,7 @@ This tutorial walks you through setting up the DNSimple Sandbox and making your 
 
 Before you begin, ensure you have:
 
-- **A DNSimple Sandbox account.** Sign up at [sandbox.dnsimple.com](https://sandbox.dnsimple.com/signup).
+- **A DNSimple Sandbox account.** Sign up at [app.sandbox.dnsimple.com](https://app.sandbox.dnsimple.com/signup).
 - **A Sandbox API access token.** See [API Access Token](/articles/api-access-token/) for instructions on generating a token.
 - **curl** installed on your system. Most macOS and Linux systems include it by default.
 
@@ -73,7 +73,7 @@ The `account.id` value is the account ID you will use in all subsequent API call
 
 ## 3. Creating DNS records {#create-records}
 
-Add a domain to your Sandbox account through the [web interface](https://sandbox.dnsimple.com) or the API, then create DNS records for it. This example creates an A record pointing the apex domain to an IP address:
+Add a domain to your Sandbox account through the [web interface](https://app.sandbox.dnsimple.com) or the API, then create DNS records for it. This example creates an A record pointing the apex domain to an IP address:
 
 ```bash
 curl -H "Authorization: Bearer $DNSIMPLE_TOKEN" \

--- a/content/articles/sandbox.md
+++ b/content/articles/sandbox.md
@@ -23,7 +23,7 @@ categories:
   <iframe loading="lazy" src="https://www.youtube.com/embed/RfQjvi75e7M" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-DNSimple maintains an isolated test environment at [sandbox.dnsimple.com](https://sandbox.dnsimple.com/) that mirrors the full production platform — web interface, domain management, DNS hosting, and API. The Sandbox provides a safe space to explore DNSimple features, test workflows, and develop integrations without risking changes to live domains, DNS records, or certificates.
+DNSimple maintains an isolated test environment at [app.sandbox.dnsimple.com](https://app.sandbox.dnsimple.com/) that mirrors the full production platform — web interface, domain management, DNS hosting, and API. The Sandbox provides a safe space to explore DNSimple features, test workflows, and develop integrations without risking changes to live domains, DNS records, or certificates.
 
 ## Why use the Sandbox? {#why}
 
@@ -43,8 +43,8 @@ The Sandbox is valuable for:
 
 The Sandbox mirrors the production environment, so workflows that succeed in the Sandbox will work in production with minimal changes. The key differences are:
 
-- **Separate accounts:** Your Sandbox account is independent of your production account. [Create a Sandbox account](https://sandbox.dnsimple.com/signup) to get started. If you are using the API, generate a separate [API access token](/articles/api-access-token/).
-- **Separate URLs:** The Sandbox web interface is at `https://sandbox.dnsimple.com`. The Sandbox API is at `https://api.sandbox.dnsimple.com`.
+- **Separate accounts:** Your Sandbox account is independent of your production account. [Create a Sandbox account](https://app.sandbox.dnsimple.com/signup) to get started. If you are using the API, generate a separate [API access token](/articles/api-access-token/).
+- **Separate URLs:** The Sandbox web interface is at `https://app.sandbox.dnsimple.com`. The Sandbox API is at `https://api.sandbox.dnsimple.com`.
 - **No real DNS resolution:** There is no public authoritative name server in the Sandbox. Zones and records you create will not resolve on the public internet.
 - **Simulated domain registrations:** Domain registrations, transfers, and renewals run against registry OT&E environments, not live production registries. Domains registered in the Sandbox do not affect real-world domain status.
 - **No certificate testing:** SSL/TLS certificate testing is not currently supported in the Sandbox because certificate validation requires actual DNS service.
@@ -58,7 +58,7 @@ The Sandbox mirrors the production environment, so workflows that succeed in the
 <div class="section-steps" markdown="1">
 ##### Setting up a Sandbox account
 
-1. Go to [sandbox.dnsimple.com/signup](https://sandbox.dnsimple.com/signup) and create an account. It does not need to match your production account.
+1. Go to [app.sandbox.dnsimple.com/signup](https://app.sandbox.dnsimple.com/signup) and create an account. It does not need to match your production account.
 1. Choose a [plan](https://sandbox.dnsimple.com/pricing) that matches the features you want to test.
 1. Subscribe using a Stripe test credit card number (e.g. `4242 4242 4242 4242` with any future expiration date and any CVC).
 1. Start adding domains, managing DNS zones, and exploring DNSimple features.

--- a/content/articles/setting-up-accounts-for-clients.md
+++ b/content/articles/setting-up-accounts-for-clients.md
@@ -35,7 +35,7 @@ Follow [Multiple Accounts Per User](/articles/account-multi/#creating-a-separate
 
 Your client must register with DNSimple before you add them to the new account.
 
-On [the signup page](https://dnsimple.com/signup), your client can register with their user email or via [Google as an identity provider](/articles/google-identity-provider/).
+On [the signup page](https://app.dnsimple.com/signup), your client can register with their user email or via [Google as an identity provider](/articles/google-identity-provider/).
 
 > [!NOTE]
 > Your client does not need an active subscription or a card on file. They only need a DNSimple user.

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -70,7 +70,7 @@
             </button>
 
             <div class="dual-cta-container">
-              <a href="https://dnsimple.com/signup?utm_source=support&utm_medium=web&utm_content=cta-header"
+              <a href="https://app.dnsimple.com/signup?utm_source=support&utm_medium=web&utm_content=cta-header"
                 class="primary">Get Started</a>
               <a href="https://dnsimple.com/enterprises?utm_source=support&utm_medium=web&utm_content=cta-header#contact-sales"
                 class="secondary">Contact Sales</a>


### PR DESCRIPTION
## Summary

The application moved from `dnsimple.com` to `app.dnsimple.com`, so every support link that points at a page behind login now uses the app host. The `/user` and `/dashboard` links returned a 404 on the bare host, and the `/login` and `/signup` redirects drop the query string, which cost the header CTA its UTM parameters. Sandbox moved the same way: `sandbox.dnsimple.com` now serves the marketing copy, and the web interface is at `app.sandbox.dnsimple.com`.

The Entra redirect URIs stay on `dnsimple.com`. DNSimple sends the bare host as the redirect URI in the authorization request, and `docs/subapps.md` records that host as a durable compatibility boundary, so a registration on the app host fails at Entra. dnsimple/dnsimple-app#36593 changes that decision, and this article needs a follow-up when it lands.

## Files changed

- `content/articles/` — the user, dashboard, login, signup, email verification, and Sandbox links use the app host
- `layouts/default.html` — the header CTA uses the app host, so the UTM parameters survive
- `CONTRIBUTING.md`, `.cursor/rules/article-structure.mdc` — the link conventions record the app host

The marketing links stay on `dnsimple.com`. I checked each one against the site route set and confirmed that it serves on the bare host.

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [x] Cross-links added on first mention of related concepts
- [x] Existing articles updated to link back (if applicable)
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`
- [x] Tested locally with `rake run`

## Review

- [ ] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)
