### PR TITLE
Document .SE registrant data verification

### DIFF
--- a/content/articles/domains-se.md
+++ b/content/articles/domains-se.md
@@ -24,6 +24,21 @@ To register a .SE domain, an ID number (e.g. civic registration number, company 
 ### VAT ID
 To register a .SE domain, a VAT ID must be stated for companies located within the European Union but outside Sweden. This attribute is optional for companies located within Sweden.
 
+## Registrant data verification {#registrant-verification}
+
+The .SE registry can require the registrant data on a registered domain to be verified, not only at registration. This happens when the registry flags the registrant record and asks for the details to be confirmed by a deadline.
+
+When this happens, DNSimple emails the account's domain notification recipients. The notice tells us the deadline and that the registry has applied restrictive statuses, such as `serverTransferProhibited` and `serverRenewProhibited`, but it does not tell us which details the registry considers wrong. If the deadline passes, the registry can suspend the domain and it stops resolving.
+
+To resolve a registrant data verification request:
+
+- Reply to the notice, or [contact us](https://dnsimple.com/feedback), so we can ask the registry what needs to change. There is no self-serve step for .SE.
+- Confirm the registrant contact on the domain is accurate, including the ID number and, for companies in the European Union outside Sweden, the VAT ID.
+- Correct any wrong or outdated details by following [Changing Domain Contacts](/articles/changing-domain-contact/).
+
+> [!NOTE]
+> Each affected domain gets its own notice, so a registrant with several .SE domains hears from us about each one.
+
 ## Have more questions?
 
 If you have any questions about registering, transferring, or renewing your .SE domain, [contact us](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/domains-se.md
+++ b/content/articles/domains-se.md
@@ -28,9 +28,9 @@ To register a .SE domain, a VAT ID must be stated for companies located within t
 
 The .SE registry can require the registrant data on a registered domain to be verified, not only at registration. This happens when the registry flags the registrant record and asks for the details to be confirmed by a deadline.
 
-When this happens, DNSimple emails the account's domain notification recipients. The notice tells us the deadline and that the registry has applied restrictive statuses, such as `serverTransferProhibited` and `serverRenewProhibited`, but it does not tell us which details the registry considers wrong. If the deadline passes, the registry can suspend the domain and it stops resolving.
+When it does, DNSimple emails the account's domain notification recipients with the deadline the registry set. Until the data is verified the registry restricts what can be done with the domain, and once the deadline passes it can suspend the domain, at which point the domain stops resolving.
 
-There is no self-serve step for .SE. Reply to the notice, or [contact us](https://dnsimple.com/feedback), and we take the verification up with the registry on your behalf.
+Reply to the notice, or [contact us](https://dnsimple.com/feedback), and we complete the verification with the registry for you.
 
 > [!NOTE]
 > Each affected domain gets its own notice, so a registrant with several .SE domains hears from us about each one.

--- a/content/articles/domains-se.md
+++ b/content/articles/domains-se.md
@@ -32,9 +32,6 @@ When it does, DNSimple emails the account's domain notification recipients with 
 
 Reply to the notice, or [contact us](https://dnsimple.com/feedback), and we complete the verification with the registry for you.
 
-> [!NOTE]
-> Each affected domain gets its own notice, so a registrant with several .SE domains hears from us about each one.
-
 ## Have more questions?
 
 If you have any questions about registering, transferring, or renewing your .SE domain, [contact us](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/domains-se.md
+++ b/content/articles/domains-se.md
@@ -30,11 +30,7 @@ The .SE registry can require the registrant data on a registered domain to be ve
 
 When this happens, DNSimple emails the account's domain notification recipients. The notice tells us the deadline and that the registry has applied restrictive statuses, such as `serverTransferProhibited` and `serverRenewProhibited`, but it does not tell us which details the registry considers wrong. If the deadline passes, the registry can suspend the domain and it stops resolving.
 
-To resolve a registrant data verification request:
-
-- Reply to the notice, or [contact us](https://dnsimple.com/feedback), so we can ask the registry what needs to change. There is no self-serve step for .SE.
-- Confirm the registrant contact on the domain is accurate, including the ID number and, for companies in the European Union outside Sweden, the VAT ID.
-- Correct any wrong or outdated details by following [Changing Domain Contacts](/articles/changing-domain-contact/).
+There is no self-serve step for .SE. Reply to the notice, or [contact us](https://dnsimple.com/feedback), and we take the verification up with the registry on your behalf.
 
 > [!NOTE]
 > Each affected domain gets its own notice, so a registrant with several .SE domains hears from us about each one.


### PR DESCRIPTION
## Summary

Documents .SE registrant data verification, which the registry can require after a domain is already registered. DNSimple is starting to notify customers when the registry flags a .SE domain (dnsimple/dnsimple-app#36716), and the notification email links `/articles/domains-se/#registrant-verification`, which is the section this PR adds. The section explains when the registry asks for verification, what happens if the deadline passes, and the one step the customer takes: reply to us, and we complete it with the registry.

This should land before dnsimple/dnsimple-app#36716 deploys, otherwise the email links an anchor that does not exist.

I could not run `rake run` locally: a git-sourced gem in the bundle is not checked out on this machine, so the checklist item below is unticked.

## Files changed

- `content/articles/domains-se.md` — adds `## Registrant data verification {#registrant-verification}` between the registration requirements and "Have more questions?".

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [x] Cross-links added on first mention of related concepts
- [x] Existing articles updated to link back (if applicable)
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`

## Review

- [x] Customer Success tagged (required for substantial updates)
