### PR TITLE
Document the .FI holder transfer key

### DIFF
--- a/content/articles/domains-fi.md
+++ b/content/articles/domains-fi.md
@@ -29,6 +29,12 @@ Organizations registering a .FI domain may need to provide:
 
 Individuals can register .FI domains with standard contact information.
 
+## Changing the contact for a .FI domain {#owner-change}
+
+Changing the registrant of a .FI domain is an owner change at the registry, and it requires a holder transfer key. It is not the authorization code used to transfer a domain between registrars.
+
+Starting a contact change requests the key for you. The registry emails it to the address listed as registrant (owner) for the domain, and it is valid for 30 days. If you are taking the domain over from someone else, the key reaches them rather than you.
+
 ## Have more questions?
 
 If you have any questions about registering, transferring, or renewing your .FI domain, [contact us](https://dnsimple.com/feedback), and we'll be happy to help.


### PR DESCRIPTION
## Summary

Changing the registrant of a .FI domain is an owner change at the registry, and it needs a holder transfer key. The article never mentioned it, and customers have been supplying the transfer authorization code instead, which the registry rejects. See dnsimple/dnsimple-app#32127.

Adds a short section saying which key an owner change needs, that it is not the transfer authorization code, where the registry sends it, and how long it lasts. The registration content is unchanged.

It describes starting a contact change as requesting the key, matching how transfer out already works, so it should not merge before the app side ships that.

Pairs with dnsimple/dnsimple-app#36770, whose `help_url` points at `#owner-change`.

## Files changed

- `content/articles/domains-fi.md`

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [ ] Cross-links added on first mention of related concepts
- [ ] Existing articles updated to link back (if applicable)
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`

## Review

- [x] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)
