### PR TITLE
Align guide H1s with frontmatter titles

### DIFF
--- a/content/articles/guide-dashboard.md
+++ b/content/articles/guide-dashboard.md
@@ -7,7 +7,7 @@ categories:
 - Guides
 ---
 
-# Guide: A Quick Tour of Your Dashboard and Domain List
+# First Steps With Your DNSimple Account
 
 Your dashboard and Domain List let you manage all of your domains across your accounts.
 

--- a/content/articles/guide-getting-started-with-your-team.md
+++ b/content/articles/guide-getting-started-with-your-team.md
@@ -7,7 +7,7 @@ categories:
 - Guides
 ---
 
-# Guide: Getting Started With Your Team
+# First Steps Guide to Setting Up Your Team
 
 ### Table of Contents {#toc}
 

--- a/content/articles/guide-register-or-transfer-a-domain.md
+++ b/content/articles/guide-register-or-transfer-a-domain.md
@@ -7,7 +7,7 @@ categories:
 - Guides
 ---
 
-# Guide: Register or Transfer a Domain With DNSimple
+# Transfer or Register Domains With DNSimple
 
 ### Table of Contents {#toc}
 

--- a/content/articles/guide-setup-and-delegate-zones.md
+++ b/content/articles/guide-setup-and-delegate-zones.md
@@ -1,5 +1,4 @@
 ---
-meta: Set Up Your First Zone and Delegate Zones to DNSimple
 title: Set Up Your First Zone and Delegate Zones to DNSimple
 excerpt: A guide for setting up your first zone with DNSimple
 meta: Learn how to set up your first DNS zone and delegate it to DNSimple effectively. Follow our step-by-step guide for seamless DNS management.
@@ -8,7 +7,7 @@ categories:
 - Guides
 ---
 
-# Guide: Set Up Your First Zone and Delegate Zones to DNSimple
+# Set Up Your First Zone and Delegate Zones to DNSimple
 
 ### Table of Contents {#toc}
 


### PR DESCRIPTION
## Summary

Four Getting Started guides had H1s that did not match frontmatter `title` (often still prefixed with `Guide:` while the title had already been renamed). That breaks the rule that the page H1 matches `title`, and makes the on-page heading disagree with category/nav labels.

This PR updates each H1 to match the existing title. Titles and category YAML are unchanged.

Also removes a duplicate `meta:` key on `guide-setup-and-delegate-zones.md`. YAML only keeps the last value; the first `meta` was a leftover title string and was unused.

## Files changed

- `content/articles/guide-dashboard.md` - H1 → `First Steps With Your DNSimple Account`
- `content/articles/guide-getting-started-with-your-team.md` - H1 → `First Steps Guide to Setting Up Your Team`
- `content/articles/guide-register-or-transfer-a-domain.md` - H1 → `Transfer or Register Domains With DNSimple`
- `content/articles/guide-setup-and-delegate-zones.md` - H1 aligned; duplicate `meta` removed (kept SEO meta)
