### PR TITLE
Add updates related to edge network migration

### DIFF
--- a/content/articles/a-record-format.md
+++ b/content/articles/a-record-format.md
@@ -19,7 +19,7 @@ The canonical representation is:
 ```
 A <address>
 ```
-where `<address>` is an IPv4 address and looks like `162.159.24.4`.
+where `<address>` is an IPv4 address and looks like `192.0.2.1`.
 
 For a deeper explanation of what A records are and how they work, see [What Is an A Record?](/articles/a-record/)
 

--- a/content/articles/aaaa-record-format.md
+++ b/content/articles/aaaa-record-format.md
@@ -19,7 +19,7 @@ The canonical representation is:
 AAAA <address>
 ```
 
-where `<address>` is an IPv6 address and looks like `2400:cb00:2049:1::a29f:1804`.
+where `<address>` is an IPv6 address and looks like `2001:db8::1`.
 
 For a broader explanation of what AAAA records are and how they work, see [What Is an AAAA Record](/articles/aaaa-record/)?
 

--- a/content/articles/announcement-ns1-ns3-ip-addresses.md
+++ b/content/articles/announcement-ns1-ns3-ip-addresses.md
@@ -87,7 +87,7 @@ dig +short ns1.yourdomain.com
 dig +short ns3.yourdomain.com
 ```
 
-If the response contains `162.159.24.4` or `162.159.26.4` (or the matching IPv6 addresses), the host is no longer resolving and you need to update your configuration to the replacement IPs.
+If the query returns `162.159.24.4` or `162.159.26.4` (or the matching IPv6 addresses), or fails to return an answer at all, the glue records still point at the retired IPs. Update them at your registrar to the replacement IPs listed above; `whois yourdomain.com` shows the name server addresses the registry currently publishes.
 
 For non-vanity setups, you can check which name servers your domain uses at its registrar. If they reference `ns1.dnsimple.com` or `ns3.dnsimple.com`, they now resolve to the new edge infrastructure and no action is required.
 

--- a/content/articles/announcement-ns1-ns3-ip-addresses.md
+++ b/content/articles/announcement-ns1-ns3-ip-addresses.md
@@ -1,7 +1,7 @@
 ---
 title: Discontinuation of Legacy NS1 and NS3 IP Addresses
-excerpt: DNSimple is migrating NS1 and NS3 to new edge infrastructure. Legacy Cloudflare IP addresses will be fully retired on July 6, 2026.
-meta: DNSimple is migrating NS1 and NS3 to new edge infrastructure. Find replacement IPs, the migration timeline, and what to do before July 6, 2026.
+excerpt: DNSimple migrated NS1 and NS3 to new edge infrastructure. The legacy Cloudflare IP addresses were fully retired on July 6, 2026.
+meta: DNSimple migrated NS1 and NS3 to new edge infrastructure and retired the legacy Cloudflare IP addresses on July 6, 2026. Find the replacement IPs and the migration timeline.
 categories:
   - DNS
 ---
@@ -9,7 +9,7 @@ categories:
 # Discontinuation of Legacy NS1 and NS3 IP Addresses
 
 > [!NOTE]
-> Most DNSimple customers do not need to take any action — we will handle the migration automatically. The only customers who must act are those using [vanity name servers](/articles/vanity-nameservers/) whose [glue records](/articles/what-are-glue-records/) still point at the legacy IPs. If you are impacted, you will receive an email from us with specific details for your account.
+> This migration completed on July 6, 2026. Most DNSimple customers did not need to take any action, and no action is required now. For the current list of name server hostnames and IP addresses, see [DNSimple Name Servers](/articles/dnsimple-nameservers/).
 
 ### Table of Contents {#toc}
 
@@ -18,91 +18,89 @@ categories:
 
 ---
 
-As part of our multi-year effort to modernize our DNS infrastructure and improve global resolution performance, we are officially retiring the legacy IP addresses associated with our NS1 and NS3 name servers. These IPs have already been replaced by our high-performance [Cache Edge network](https://blog.dnsimple.com/2023/03/cache-edge-layer/), first introduced in 2023.
+As part of our multi-year effort to modernize our DNS infrastructure and improve global resolution performance, we retired the legacy IP addresses associated with our NS1 and NS3 name servers. These IPs had already been replaced by our high-performance [Cache Edge network](https://blog.dnsimple.com/2023/03/cache-edge-layer/), first introduced in 2023.
 
-Following [the expansion of our cache edge infrastructure in 2024](https://blog.dnsimple.com/2024/10/expanding-cache-edge-network/) and the discontinuation of the legacy NS2 and NS4 IP addresses in June 2025, NS1 and NS3 are the final two name servers still pointing to the older infrastructure. The legacy IPs will be fully decommissioned on **July 6, 2026**.
+Following [the expansion of our cache edge infrastructure in 2024](https://blog.dnsimple.com/2024/10/expanding-cache-edge-network/) and the discontinuation of the legacy NS2 and NS4 IP addresses in June 2025, NS1 and NS3 were the final two name servers still pointing to the older infrastructure. The legacy IPs were fully decommissioned on **July 6, 2026**.
 
-## What's changing {#changing}
+## What changed {#changing}
 
-The table below summarizes the IP addresses that will be deprecated, along with their replacements in the cache edge layer:
+The table below summarizes the IP addresses that were deprecated, along with their replacements in the cache edge layer:
 
-| Name Server | Deprecated IP                 | Replacement IP      |
+| Name Server | Retired IP                    | Replacement IP      |
 |-------------|-------------------------------|---------------------|
 | **NS1**     | `162.159.24.4`                | `199.247.152.53`    |
 | **NS1**     | `2400:cb00:2049:1::a29f:1804` | `2620:111:8004::53` |
 | **NS3**     | `162.159.26.4`                | `199.247.154.53`    |
 | **NS3**     | `2400:cb00:2049:1::a29f:1a04` | `2620:111:8006::53` |
 
-As part of this change, the canonical name server hostnames for NS1 and NS3 are also moving to dedicated edge domains:
+As part of this change, the canonical name server hostnames for NS1 and NS3 also moved to dedicated edge domains:
 
-- `ns1.dnsimple.com` → `ns1.dnsimple-edge.com`
-- `ns3.dnsimple.com` → `ns3.dnsimple-edge.io`
+- `ns1.dnsimple.com` to `ns1.dnsimple-edge.com`
+- `ns3.dnsimple.com` to `ns3.dnsimple-edge.io`
 
-The legacy `ns1.dnsimple.com` and `ns3.dnsimple.com` hostnames will continue to resolve after the migration, but they will point to the new edge infrastructure.
+The legacy `ns1.dnsimple.com` and `ns3.dnsimple.com` hostnames continue to resolve after the migration, but they now point to the new edge infrastructure.
 
 ## Timeline {#timeline}
 
 | Date                | Milestone                                                                                     |
 |---------------------|-----------------------------------------------------------------------------------------------|
-| **May 1, 2026**     | New NS1 & NS3 edge infrastructure goes live. **You can begin self-migrating at any time after this date.** |
-| **May 1, 2026**     | Start staged automatic migration of domains registered with DNSimple (Group 1)                |
-| **May 29, 2026**    | End staged automatic migration of domains registered with DNSimple. (Group 1)                 |
-| **June 1, 2026**    | Start migration of hosted zones still delegated to the legacy hostnames. (Group 2)            |
-| **June 12, 2026**   | End migration of hosted zones still delegated to the legacy hostnames. (Group 2)              |
-| **June 15, 2026**   | Cloudflare brownout #1 — legacy IPs temporarily stop answering to surface remaining traffic.  |
-| **June 22, 2026**   | Cloudflare brownout #2 — legacy IPs temporarily stop answering to surface remaining traffic.  |
-| **July 6, 2026**    | **Legacy Cloudflare IPs fully decommissioned.** Any configuration still pointing at the old IPs will stop resolving. |
+| **May 1, 2026**     | New NS1 & NS3 edge infrastructure went live. Self-migration was available from this date.      |
+| **May 1, 2026**     | Started staged automatic migration of domains registered with DNSimple (Group 1)              |
+| **May 29, 2026**    | Ended staged automatic migration of domains registered with DNSimple (Group 1)                |
+| **June 1, 2026**    | Started migration of hosted zones still delegated to the legacy hostnames (Group 2)           |
+| **June 12, 2026**   | Ended migration of hosted zones still delegated to the legacy hostnames (Group 2)             |
+| **June 15, 2026**   | Cloudflare brownout #1 - legacy IPs temporarily stopped answering to surface remaining traffic. |
+| **June 22, 2026**   | Cloudflare brownout #2 - legacy IPs temporarily stopped answering to surface remaining traffic. |
+| **July 6, 2026**    | **Legacy Cloudflare IPs fully decommissioned.** Any configuration still pointing at the old IPs stopped resolving. |
 
-## Am I impacted? {#impacted}
+The two brownouts on June 15 and June 22, 2026 briefly paused answering queries on the legacy Cloudflare IPs. This surfaced any traffic still landing on the old infrastructure so that remaining configurations could be identified and updated before the final decommission date.
 
-There are three groups of customers affected by this migration, each with a different level of action required.
+## Who was impacted {#impacted}
 
-### Group 1 — Domains registered with DNSimple
+Three groups of customers were affected by this migration, each with a different level of action required.
 
-**You do not need to do anything.** If your domain is registered with DNSimple and delegated to our name servers, we will handle the migration for you automatically between May 1 and June 1, 2026. All registered domains will be fully migrated by June 26, 2026. For domains using [vanity name servers](/articles/vanity-nameservers/), we will also update the glue records at the registry and the corresponding A/AAAA records in your zone.
+### Group 1 - Domains registered with DNSimple
 
-If you independently maintain a copy of your zone at another DNS provider (not through DNSimple's secondary DNS), you should update the NS records at that provider to reference `ns1.dnsimple-edge.com` and `ns3.dnsimple-edge.io`. The old `ns1.dnsimple.com` and `ns3.dnsimple.com` hostnames will continue to work, but updating ensures your configuration stays current.
+**No action was required.** For domains registered with DNSimple and delegated to our name servers, we handled the migration automatically between May 1 and May 29, 2026. For domains using [vanity name servers](/articles/vanity-nameservers/), we also updated the glue records at the registry and the corresponding A/AAAA records in the zone.
 
-### Group 2 — Domains registered elsewhere with DNS hosted at DNSimple
+If you independently maintain a copy of your zone at another DNS provider (not through DNSimple's secondary DNS), you should update the NS records at that provider to reference `ns1.dnsimple-edge.com` and `ns3.dnsimple-edge.io`. The old `ns1.dnsimple.com` and `ns3.dnsimple.com` hostnames continue to work, but updating ensures your configuration stays current.
 
-**We recommend self-migrating, but we will force-migrate you by June 12, 2026.** If your domain is registered at another registrar but uses DNSimple for DNS, your delegation at that registrar currently points at `ns1.dnsimple.com` and/or `ns3.dnsimple.com`. You have two options:
+### Group 2 - Domains registered elsewhere with DNS hosted at DNSimple
 
-- **Self-migrate** (recommended): at your registrar, update the delegation to use `ns1.dnsimple-edge.com` and `ns3.dnsimple-edge.io` instead. You can do this any time **after May 1, 2026**.
-- **Do nothing**: by June 12, 2026, we will transparently update the A and AAAA records for `ns1.dnsimple.com` and `ns3.dnsimple.com` to point at the new edge infrastructure. Your delegation will continue to work without changes on your side.
+**We force-migrated these domains by June 12, 2026.** For domains registered at another registrar but using DNSimple for DNS, the delegation at that registrar pointed at `ns1.dnsimple.com` and/or `ns3.dnsimple.com`. By June 12, 2026, we transparently updated the A and AAAA records for `ns1.dnsimple.com` and `ns3.dnsimple.com` to point at the new edge infrastructure, so delegation continued to work without changes on the customer side.
 
-### Group 3 — Using vanity name servers with a domain NOT registered through DNSimple
+If you want your delegation to reflect the current hostnames, update it at your registrar to use `ns1.dnsimple-edge.com` and `ns3.dnsimple-edge.io`.
 
-**You must self-migrate before July 6, 2026.** If you use vanity name servers (for example `ns1.yourdomain.com`), the glue records at your registrar currently point at the legacy Cloudflare IPs. We cannot update glue records on your behalf — only your registrar can do that. If you take no action, your domains will stop resolving when the legacy IPs are decommissioned.
+### Group 3 - Using vanity name servers with a domain NOT registered through DNSimple
 
-## How to verify if you're impacted {#verify}
+**These customers had to self-migrate before July 6, 2026.** For vanity name servers (for example `ns1.yourdomain.com`), the glue records at the registrar pointed at the legacy Cloudflare IPs. We cannot update glue records on a customer's behalf - only the registrar can do that.
 
-If you use a vanity name server, you can check whether your glue records are still on the legacy IPs by running:
+> [!WARNING]
+> Any glue records still pointing at the legacy Cloudflare IPs stopped resolving on July 6, 2026. If your domains are no longer resolving, update the [glue records](/articles/what-are-glue-records/) at your registrar to the replacement IPs listed above.
+
+## How to check your glue records {#verify}
+
+If you use a vanity name server, you can check whether your glue records still point at a legacy IP by running:
 
 ```
 dig +short ns1.yourdomain.com
 dig +short ns3.yourdomain.com
 ```
 
-If the response contains `162.159.24.4` or `162.159.26.4` (or the matching IPv6 addresses), you need to update your configuration before July 6, 2026.
+If the response contains `162.159.24.4` or `162.159.26.4` (or the matching IPv6 addresses), the host is no longer resolving and you need to update your configuration to the replacement IPs.
 
-For non-vanity setups, you can check which name servers your domain uses at its registrar — if they reference `ns1.dnsimple.com` or `ns3.dnsimple.com`, you fall under Group 1 or Group 2 and no action is strictly required.
-
-## What about the brownouts? {#brownouts}
-
-On **June 15, 2026** and **June 22, 2026** we will briefly pause answering queries on the legacy Cloudflare IPs. Any traffic still landing on the old infrastructure will temporarily fail, making it easy to identify configurations that still need attention. If you notice intermittent resolution failures on those dates, treat it as a strong signal that you still have glue records or delegations pointing at the legacy IPs and should complete your migration before July 15, 2026.
+For non-vanity setups, you can check which name servers your domain uses at its registrar. If they reference `ns1.dnsimple.com` or `ns3.dnsimple.com`, they now resolve to the new edge infrastructure and no action is required.
 
 ## What you need to do {#what-to-do}
 
-- **Group 1 — registered with DNSimple:** No action required. We'll handle the migration between May 1 and May 29, 2026.
-- **Group 2 — hosted at DNSimple, registered elsewhere:** Optional but recommended: update your delegation at your registrar to `ns1.dnsimple-edge.com` and `ns3.dnsimple-edge.io` any time after May 1, 2026. Otherwise, you will be migrated transparently on June 26, 2026.
-- **Group 3 — vanity name servers:** Required: update the [glue records](/articles/what-are-glue-records/) at your registrar to the replacement IPs above before **July 6, 2026**.
+- **Group 1 - registered with DNSimple:** No action required. We handled the migration between May 1 and May 29, 2026.
+- **Group 2 - hosted at DNSimple, registered elsewhere:** No action required. We migrated the delegation transparently by June 12, 2026. Optionally, update your delegation at your registrar to `ns1.dnsimple-edge.com` and `ns3.dnsimple-edge.io`.
+- **Group 3 - vanity name servers:** If your domains stopped resolving, update the [glue records](/articles/what-are-glue-records/) at your registrar to the replacement IPs above.
 
-You can always refer to the latest list of official DNSimple name servers here:
-
-👉 [DNSimple Name Server Reference](/articles/dnsimple-nameservers/)
+You can always refer to the latest list of official DNSimple name servers here: [DNSimple Name Server Reference](/articles/dnsimple-nameservers/).
 
 ## Questions or concerns? {#questions}
 
-If you have any questions or need help with the transition, don't hesitate to [reach out to our support team](https://dnsimple.com/contact).
+If you have any questions or need help, [reach out to our support team](https://dnsimple.com/contact).
 
 Thank you for being part of DNSimple as we continue to invest in speed, resilience, and the future of DNS.

--- a/content/articles/before-transferring-domain.md
+++ b/content/articles/before-transferring-domain.md
@@ -62,19 +62,19 @@ $ dig @NAME_SERVER DOMAIN_NAME [RECORD_TYPE]
 For example, the following command checks the A records associated to the root domain:
 
 ```
-$ dig @ns1.dnsimple.com example.com
+$ dig @ns1.dnsimple-edge.com example.com
 ```
 
 To look up details for a subdomain use:
 
 ```
-$ dig @ns1.dnsimple.com www.example.com
+$ dig @ns1.dnsimple-edge.com www.example.com
 ```
 
 To look up details for a specific record type use:
 
 ```
-$ dig @ns1.dnsimple.com www.example.com CNAME
+$ dig @ns1.dnsimple-edge.com www.example.com CNAME
 ```
 
 

--- a/content/articles/dns-glossary.md
+++ b/content/articles/dns-glossary.md
@@ -187,7 +187,7 @@ Learn more:
 
 NS (Name Server) records identify the authoritative name servers for a domain or subdomain. NS records are crucial for delegating control of a DNS zone to specific servers. 
 
-*Example: `example.com. IN NS ns1.dnsimple.com.`* 
+*Example: `example.com. IN NS ns1.dnsimple-edge.com.`* 
 
 Learn more: 
 
@@ -209,7 +209,7 @@ Learn more:
 
 SOA (Start Of Authority) records provide essential administrative information about a DNS zone, including the primary name server, the email address of the domain administrator, the zone's serial number (indicating when the zone file was last updated), and various timers for refresh, retry, and expiry. Every zone file must have one SOA record. 
 
-*Example: `example.com. IN SOA ns1.dnsimple.com. hostmaster.example.com. ( 2025071101 7200 3600 1209600 3600 )`* 
+*Example: `example.com. IN SOA ns1.dnsimple-edge.com. hostmaster.example.com. ( 2025071101 7200 3600 1209600 3600 )`* 
 
 Learn more: 
 

--- a/content/articles/dnsimple-nameservers.md
+++ b/content/articles/dnsimple-nameservers.md
@@ -54,11 +54,11 @@ If you need to provide the IP addresses to your current registrar, use the follo
 </tr>
 </table>
 
-If you are updating delegation or glue records during the NS1/NS3 edge migration, see [Discontinuation of Legacy NS1 and NS3 IP Addresses](/articles/announcement-ns1-ns3-ip-addresses/).
+For background on the NS1/NS3 edge migration that completed on July 6, 2026, see [Discontinuation of Legacy NS1 and NS3 IP Addresses](/articles/announcement-ns1-ns3-ip-addresses/).
 
 ## Legacy Name Servers {#legacy-name-servers}
 
-We have some older name servers that we consider legacy. You can use them, but we recommend you use the more diverse names and TLDs:
+We have some older name server hostnames that we consider legacy. They still resolve, but they are now aliases onto the edge infrastructure above. For new configurations, use the `dnsimple-edge` names:
 
 - ns1.dnsimple.com
 - ns2.dnsimple.com

--- a/content/articles/empty-non-terminals.md
+++ b/content/articles/empty-non-terminals.md
@@ -127,19 +127,19 @@ In this zone:
 **Query results:**
 
 ```
-$ dig @ns1.dnsimple.com network.example.com A +short
+$ dig @ns1.dnsimple-edge.com network.example.com A +short
 (empty - ENT, no records returned)
 
-$ dig @ns1.dnsimple.com retails.network.example.com A +short
+$ dig @ns1.dnsimple-edge.com retails.network.example.com A +short
 (empty - ENT, no records returned)
 
-$ dig @ns1.dnsimple.com srv1.retails.network.example.com A +short
+$ dig @ns1.dnsimple-edge.com srv1.retails.network.example.com A +short
 192.168.1.10
 
-$ dig @ns1.dnsimple.com eu.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com eu.prod.example.com A +short
 192.168.0.21
 
-$ dig @ns1.dnsimple.com app.eu.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com app.eu.prod.example.com A +short
 192.168.0.22
 ```
 
@@ -162,9 +162,9 @@ This is known as a `NODATA` response. It indicates that the domain name exists b
 Using our zone example, let us query the ENT `network.example.com`:
 
 ```
-$ dig @ns1.dnsimple.com network.example.com A
+$ dig @ns1.dnsimple-edge.com network.example.com A
 
-; <<>> DiG 9.10.6 <<>> @ns1.dnsimple.com network.example.com A
+; <<>> DiG 9.10.6 <<>> @ns1.dnsimple-edge.com network.example.com A
 ;; global options: +cmd
 ;; Got answer:
 ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12345
@@ -174,10 +174,10 @@ $ dig @ns1.dnsimple.com network.example.com A
 ;network.example.com.       IN  A
 
 ;; AUTHORITY SECTION:
-example.com.        3600    IN  SOA ns1.dnsimple.com. admin.dnsimple.com. ...
+example.com.        3600    IN  SOA ns1.dnsimple-edge.com. admin.dnsimple.com. ...
 
 ;; Query time: 45 msec
-;; SERVER: 198.241.10.53#53(198.241.10.53)
+;; SERVER: 199.247.152.53#53(199.247.152.53)
 ```
 
 Notice the key indicators:
@@ -221,7 +221,7 @@ graph TD
 With only this wildcard record, querying `us.prod.example.com` returns:
 
 ```
-$ dig @ns1.dnsimple.com us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com us.prod.example.com A +short
 192.168.0.11
 ```
 
@@ -260,7 +260,7 @@ Let us compare the queries.
 **Querying `fr.prod.example.com` (non-existent name, wildcard matches):**
 
 ```
-$ dig @ns1.dnsimple.com fr.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com fr.prod.example.com A +short
 192.168.0.11
 ```
 
@@ -269,9 +269,9 @@ The wildcard `*.prod.example.com` matches because `fr.prod.example.com` does not
 **Querying `us.prod.example.com` (ENT, wildcard blocked):**
 
 ```
-$ dig @ns1.dnsimple.com us.prod.example.com A
+$ dig @ns1.dnsimple-edge.com us.prod.example.com A
 
-; <<>> DiG 9.10.6 <<>> @ns1.dnsimple.com us.prod.example.com A
+; <<>> DiG 9.10.6 <<>> @ns1.dnsimple-edge.com us.prod.example.com A
 ;; global options: +cmd
 ;; Got answer:
 ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 54321
@@ -281,10 +281,10 @@ $ dig @ns1.dnsimple.com us.prod.example.com A
 ;us.prod.example.com.       IN  A
 
 ;; AUTHORITY SECTION:
-example.com.        3600    IN  SOA ns1.dnsimple.com. admin.dnsimple.com. ...
+example.com.        3600    IN  SOA ns1.dnsimple-edge.com. admin.dnsimple.com. ...
 
 ;; Query time: 42 msec
-;; SERVER: 198.241.10.53#53(198.241.10.53)
+;; SERVER: 199.247.152.53#53(199.247.152.53)
 ```
 
 Even though `us.prod.example.com` falls within the wildcard's scope, it returns empty. According to RFC 4592, the wildcard at `*.prod.example.com` does **not** apply here because the name `us.prod.example.com` now exists (as an ENT). Wildcards only match names that do not exist, not ENTs.
@@ -324,7 +324,7 @@ This single TXT record creates **multiple Empty Non-Terminals** in the path:
 Now, querying `us.prod.example.com` returns an empty response:
 
 ```
-$ dig @ns1.dnsimple.com us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com us.prod.example.com A +short
 (empty)
 ```
 
@@ -333,13 +333,13 @@ The wildcard no longer matches because `us.prod.example.com` now exists as an EN
 **Before the ACME challenge record:**
 
 ```
-$ dig @ns1.dnsimple.com us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com us.prod.example.com A +short
 1.2.3.4
 
-$ dig @ns1.dnsimple.com app.us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com app.us.prod.example.com A +short
 1.2.3.4
 
-$ dig @ns1.dnsimple.com anything.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com anything.prod.example.com A +short
 1.2.3.4
 ```
 
@@ -348,13 +348,13 @@ All names match the wildcard because none of them exist.
 **After the ACME challenge record:**
 
 ```
-$ dig @ns1.dnsimple.com us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com us.prod.example.com A +short
 (empty - now an ENT)
 
-$ dig @ns1.dnsimple.com app.us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com app.us.prod.example.com A +short
 (empty - now an ENT)
 
-$ dig @ns1.dnsimple.com anything.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com anything.prod.example.com A +short
 1.2.3.4
 ```
 

--- a/content/articles/how-dig.md
+++ b/content/articles/how-dig.md
@@ -54,9 +54,9 @@ What else can you do with `dig`? The first example uses the name servers configu
 You can also specify a name server:
 
 ```
-$ dig @ns1.dnsimple.com dnsimple.com
+$ dig @ns1.dnsimple-edge.com dnsimple.com
 
-; <<>> DiG 9.8.3-P1 <<>> @ns1.dnsimple.com dnsimple.com
+; <<>> DiG 9.8.3-P1 <<>> @ns1.dnsimple-edge.com dnsimple.com
 ; (1 server found)
 ;; global options: +cmd
 ;; Got answer:
@@ -71,7 +71,7 @@ $ dig @ns1.dnsimple.com dnsimple.com
 dnsimple.com.		60	IN	A	50.31.213.210
 
 ;; Query time: 145 msec
-;; SERVER: 198.241.10.53#53(198.241.10.53)
+;; SERVER: 199.247.152.53#53(199.247.152.53)
 ;; WHEN: Tue Feb  3 11:28:02 2015
 ;; MSG SIZE  rcvd: 46
 ```
@@ -115,21 +115,21 @@ com.			172800	IN	NS	h.gtld-servers.net.
 com.			172800	IN	NS	g.gtld-servers.net.
 ;; Received 490 bytes from 192.112.36.4#53(192.112.36.4) in 1849 ms
 
-dnsimple.com.		172800	IN	NS	ns1.dnsimple.com.
+dnsimple.com.		172800	IN	NS	ns1.dnsimple-edge.com.
 dnsimple.com.		172800	IN	NS	ns2.dnsimple-edge.net.
-dnsimple.com.		172800	IN	NS	ns3.dnsimple.com.
+dnsimple.com.		172800	IN	NS	ns3.dnsimple-edge.io.
 dnsimple.com.		172800	IN	NS	ns4.dnsimple-edge.org.
 ;; Received 278 bytes from 192.55.83.30#53(192.55.83.30) in 306 ms
 
 dnsimple.com.		60	IN	A	50.31.213.210
-;; Received 46 bytes from 50.31.242.53#53(50.31.242.53) in 55 ms
+;; Received 46 bytes from 199.247.154.53#53(199.247.154.53) in 55 ms
 ```
 
 With `+trace` enabled, you can see the entire delegation tree.
 
 - First you receive a list of NS records showing the next name server set to query from the server `8.8.8.8`. One of the NS records is chosen randomly (in this case it was `192.112.36.4`, which is `g.root-servers.net`. That server is queried and responds with a list of servers that respond for `.com.` domains.
 
-- `dig` then queries `192.55.83.30` (`m.gtld-servers.net.`), and that name server responds with the `ns1.dnsimple.com` through `ns4.dnsimple.com` name servers. One of those is selected at random (`50.31.242.53` which is `ns3.dnsimple.com`). That name server finally returns the authoritative response and the IP address for the A record.
+- `dig` then queries `192.55.83.30` (`m.gtld-servers.net.`), and that name server responds with the `ns1.dnsimple-edge.com` through `ns4.dnsimple-edge.org` name servers. One of those is selected at random (`199.247.154.53` which is `ns3.dnsimple-edge.io`). That name server finally returns the authoritative response and the IP address for the A record.
 
 ## Additional common lookups {#additional-common-lookups}
 
@@ -138,9 +138,9 @@ With `+trace` enabled, you can see the entire delegation tree.
 You can use `dig` to determine the AAAA record associated with a domain name. The result is contained in the ANSWER section. It contains the fully-qualified domain name (FQDN), the remaining time-to-live (TTL), and the IP address.
 
 ```
-$ dig AAAA ns1.dnsimple.com
+$ dig AAAA ns1.dnsimple-edge.com
 
-; <<>> DiG 9.10.6 <<>> AAAA ns1.dnsimple.com
+; <<>> DiG 9.10.6 <<>> AAAA ns1.dnsimple-edge.com
 ;; global options: +cmd
 ;; Got answer:
 ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 52403
@@ -149,10 +149,10 @@ $ dig AAAA ns1.dnsimple.com
 ;; OPT PSEUDOSECTION:
 ; EDNS: version: 0, flags:; udp: 512
 ;; QUESTION SECTION:
-;ns1.dnsimple.com.		IN	AAAA
+;ns1.dnsimple-edge.com.		IN	AAAA
 
 ;; ANSWER SECTION:
-ns1.dnsimple.com.	1795	IN	AAAA	2400:cb00:2049:1::a29f:1804
+ns1.dnsimple-edge.com.	1795	IN	AAAA	2620:111:8004::53
 
 ;; Query time: 47 msec
 ;; SERVER: 8.8.8.8#53(8.8.8.8)

--- a/content/articles/how-to-fix-empty-responses-from-empty-non-terminals.md
+++ b/content/articles/how-to-fix-empty-responses-from-empty-non-terminals.md
@@ -35,14 +35,14 @@ The record `app.us.prod.example.com` creates an ENT at `us.prod.example.com`. Qu
 First, check if there are any records beneath the name that is returning empty responses. Use [`dig`](/articles/how-dig/) to query your zone:
 
 ```
-$ dig @ns1.dnsimple.com us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com us.prod.example.com A +short
 (empty)
 ```
 
 If you get an empty response but the name exists (status: NOERROR), it is likely an ENT. To confirm, check if there are child records:
 
 ```
-$ dig @ns1.dnsimple.com app.us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com app.us.prod.example.com A +short
 192.168.0.41
 ```
 
@@ -51,7 +51,7 @@ If child records exist, the parent name is an ENT.
 You can also view your full zone to see the hierarchy:
 
 ```
-$ dig @ns1.dnsimple.com example.com AXFR
+$ dig @ns1.dnsimple-edge.com example.com AXFR
 ```
 
 Look for records that are deeper in the hierarchy than the name returning empty responses.
@@ -83,7 +83,7 @@ This ensures consistent behavior with other names that match the wildcard.
 After adding the explicit record, verify that the name now returns the expected response:
 
 ```
-$ dig @ns1.dnsimple.com us.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com us.prod.example.com A +short
 192.168.0.11
 ```
 

--- a/content/articles/ns-record.md
+++ b/content/articles/ns-record.md
@@ -54,7 +54,7 @@ When it comes to managing the authoritative name servers for your domain, the pr
 ### To use DNSimple's name servers (delegate to DNSimple)
 **If DNSimple is your domain registrar:** [Update your domain's name servers](/articles/delegating-dnsimple-registered/) directly within your DNSimple account. This points your domain to DNSimple's authoritative name servers.
 
-**If another registrar holds your domain:** Log in to that registrar's control panel, and [update your domain's name servers](/articles/delegating-dnsimple-hosted/), pointing them to DNSimple's name servers (e.g., `ns1.dnsimple.com`, `ns2.dnsimple-edge.net`, etc.).
+**If another registrar holds your domain:** Log in to that registrar's control panel, and [update your domain's name servers](/articles/delegating-dnsimple-hosted/), pointing them to DNSimple's name servers (e.g., `ns1.dnsimple-edge.com`, `ns2.dnsimple-edge.net`, etc.).
 
 ### To delegate to another DNS provider
 **If DNSimple is your domain registrar:** Update your domain's name servers within your DNSimple account, and [enter the name servers of the other DNS provider](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider/).

--- a/content/articles/protection-ddos.md
+++ b/content/articles/protection-ddos.md
@@ -19,7 +19,7 @@ DNSimple's DDoS defense system acts as a protective layer that sits in front of 
 
 Think of it like a security checkpoint:
 
-- **Initial screening:** All incoming traffic is continuously analyzed for potential malicious patterns and anomalies.
+- **Initial screening:** All incoming traffic is continuously analyzed for potential malicious patterns and anomalies, including signature detection at the cache layer.
 - **Legitimate traffic:** Legitimate requests are allowed to pass through the system. They are then served from a fast caching layer if the information is available, or forwarded to the nearest data center for a fresh response.
 - **Malicious traffic:** Malicious requests are detected and blocked at the POP level, preventing them from consuming the resources of our name servers and disrupting service for others.
 
@@ -27,7 +27,7 @@ This multilayered defense, powered by Anycast routing, ensures that your domain 
 
 ## Multi-provider protection {#multi-provider-protection}
 
-DNSimple's name servers and DDoS protection infrastructure are distributed in multiple locations around the world. We are always working to introduce additional providers for zones where complete redundancy is critical.
+DNSimple's name servers and DDoS protection infrastructure are distributed in multiple locations around the world. Our two-provider edge is live, providing complete redundancy for zones where it is critical.
 
 If you are interested in leveraging this for your domain, please [contact us](https://dnsimple.com/contact) to discuss the technical requirements and pricing.
 

--- a/content/articles/protection-ddos.md
+++ b/content/articles/protection-ddos.md
@@ -29,7 +29,7 @@ This multilayered defense, powered by Anycast routing, ensures that your domain 
 
 DNSimple's name servers and DDoS protection infrastructure are distributed in multiple locations around the world. Our two-provider edge is live, providing complete redundancy for zones where it is critical.
 
-If you are interested in leveraging this for your domain, please [contact us](https://dnsimple.com/contact) to discuss the technical requirements and pricing.
+If you would like to learn more about how this redundancy protects your domains, please [contact us](https://dnsimple.com/contact) and we will be happy to walk you through the details.
 
 ## Have more questions?
 If you have additional questions or need any assistance with your domain security, just [contact support](https://dnsimple.com/feedback), and we will be happy to help. 

--- a/content/articles/record-resolution-issues.md
+++ b/content/articles/record-resolution-issues.md
@@ -33,15 +33,15 @@ com.            172800  IN  NS  g.gtld-servers.net.
 ...
 ;; Received 1176 bytes from 199.9.14.201#53(b.root-servers.net) in 86 ms
 
-dnsimple.com.       172800  IN  NS  ns1.dnsimple.com.
+dnsimple.com.       172800  IN  NS  ns1.dnsimple-edge.com.
 dnsimple.com.       172800  IN  NS  ns2.dnsimple-edge.net.
-dnsimple.com.       172800  IN  NS  ns3.dnsimple.com.
+dnsimple.com.       172800  IN  NS  ns3.dnsimple-edge.io.
 dnsimple.com.       172800  IN  NS  ns4.dnsimple-edge.org.
 ...
 ;; Received 842 bytes from 192.33.14.30#53(b.gtld-servers.net) in 38 ms
 
 www.dnsimple.com.   3600    IN  CNAME   dnsimple.com.
-;; Received 59 bytes from 162.159.27.4#53(ns4.dnsimple.com) in 34 ms
+;; Received 59 bytes from 199.247.155.53#53(ns4.dnsimple-edge.org) in 34 ms
 ~~~
 
 In the resulting query chain, you can see each hop to resolve the CNAME. 
@@ -59,10 +59,10 @@ If you recently changed a record, it may take a while for the change to propagat
 
 You usually can bypass a propagation delay by passing a custom name server in the `dig` call.
 
-The following command checks the DNS record against the `ns1.dnsimple.com` name server:
+The following command checks the DNS record against the `ns1.dnsimple-edge.com` name server:
 
 ```
-$ dig www.dnsimple.com @ns1.dnsimple.com
+$ dig www.dnsimple.com @ns1.dnsimple-edge.com
 ```
 
 If you get the expected response, the record has been updated in our system, but the changes still need to propagate. They should be visible after the TTL period. To compare results globally or run checks with third-party sites, see [External DNS Diagnostic Tools](/articles/external-dns-diagnostic-tools/).
@@ -110,9 +110,9 @@ If both commands return no results, you need to add an A or AAAA record for the 
 You can also query DNSimple's name servers directly to verify the record does not exist in our system:
 
 ```
-$ dig example.com A @ns1.dnsimple.com +short
+$ dig example.com A @ns1.dnsimple-edge.com +short
 
-$ dig example.com AAAA @ns1.dnsimple.com +short
+$ dig example.com AAAA @ns1.dnsimple-edge.com +short
 ```
 
 ### How to fix

--- a/content/articles/secondary-dns-dnsimple-as-secondary.md
+++ b/content/articles/secondary-dns-dnsimple-as-secondary.md
@@ -88,9 +88,9 @@ Example of what the set of NS records may look like:
 - `NS example.com ns1.primary.com`
 - `NS example.com ns2.primary.com`
 - `NS example.com ns3.primary.com`
-- `NS example.com ns1.dnsimple.com`
+- `NS example.com ns1.dnsimple-edge.com`
 - `NS example.com ns2.dnsimple-edge.net`
-- `NS example.com ns3.dnsimple.com`
+- `NS example.com ns3.dnsimple-edge.io`
 
 ### 2. Delegate the domain through both DNS providers at your domain's registrar
 
@@ -102,8 +102,8 @@ Example of what the name servers may look like:
 - `ns1.primary.com`
 - `ns2.primary.com`
 - `ns3.primary.com`
-- `ns1.dnsimple.com`
+- `ns1.dnsimple-edge.com`
 - `ns2.dnsimple-edge.net`
-- `ns3.dnsimple.com`
+- `ns3.dnsimple-edge.io`
 
 

--- a/content/articles/secondary-dns-dnsimple-with-hidden-primary.md
+++ b/content/articles/secondary-dns-dnsimple-with-hidden-primary.md
@@ -66,7 +66,7 @@ Verify that the records have been synchronized in your DNSimple account.
 
 Run the following `dig` command from your console:
 ```
-dig @ns1.dnsimple.com example.com
+dig @ns1.dnsimple-edge.com example.com
 ```
 ### Hidden primary is not exposed
 
@@ -74,9 +74,9 @@ Verify that the hidden primary name servers are **not** publicly exposed by runn
 ```
 > whois your-domain-name.com
 ...
-Name Server: ns1.dnsimple.com
+Name Server: ns1.dnsimple-edge.com
 Name Server: ns2.dnsimple-edge.net
-Name Server: ns3.dnsimple.com
+Name Server: ns3.dnsimple-edge.io
 Name Server: ns4.dnsimple-edge.org
 ```
 ## Have more questions?

--- a/content/articles/secondary-dns-provider-dns-made-easy.md
+++ b/content/articles/secondary-dns-provider-dns-made-easy.md
@@ -92,10 +92,10 @@ example.com.  3600  IN  SOA axfr.dnsimple.com. admin.dnsimple.com. 1425544360 86
 example.com.  3600  IN  NS  ns2.dnsimple-edge.net.
 example.com.  3600  IN  NS  ns6.dnsmadeeasy.com.
 example.com.  3600  IN  NS  ns7.dnsmadeeasy.com.
-example.com.  3600  IN  NS  ns3.dnsimple.com.
+example.com.  3600  IN  NS  ns3.dnsimple-edge.io.
 example.com.  3600  IN  NS  ns5.dnsmadeeasy.com.
 example.com.  3600  IN  NS  ns4.dnsimple-edge.org.
-example.com.  3600  IN  NS  ns1.dnsimple.com.
+example.com.  3600  IN  NS  ns1.dnsimple-edge.com.
 
 ;; Query time: 55 msec
 ;; SERVER: 208.94.148.13#53(208.94.148.13)

--- a/content/articles/secondary-dns-provider-easy-dns.md
+++ b/content/articles/secondary-dns-provider-easy-dns.md
@@ -86,8 +86,8 @@ example.com. 3600  IN  SOA axfr.dnsimple.com. admin.dnsimple.com. 1425558979 864
 example.com. 3600  IN  NS  xfr0.easydns.com.
 example.com. 3600  IN  NS  ns4.dnsimple-edge.org.
 example.com. 3600  IN  NS  ns2.dnsimple-edge.net.
-example.com. 3600  IN  NS  ns1.dnsimple.com.
-example.com. 3600  IN  NS  ns3.dnsimple.com.
+example.com. 3600  IN  NS  ns1.dnsimple-edge.com.
+example.com. 3600  IN  NS  ns3.dnsimple-edge.io.
 
 ;; ADDITIONAL SECTION:
 xfr0.easydns.com. 300 IN  A 64.68.200.91

--- a/content/articles/soa-record.md
+++ b/content/articles/soa-record.md
@@ -29,12 +29,12 @@ The SOA record contains several vital pieces of information that govern how the 
 An example breakdown of the typical components in an SOA record:
 
 ```
-ns1.dnsimple.com admin.dnsimple.com 2013022001 86400 7200 604800 300
+ns1.dnsimple-edge.com admin.dnsimple.com 2013022001 86400 7200 604800 300
 ```
 
 ### Examining each element:
 **Primary name server (MNAME - master name**):
-- `ns1.dnsimple.com` (or the first name server in your vanity name server list).
+- `ns1.dnsimple-edge.com` (or the first name server in your vanity name server list).
 - This specifies the primary authoritative name server for this zone. All updates to the zone should originate here.
 
 **Responsible party (RNAME - responsible person):**

--- a/content/articles/system-records.md
+++ b/content/articles/system-records.md
@@ -24,7 +24,7 @@ When your domain is actively resolving using DNSimple's name servers, the system
 
 ### Four NS (Name Server) records
 
-- **Purpose:** These NS records explicitly identify DNSimple's authoritative name servers (e.g., `ns1.dnsimple.com`, `ns2.dnsimple-edge.net`, etc.) as the source of truth for your domain's DNS information. They are the records that the Top-Level Domain (TLD) registry points to, effectively delegating authority for your domain to DNSimple.
+- **Purpose:** These NS records explicitly identify DNSimple's authoritative name servers (e.g., `ns1.dnsimple-edge.com`, `ns2.dnsimple-edge.net`, etc.) as the source of truth for your domain's DNS information. They are the records that the Top-Level Domain (TLD) registry points to, effectively delegating authority for your domain to DNSimple.
 - **Why they're necessary:** These records are the backbone of DNS delegation. They tell the entire internet where to go to find all other records for your domain. If these were missing or incorrect, your domain would not resolve.
 - **Learn more:** [What Is an NS Record?](/articles/ns-record/)
 

--- a/content/articles/troubleshooting-empty-non-terminal-issues.md
+++ b/content/articles/troubleshooting-empty-non-terminal-issues.md
@@ -30,7 +30,7 @@ ENT-related issues typically manifest as:
 Use a script or manual inspection to identify ENTs in your zone. Start by querying the problematic name:
 
 ```
-$ dig @ns1.dnsimple.com problematic-name.example.com A
+$ dig @ns1.dnsimple-edge.com problematic-name.example.com A
 ```
 
 Look for these indicators:
@@ -46,7 +46,7 @@ If you see these indicators, the name is likely an ENT.
 Query names beneath the problematic name to see if they have records:
 
 ```
-$ dig @ns1.dnsimple.com child.problematic-name.example.com A +short
+$ dig @ns1.dnsimple-edge.com child.problematic-name.example.com A +short
 ```
 
 If child records exist, the parent is an ENT.
@@ -56,7 +56,7 @@ If child records exist, the parent is an ENT.
 To see the complete hierarchy, export your zone:
 
 ```
-$ dig @ns1.dnsimple.com example.com AXFR
+$ dig @ns1.dnsimple-edge.com example.com AXFR
 ```
 
 This shows all records and helps identify where ENTs are created in the hierarchy.
@@ -81,7 +81,7 @@ The `app.us.prod.example.com` record creates an ENT at `us.prod.example.com`, bl
 **Check for this:**
 
 ```
-$ dig @ns1.dnsimple.com example.com AXFR | grep -E "^\*\.|^[^;].*\.prod\.example\.com"
+$ dig @ns1.dnsimple-edge.com example.com AXFR | grep -E "^\*\.|^[^;].*\.prod\.example\.com"
 ```
 
 ### ACME challenge records
@@ -91,7 +91,7 @@ Check for leftover or active Let's Encrypt challenge records. These often create
 **Check for this:**
 
 ```
-$ dig @ns1.dnsimple.com _acme-challenge.subdomain.example.com TXT +short
+$ dig @ns1.dnsimple-edge.com _acme-challenge.subdomain.example.com TXT +short
 ```
 
 ACME challenge records follow the pattern `_acme-challenge.<subdomain>.example.com` and create ENTs at each level in the path.
@@ -103,7 +103,7 @@ DKIM records like `selector._domainkey.example.com` create ENTs at `_domainkey.e
 **Check for this:**
 
 ```
-$ dig @ns1.dnsimple.com _domainkey.example.com TXT +short
+$ dig @ns1.dnsimple-edge.com _domainkey.example.com TXT +short
 ```
 
 If you get an empty response but DKIM records exist beneath it, `_domainkey.example.com` is an ENT.
@@ -115,7 +115,7 @@ SRV records following the pattern `_service._protocol.example.com` create ENTs a
 **Check for this:**
 
 ```
-$ dig @ns1.dnsimple.com _tcp.example.com SRV +short
+$ dig @ns1.dnsimple-edge.com _tcp.example.com SRV +short
 ```
 
 If you get an empty response but SRV records exist beneath it, the intermediate name is an ENT.
@@ -160,7 +160,7 @@ If ENTs are causing widespread issues, consider restructuring your zone to avoid
 After making changes, verify that the issue is resolved:
 
 ```
-$ dig @ns1.dnsimple.com problematic-name.example.com A +short
+$ dig @ns1.dnsimple-edge.com problematic-name.example.com A +short
 192.168.0.11
 ```
 
@@ -171,7 +171,7 @@ The name should now return the expected response instead of empty.
 If you fixed a wildcard-related ENT issue, test that wildcard matching works as expected:
 
 ```
-$ dig @ns1.dnsimple.com new-subdomain.prod.example.com A +short
+$ dig @ns1.dnsimple-edge.com new-subdomain.prod.example.com A +short
 192.168.0.11
 ```
 

--- a/content/articles/what-are-glue-records.md
+++ b/content/articles/what-are-glue-records.md
@@ -50,7 +50,7 @@ Without glue for in-zone server names, many resolvers cannot complete the chain.
 
 ## NS records, A/AAAA records, and glue {#relationship-to-other-records}
 
-NS records at the parent state which hosts are authoritative for the child zone. When those hosts are out-of-zone (for example `ns1.dnsimple.com` for `example.com`), the resolver can resolve `ns1.dnsimple.com` without glue from the `example.com` parent. When they are in-zone, glue at the parent carries the bootstrap addresses.
+NS records at the parent state which hosts are authoritative for the child zone. When those hosts are out-of-zone (for example `ns1.dnsimple-edge.com` for `example.com`), the resolver can resolve `ns1.dnsimple-edge.com` without glue from the `example.com` parent. When they are in-zone, glue at the parent carries the bootstrap addresses.
 
 The addresses in glue match what you would express as A or AAAA for those hosts, but they are served from the delegation context at the parent, not retrieved only from the child zone.
 

--- a/content/articles/what-are-vanity-name-servers.md
+++ b/content/articles/what-are-vanity-name-servers.md
@@ -13,7 +13,7 @@ categories:
   <iframe loading="lazy" src="https://www.youtube.com/embed/8p7GFBvTnxM" class="aspect-ratio--object" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-Vanity name servers (also called private name servers or custom name servers) are authoritative name server hostnames that use your own domain instead of your DNS provider's defaults. For example, you might publish `ns1.example.com` and `ns2.example.com` at the registry instead of hostnames such as `ns1.dnsimple.com`. Public lookups still show which servers are authoritative; only the hostnames change.
+Vanity name servers (also called private name servers or custom name servers) are authoritative name server hostnames that use your own domain instead of your DNS provider's defaults. For example, you might publish `ns1.example.com` and `ns2.example.com` at the registry instead of hostnames such as `ns1.dnsimple-edge.com`. Public lookups still show which servers are authoritative; only the hostnames change.
 
 For background on what authoritative name servers do in general, see [What is a Name Server?](/articles/what-is-a-nameserver/).
 
@@ -38,7 +38,7 @@ These are presentation and operational preferences, not a change to how DNS reso
 
 When the delegated name servers are names inside the same zone being delegated (for example delegating `example.com` to `ns1.example.com`), resolvers face a circular dependency: they need an IP for `ns1.example.com` before they can query it for `example.com`. The parent zone fixes that by publishing [glue records](/articles/what-are-glue-records/) (addresses for those server names) next to the NS delegation.
 
-If your authoritative servers use provider-supplied names outside your zone (for example `ns1.dnsimple.com`), your zone does not need glue for delegation at the parent in the same way. For the step-by-step resolution story, read [What Are Glue Records?](/articles/what-are-glue-records/).
+If your authoritative servers use provider-supplied names outside your zone (for example `ns1.dnsimple-edge.com`), your zone does not need glue for delegation at the parent in the same way. For the step-by-step resolution story, read [What Are Glue Records?](/articles/what-are-glue-records/).
 
 ## Vanity name servers at DNSimple {#vanity-at-dnsimple}
 


### PR DESCRIPTION
## Summary

The NS1/NS3 edge migration completed on July 6, 2026, but content across the support site still described it as upcoming and quoted decommissioned Cloudflare IP addresses and legacy `ns1/ns3.dnsimple.com` hostnames. This updates the announcement to a historical record and normalizes every stale nameserver reference to the canonical `dnsimple-edge` set. Belongs to the NS1/NS3 edge migration.

Canonical values used throughout:

- `ns1.dnsimple-edge.com` / `199.247.152.53` / `2620:111:8004::53`
- `ns2.dnsimple-edge.net` / `199.247.153.53` / `2620:111:8005::53`
- `ns3.dnsimple-edge.io` / `199.247.154.53` / `2620:111:8006::53`
- `ns4.dnsimple-edge.org` / `199.247.155.53` / `2620:111:8007::53`

### Announcement

- Rewrote `announcement-ns1-ns3-ip-addresses.md` in past tense; the article stays live at its URL and listed under Announcements as a historical record.
- Reconciled the three internal date conflicts to the timeline table: Group 1 ran May 1-29, Group 2 ran June 1-12, legacy IPs decommissioned July 6, 2026. Fixed the stray July 15 reference to July 6.
- Folded the brownouts section into the timeline, replaced em dashes with hyphens, removed the emoji, and dropped body contractions per the style rules.

### Infrastructure status copy

- `dnsimple-nameservers.md`: migration pointer is past tense; legacy hostnames are now described as aliases onto the edge infrastructure.
- `protection-ddos.md`: reflects the shipped two-provider edge and cache-layer signature detection.

### Examples normalized

- `a-record-format.md` and `aaaa-record-format.md` now use RFC documentation addresses (`192.0.2.1`, `2001:db8::1`).
- Updated `dig` output, `+trace` NS sets, SOA MNAMEs, WHOIS/AXFR blocks, and glossary examples in: `how-dig.md`, `record-resolution-issues.md`, `before-transferring-domain.md`, `empty-non-terminals.md`, `troubleshooting-empty-non-terminal-issues.md`, `how-to-fix-empty-responses-from-empty-non-terminals.md`, `secondary-dns-dnsimple-as-secondary.md`, `secondary-dns-dnsimple-with-hidden-primary.md`, `secondary-dns-provider-dns-made-easy.md`, `secondary-dns-provider-easy-dns.md`, `ns-record.md`, `system-records.md`, `soa-record.md`, `dns-glossary.md`, `what-are-glue-records.md`, and `what-are-vanity-name-servers.md`.

## Verification

- [x] `rg "162\.159\.|2400:cb00|198\.241\.10|50\.31\.242|ns[0-9]\.dnsimple\.com" content/` returns only the retired-IP table and intentional alias/legacy explanations in the announcement and `dnsimple-nameservers.md`.
- [x] No em/en dashes, curly quotes, or ellipsis characters in the changed files.
- [x] `rake test` passes (banned-character and link-prefix checks).
- [x] Confirm the announcement URL still resolves (no rename or redirect change).
- [x] SME to confirm the two DDoS claims in `protection-ddos.md` (two-provider edge live, cache-layer signature detection) before merge.