### PR TITLE
Annotate two more account pages for capture

### DIFF
--- a/content/articles/activity-tracking.md
+++ b/content/articles/activity-tracking.md
@@ -55,6 +55,7 @@ The **Events** filter shows event types within a chosen time frame. Filter by DN
 
 ![Screenshot of link to view activity log](/files/view-activity-log.png)
 ![Overview of users activity](/files/user-activity-log.png)
+<!-- capture: /a/{account}/account/activity#.container-main -->
 
 ## Have more questions?
 

--- a/content/articles/api-access-token.md
+++ b/content/articles/api-access-token.md
@@ -40,7 +40,7 @@ The user token gives you access to any resource associated with any account the 
 1. Click the **API & Access** tab on the left side.
 
 ![screenshot of the API & Access page](/files/access-tokens.png)
-<!-- capture: /a/{account}/account/api_tokens -->
+<!-- capture: /a/{account}/account/api_tokens#.container-main -->
 
 This page shows your API usage and limits at the top, followed by your access tokens, including the last used date for each. You can add new access tokens or remove existing ones from here.
 

--- a/content/articles/changing-account-information.md
+++ b/content/articles/changing-account-information.md
@@ -51,7 +51,7 @@ You can also edit your account name, country of operation, and answers to securi
 
 1. Change or set the information according to your needs.
 
-    ![Account information form](/files/account-information-form.png)
+    ![Account information form](/files/account-information-form.png) <!-- capture: /a/{account}/account/edit#.container-main -->
 
 1. Once the information has been updated, click <label>Update account</label> to save the changes. You will see the changes reflected on the <label>Account</label> card under the <label>General</label> tab on your account page.
 


### PR DESCRIPTION
Adds `capture:` specs for two more account-level pages, and reports what a real
capture run produced for them.

| Image | Spec | Article |
| --- | --- | --- |
| `user-activity-log.png` | `/a/{account}/account/activity#.container-main` | `activity-tracking.md` |
| `account-information-form.png` | `/a/{account}/account/edit#.container-main` | `changing-account-information.md` |

Both are clipped to `.container-main`, the content wrapper in
`layouts/app/application.html.erb`. The existing images are content-area crops
rather than viewport shots, so a bare viewport capture would not match their
framing.

## Test run

Captured on a throwaway branch carrying a temporary `push:` trigger, since
`workflow_dispatch` and the comment trigger both need this workflow on the
default branch and it is not there yet. That branch is deleted; the run and its
artifact remain.

[Run 33691594786](https://github.com/dnsimple/dnsimple-support/actions/runs/33691594786),
green in 30s:

```
App origin: https://app.sandbox.dnsimple.com
Detected account 2944
CHANGED user-activity-log.png
CHANGED access-tokens.png
CHANGED account-information-form.png
Done: 3 changed, 0 unchanged, 0 failed.
```

The harness itself worked end to end: login, account auto-detection, sandbox
ribbon suppression, element clipping, and change detection. The captured images
are in the run's `captures` artifact.

## The captures are not usable yet, and the reason is the account, not the code

1. **The screenshot account's email is in the frame.** `screenshot@dallasread.com`
   appears in the navbar of `access-tokens.png` and in every row of
   `user-activity-log.png`. That would put an internal address into
   customer-facing docs.
2. **The account is on a plan that renders the restricted view.**
   `user-activity-log.png` now reads "Account activity of the last 30 days" with
   an Upgrade plan promo, where the current image shows the date-range picker and
   Events filter that the article describes. `access-tokens.png` gains an Upgrade
   banner and shows an empty token list, so the "last used date for each" the
   article mentions is not visible.
3. **The Edit account form genuinely changed.** It no longer has an Account email
   field. That is a copy fix in `changing-account-information.md`, not a
   screenshot swap, so it is out of scope here.

Seeding the screenshot account on a plan that shows the full feature set, with a
neutral account name and email, is what stands between this and unattended
refreshes.

## Parser gotcha found while writing these

A `capture:` comment trailing an image line also binds to the *previous* image
when two images sit on consecutive lines. The first version of the
`activity-tracking.md` annotation silently picked up `view-activity-log.png`, a
crop of a link, and would have overwritten it with the whole activity page.

`node capture.js --list` caught it before the run, which is a good argument for
making that check part of review. Worth deciding whether `extractSpecs` should
refuse to bind a comment across an intervening image line. Not changed here.

Draft: the annotations are only meaningful once #2093 lands, and the account
seeding above should be settled first.
