### PR TITLE
Align Payment Methods title case with H1

### DIFF
--- a/categories/dnsimple.yaml
+++ b/categories/dnsimple.yaml
@@ -23,7 +23,7 @@ DNSimple Products:
 - "Getting to Know Your DNSimple Domain List"
 - "DNSimple and ClickFunnels"
 - "Leave a Review"
-- "Payment methods"
+- "Payment Methods"
 - "Product Expiration Notification"
 - "Product Expiring Tomorrow Notification"
 - "Expiring Product Email Notifications"

--- a/content/articles/payment-methods.md
+++ b/content/articles/payment-methods.md
@@ -1,5 +1,5 @@
 ---
-title: Payment methods
+title: Payment Methods
 excerpt: Payment methods supported by DNSimple.
 meta: Payment methods supported by DNSimple. We use a PCI-compliant billing provider to process and store all payment data securely.
 categories:

--- a/content/articles/your-dnsimple-account.md
+++ b/content/articles/your-dnsimple-account.md
@@ -41,7 +41,7 @@ For a guided first login, see [First Steps With Your DNSimple Account](/articles
 - [Subscription Renewals](/articles/subscription-renewals/) - Monthly renewal charges and what happens when payment fails.
 - [What Happens if I Stop Paying for My DNSimple Subscription?](/articles/what-happens-if-i-stop-paying/) - Outcomes when renewal collection fails and the subscription is canceled.
 - [Discount Codes](/articles/discount-codes/) - How promotional codes apply.
-- [Payment methods](/articles/payment-methods/) - How DNSimple accepts payment.
+- [Payment Methods](/articles/payment-methods/) - How DNSimple accepts payment.
 - [Billing Settings](/articles/billing-settings/) - Customize invoice details and billing email.
 - [Changing Payment Details](/articles/changing-payment-details/) - Update the card on file.
 - [Changing Subscription Plan](/articles/changing-plans/) - Upgrade or downgrade your plan.


### PR DESCRIPTION
## Summary

The Payment Methods article had a case mismatch between frontmatter `title` (`Payment methods`) and the page H1 (`Payment Methods`). Category YAML matches the frontmatter title exactly, so leaving them out of sync risks silent category/nav drift and matches the H1 alignment work Stephanie has been doing elsewhere.

This PR capitalizes the title to match the H1, updates the DNSimple category entry, and updates the Account pillar link text that used the old title casing.

## Files changed

- `content/articles/payment-methods.md` - title `Payment methods` → `Payment Methods`
- `categories/dnsimple.yaml` - category listing updated to the new title
- `content/articles/your-dnsimple-account.md` - cross-link label updated to match

## Verification

- H1 and frontmatter `title` now match
- Category YAML title matches the article title (no orphan/invisible comment risk)
- No redirects needed (slug unchanged)
- No smart/curly quotes or em/en dashes introduced



