### PR TITLE
Correct SSL renewal notice windows and Renew button availability

### DIFF
--- a/content/articles/buy-sectigo-ssl-certificate.md
+++ b/content/articles/buy-sectigo-ssl-certificate.md
@@ -17,7 +17,7 @@ categories:
 
 DNSimple provides an SSL certificate interface you can use to purchase a new [SSL certificate](/articles/what-is-ssl-certificate/). Buying a Sectigo certificate through DNSimple costs $20 for a single-name certificate or $100 for a wildcard certificate.
 
-Starting March 15, 2026, Sectigo SSL certificates sold by DNSimple are valid for a maximum of 200 days due to [CA/Browser Forum requirements](/articles/can-multi-year-ssl-certificates/#shorter-validity). You will need to purchase a new certificate before it expires to maintain uninterrupted coverage. Sixty days before the certificate expires, you will begin receiving renewal notices.
+Starting March 15, 2026, Sectigo SSL certificates sold by DNSimple are valid for a maximum of 200 days due to [CA/Browser Forum requirements](/articles/can-multi-year-ssl-certificates/#shorter-validity). You will need to purchase a new certificate before it expires to maintain uninterrupted coverage. Seven days before the certificate expires, you will begin receiving renewal notices.
 
 
 ## Before You Start {#before-you-start}

--- a/content/articles/expiring-product-email-notifications.md
+++ b/content/articles/expiring-product-email-notifications.md
@@ -17,7 +17,13 @@ categories:
 
 ---
 
-DNSimple monitors the expiration date of your purchased domains and certificates. We will send weekly email notifications to the account owner when these products are 60 days from expiration.
+DNSimple monitors the expiration date of your purchased domains and certificates. We will send weekly email notifications to the account owner when these products approach expiration.
+
+Domains and SSL certificates use different notice windows:
+
+- **Domains**: notifications begin 60 days from expiration.
+- **Let's Encrypt certificates**: notifications begin 30 days from expiration.
+- **Sectigo certificates**: notifications begin 7 days from expiration. Certificates purchased before March 15, 2026 use the previous 60-day window.
 
 There are two types of expiring domain notifications:
 
@@ -25,7 +31,7 @@ There are two types of expiring domain notifications:
 
 DNSimple's expiration notifications are separate from the ICANN-required notifications sent by registrars. DNSimple notifications are sent to the account owner email address and provide a convenient summary of all expiring products in your account. ICANN notifications are sent to the registrant email address for each domain and are required by policy. You may receive both types of notifications for the same domain, which is normal and expected. DNSimple notifications can be disabled for domains without auto-renewal, but ICANN notifications cannot be disabled because they are mandated by policy.
 
-- [Product Expiration](/articles/product-expiration-notification/) - An email reminder with a list of products expiring within 2 months. This is delivered every week if you have products expiring within 60 days.
+- [Product Expiration](/articles/product-expiration-notification/) - An email reminder with a list of expiring products. This is delivered every week once a product enters its notice window.
 - [Product Expiring Tomorrow](/articles/product-expiring-tomorrow-notification/) - An email reminder that lists products expiring in under 24 hours. This is a final notice, delivered once the day before the expiration date.
 
 > [!NOTE]

--- a/content/articles/renew-lets-encrypt-ssl-certificate.md
+++ b/content/articles/renew-lets-encrypt-ssl-certificate.md
@@ -30,7 +30,9 @@ All Let's Encrypt SSL certificates, including renewals, are valid for no more th
 
     ![Renewing a Certificate](/files/certificates-renew-action.png)
 
-    If you cannot see the <label>Renew</label> button, the certificate is either expired or not in a state that allows a renewal.
+    The <label>Renew</label> button only appears once the certificate is close to expiring. For Let's Encrypt certificates, it becomes available 30 days before the expiration date and remains available for 7 days after.
+
+    If the button is missing outside that period, the certificate is either not yet due for renewal, already expired for more than 7 days, or in a state that does not allow a renewal.
 
 1.  Configure the certificate renewal:
 

--- a/content/articles/renew-sectigo-ssl-certificate.md
+++ b/content/articles/renew-sectigo-ssl-certificate.md
@@ -18,12 +18,12 @@ categories:
 > [!NOTE]
 > There are a few important things you should note about [renewing an SSL certificate](/articles/renew-ssl-certificate/) before continuing with this document.
 
-Sixty days before the certificate expires, you will begin receiving renewal notices.
+Seven days before the certificate expires, you will begin receiving renewal notices. Certificates purchased before March 15, 2026 use the previous 60-day notice window.
 
 > [!NOTE]
 > Starting March 15, 2026, Sectigo certificates are valid for a maximum of 200 days due to [CA/Browser Forum lifetime reduction requirements](/articles/can-multi-year-ssl-certificates/#shorter-validity). You will need to purchase a new certificate before it expires to maintain uninterrupted coverage.
 
-We encourage you to plan the renewal of your certificate to occur at least one week before the expiration to avoid downtime or issues caused by possible renewal delays.
+Start the renewal as soon as the <label>Renew</label> button becomes available, so that email validation and issuance have time to complete before the current certificate expires. If you want a longer lead time, you can [purchase a new certificate](/articles/buy-sectigo-ssl-certificate/) at any point instead of waiting for the renewal window.
 
 ## Renewing your Sectigo certificate {#renew}
 
@@ -37,7 +37,9 @@ We encourage you to plan the renewal of your certificate to occur at least one w
 
     ![Renewing a Certificate](/files/certificates-renew-action.png)
 
-    If you do not see the <label>Renew</label> button, the certificate is either expired or not in a state that allows a renewal.
+    The <label>Renew</label> button only appears once the certificate is close to expiring. For Sectigo certificates, it becomes available 7 days before the expiration date and remains available for 7 days after. Certificates purchased before March 15, 2026 use the previous 60-day window.
+
+    If the button is missing outside that period, the certificate is either not yet due for renewal, already expired for more than 7 days, or in a state that does not allow a renewal.
 
 1.  Follow the instructions to purchase the certificate renewal.
 

--- a/content/articles/renew-ssl-certificate.md
+++ b/content/articles/renew-ssl-certificate.md
@@ -23,7 +23,7 @@ An SSL certificate renewal in DNSimple results in a new certificate being issued
 ## Before You Start {#before-you-start}
 
 - You need an active SSL certificate in your DNSimple account that is approaching its expiration date.
-- You will begin receiving renewal notices 60 days before a Sectigo certificate expires and 30 days before a Let's Encrypt certificate expires.
+- You will begin receiving renewal notices 7 days before a Sectigo certificate expires and 30 days before a Let's Encrypt certificate expires. Sectigo certificates purchased before March 15, 2026 use the previous 60-day notice window.
 - You may have more than one certificate for a hostname at the same time, so renewing before expiration will not affect your current operations.
 
 ## Renewing Your SSL Certificate {#renew}


### PR DESCRIPTION
## Summary

Reported by a customer in [Groove ticket #584783](https://dnsimple.groovehq.com/tickets/584783). They had a Sectigo certificate expiring in about a month, could not find the Renew button, and the documentation did not explain why.

The cause is the March 2026 certificate lifetime change. `compute_expiring_days` now returns `7` for Sectigo certificates purchased after 2026-03-15, down from `60`. That value drives both the renewal notice emails and whether the Renew button is shown, so several articles now state the wrong window.

What was wrong:

- Three articles said Sectigo renewal notices begin 60 days before expiration. They now begin 7 days before.
- Two articles explained a missing Renew button as "either expired or not in a state that allows a renewal," omitting the most common cause, which is that the certificate is not yet inside its renewal window. This is exactly what the customer ran into.
- The expiring product notification article gave a single 60-day figure for domains and certificates together. It is correct for domains only.

Each change notes that certificates purchased before 2026-03-15 still use the old 60-day window, since `expiring_days` is stored per certificate at purchase and those certificates can remain valid into April 2027.

## Files changed

- `content/articles/renew-sectigo-ssl-certificate.md` - corrected the notice window, documented when the Renew button appears (7 days before expiration through 7 days after), and replaced the "renew at least one week before expiration" guidance, which the 7-day window made impossible to follow
- `content/articles/renew-lets-encrypt-ssl-certificate.md` - documented the Renew button window for Let's Encrypt (30 days before expiration through 7 days after)
- `content/articles/renew-ssl-certificate.md` - corrected the Sectigo notice window in Before You Start
- `content/articles/buy-sectigo-ssl-certificate.md` - corrected the notice window
- `content/articles/expiring-product-email-notifications.md` - split the single 60-day claim into the three actual windows (domains 60, Let's Encrypt 30, Sectigo 7)

## Verification

All figures were checked against the application source rather than existing documentation:

- `lib/dnsimple/certificates/commercial/facade.rb` - `compute_expiring_days` returns 7 once `CERTS_SHORTEN_DATE_1` (2026-03-15) has passed
- `lib/dnsimple/certificates/facade.rb` - `find_notifying` gates notices on `renew_by - expiring_days <= today`
- `app/models/certificate.rb` - `allows_renewal?` requires `expiring_or_recently_expired?`, which is `(expires_at - today)` within `-7..expiring_days`; `renew_by` is set to the expiration date
- `lib/dnsimple/certificates/acme/facade.rb` - Let's Encrypt uses `expiring_days: 30`, so the existing 30-day statements elsewhere are correct and were left alone

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter unchanged
- [x] Opening paragraph directly answers the article's core question (SEO/GEO) - not applicable, no new articles
- [x] Cross-links added on first mention of related concepts
- [x] Existing articles updated to link back (if applicable) - not applicable
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types

## Review

- [x] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged

## Note for reviewers

Separate from these documentation fixes, the 7-day Sectigo renewal window may be worth a product discussion. Sectigo renewal requires email validation, which needs a person to click an approval link, and issuance is not instant. A customer who misses the notice by a few days, or whose validation email reaches a colleague who is away, can run out of time before the certificate expires. Buying a new certificate instead of renewing works as a workaround, but nothing in the interface points anyone toward it.
