### PR TITLE
Remove the rake run checklist item from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,6 @@
 - [ ] Existing articles updated to link back (if applicable)
 - [ ] No smart/curly quotes or special characters from macOS
 - [ ] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`
-- [ ] Tested locally with `rake run`
 
 ## Review
 


### PR DESCRIPTION
## Summary

Removes the "Tested locally with `rake run`" checklist item from the pull request template.

Came up while opening #2115. The item is not something every PR can satisfy, and an unchecked box that a contributor cannot act on adds noise to the review without adding signal. Documentation-only edits to body prose do not need a local build to verify.

## Files changed

- `.github/pull_request_template.md` - removed the `rake run` checklist item

## Note

`rake run` is still documented in `README.md` and `CONTRIBUTING.md` as the way to preview the site locally, which is worth keeping.

One related spot was left alone deliberately: `CONTRIBUTING.md` line 14 lists "Test locally with `rake run`" as step 4 of the contribution workflow, so the requirement still exists there in prose. 