### PR TITLE
Add missing meta descriptions to six articles

### DIFF
--- a/content/articles/api-access-token.md
+++ b/content/articles/api-access-token.md
@@ -1,6 +1,7 @@
 ---
 title: API Access Token
 excerpt: Explains how to create a new API access token for access to the API version 2, including how to create a scoped access token with granular permissions.
+meta: Create a DNSimple API access token for API v2 or the CLI, including account-scoped tokens with granular permissions.
 categories:
 - API
 - Enterprise

--- a/content/articles/consul-integration.md
+++ b/content/articles/consul-integration.md
@@ -1,6 +1,7 @@
 ---
 title: Consul Integration
 excerpt: How to use DNSimple's Consul NIA Integration to automate DNS management via Network Infrastructure Automation (NIA)
+meta: Automate DNSimple DNS records from HashiCorp Consul using the Consul-Terraform-Sync (NIA) integration module.
 categories:
 - Integrations
 ---

--- a/content/articles/domains-com-br.md
+++ b/content/articles/domains-com-br.md
@@ -1,6 +1,7 @@
 ---
 title: .COM.BR Domains
 excerpt: How .COM.BR registration works with DNSimple, including trustee service, registry DNS rules, and typical completion time.
+meta: Register .COM.BR domains with DNSimple. Covers trustee service for non-Brazilian registrants, registry DNS rules, and typical registration time.
 categories:
 - TLDs
 ---

--- a/content/articles/product-expiration-notification.md
+++ b/content/articles/product-expiration-notification.md
@@ -1,6 +1,7 @@
 ---
 title: Product Expiration Notification
 excerpt: The Product Expiration email contains a list of products expiring within two months, grouped by expiration range.
+meta: DNSimple Product Expiration emails list domains, certificates, and WHOIS privacy products expiring within two months, grouped by expiration range.
 categories:
 - DNSimple
 ---

--- a/content/articles/secondary-dns-provider-dns-made-easy.md
+++ b/content/articles/secondary-dns-provider-dns-made-easy.md
@@ -1,6 +1,7 @@
 ---
 title: Add DNSMadeEasy as a secondary DNS server
 excerpt: Secondary DNS can be complicated to set up. We simplify it with provider specific settings for DNSMadeEasy.
+meta: Configure DNSMadeEasy as a secondary DNS provider for a DNSimple-hosted zone using the provider-specific secondary DNS settings.
 categories:
 - Secondary DNS
 - Enterprise

--- a/content/articles/secondary-dns-provider-easy-dns.md
+++ b/content/articles/secondary-dns-provider-easy-dns.md
@@ -1,6 +1,7 @@
 ---
 title: Adding EasyDNS as a Secondary DNS Server
 excerpt: Secondary DNS can be complicated to set up. We simplify it with provider-specific settings for EasyDNS.
+meta: Configure EasyDNS as a secondary DNS provider for a DNSimple-hosted zone using the provider-specific secondary DNS settings.
 categories:
 - Secondary DNS
 - Enterprise


### PR DESCRIPTION
## Summary

Six articles were missing the required `meta:` frontmatter field. Without it, search and AI answer engines fall back to `excerpt` (or weaker defaults), which hurts snippet quality.

This PR adds an SEO/GEO-focused `meta` line to each article. Each meta differs from the excerpt and answers the question the page covers.

## Files changed

- `content/articles/api-access-token.md` - meta for API v2/CLI token creation and scoped permissions
- `content/articles/consul-integration.md` - meta for Consul-Terraform-Sync (NIA) DNS automation
- `content/articles/domains-com-br.md` - meta for .COM.BR trustee, registry DNS rules, and timing
- `content/articles/product-expiration-notification.md` - meta for Product Expiration email contents
- `content/articles/secondary-dns-provider-dns-made-easy.md` - meta for DNSMadeEasy secondary DNS setup
- `content/articles/secondary-dns-provider-easy-dns.md` - meta for EasyDNS secondary DNS setup

## Verification

Integrity audit on `main` before this change found these six as the only articles with empty `meta:`. After this PR:

- Zero articles missing `meta:` among the files touched
- No category YAML, redirect, H1, or body content changes
- No smart/curly quotes or em/en dashes introduced

None. Meta text is derived from existing excerpts and article scope; no new product claims.

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [ ] Opening paragraph directly answers the article's core question (SEO/GEO) (n/a - frontmatter only)
- [ ] Cross-links added on first mention of related concepts (n/a)
- [ ] Existing articles updated to link back (if applicable) (n/a)
- [x] No smart/curly quotes or special characters from macOS
- [ ] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]` (n/a)
