### PR TITLE
Correct the number of records allowed per zone on Teams.

### DIFF
--- a/content/articles/dnsimple-plans.md
+++ b/content/articles/dnsimple-plans.md
@@ -21,7 +21,7 @@ You'll find all [the features listed for each plan on our pricing page](https://
 |---------|:----:|:-----:|:----------:|
 | Domain registration, transfer, renewal | Yes | Yes | Yes |
 | DNS zones with Anycast, DNSSEC, DDoS defense | Yes | Yes | Yes |
-| DNS records per zone | 100 | 100 | Custom |
+| DNS records per zone | 100 | 1000 | Custom |
 | Let's Encrypt (root and www) | Yes | Yes | Yes |
 | Let's Encrypt custom hostnames | -- | Yes | Yes |
 | Let's Encrypt wildcard | -- | Yes | Yes |
@@ -96,6 +96,7 @@ $29 base monthly subscription fee — includes one seat with the ability to add
 
 ### The Teams plan includes everything on the Solo plan, plus:
 
+- 1000 DNS records per zone
 - [HTTPS URL redirects](/articles/redirector/)
 - Let's Encrypt custom hostname certificates
 - Let's Encrypt [wildcard certificates](/articles/buy-wildcard-ssl-certificate/)


### PR DESCRIPTION
## Summary

Teams plans are permitted 1000 records in a zone.

## Files changed

- `dnsimple-plans.md`

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [x] Cross-links added on first mention of related concepts
- [x] Existing articles updated to link back (if applicable)
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`
- [x] Tested locally with `rake run`

## Review

- [x] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)
