### PR TITLE
Restructure Secondary DNS category into Diataxis sections

### DIFF
--- a/categories/meta.yaml
+++ b/categories/meta.yaml
@@ -13,7 +13,7 @@ connectors: Articles on DNSimple connectors, which link a domain to a Heroku app
 services: Explore our one-click services, designed to help you effectively utilize and manage DNSimple's powerful features and tools.
 name_servers: Articles on name server setup, management, and troubleshooting at DNSimple, including vanity name servers and delegation configuration.
 whois_privacy: Articles on DNSimple's free WHOIS Privacy service, covering setup, management, and how it protects your personal information from public view.
-secondary_dns: Explore our comprehensive guide on Secondary DNS at DNSimple. Find articles, tutorials, and resources to enhance your domain's reliability and performance.
+secondary_dns: Articles on Secondary DNS at DNSimple, covering DNS redundancy options, outbound and inbound zone transfers, provider setup, and using DNSimple alongside other DNS providers.
 integrations: Articles on DNSimple integrations, with guides and resources for connecting your domains with external DNS providers and services.
 guides: Master DNS management and domain registration with our expert guides, tips, and step-by-step instructions to enhance your online presence.
 ssl_certificates: Discover in-depth guides on SSL certificates, including installation, management, and best practices to enhance your website's security and safeguard user data.

--- a/categories/secondary_dns.yaml
+++ b/categories/secondary_dns.yaml
@@ -1,14 +1,16 @@
-Configurations:
-- "DNS Redundancy Options at DNSimple"
-- "Add a secondary DNS server to DNSimple"
-- "Add DNSimple as a secondary DNS server"
-- "Add DNSimple as Secondary DNS with a Hidden Primary"
-- "Using DNSimple alongside other DNS providers"
-
-Integration with other DNS providers:
-- "Add DNSMadeEasy as a secondary DNS server"
-- "Adding Dyn as a Secondary DNS Server"
-- "Adding EasyDNS as a Secondary DNS Server"
-
 Explanation:
+- "DNS Redundancy Options at DNSimple"
 - "Why DNSSEC and Secondary DNS May Not Work Together"
+- "How ALIAS Records Resolve with Secondary DNS"
+
+How-to:
+  DNSimple as primary:
+    - "Add a secondary DNS server to DNSimple"
+    - "Add DNSMadeEasy as a secondary DNS server"
+    - "Adding Dyn as a Secondary DNS Server"
+    - "Adding EasyDNS as a Secondary DNS Server"
+  DNSimple as secondary:
+    - "Add DNSimple as a secondary DNS server"
+    - "Add DNSimple as Secondary DNS with a Hidden Primary"
+  Multi-provider without zone transfers:
+    - "Using DNSimple alongside other DNS providers"

--- a/content/articles/alias-and-secondary-dns.md
+++ b/content/articles/alias-and-secondary-dns.md
@@ -4,6 +4,7 @@ excerpt: How DNSimple ensures ALIAS resolution on secondary servers.
 meta: Learn more about how DNSimple's special handling process to ensure your secondary servers always have the most up-to-date IP addresses.
 categories:
 - DNS
+- Secondary DNS
 ---
 
 # How ALIAS Records Resolve with Secondary DNS


### PR DESCRIPTION
## Summary

Reorganizes the Secondary DNS category on the Help site into Diataxis-aligned sections. YAML only — no article content changes.

Closes dnsimple/dnsimple-customer-success#244

Part of dnsimple/dnsimple-customer-success#243 (Phase 3 of dnsimple/dnsimple-customer-success#200)

## What changed

| Before | After |
|--------|--------|
| Configurations, Integration with other DNS providers, Explanation (1) | **Explanation**, **How-to** (nested by setup path) |

**Explanation**
- DNS Redundancy Options at DNSimple
- Why DNSSEC and Secondary DNS May Not Work Together
- How ALIAS Records Resolve with Secondary DNS (cross-list; already listed under DNS)

**How-to**
- DNSimple as primary (outbound AXFR + provider guides)
- DNSimple as secondary (inbound AXFR + hidden primary)
- Multi-provider without zone transfers

Also replaces the `secondary_dns` entry in `categories/meta.yaml` (marketing fluff → factual description).

## Files changed

- `categories/secondary_dns.yaml` — Diataxis restructure; exact current frontmatter titles only
- `categories/meta.yaml` — Secondary DNS category description

## Verification

- [x] Every YAML listing matches article frontmatter `title` exactly (10 titles checked)
- [x] No article body or display-title changes
- [x] No Getting started section yet (pillar lands in a later PR)
- [x] Unrelated local files left out of the commit

## Not in this PR (follow-up)

- Article rules + accuracy passes (#245, #247–#249)
- What is Secondary DNS? (#246)
- Secondary DNS at DNSimple pillar (#250)

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [ ] Frontmatter has `title`, `excerpt`, `meta`, and `categories` (n/a — YAML only)
- [ ] Opening paragraph directly answers the article's core question (SEO/GEO) (n/a)
- [ ] Cross-links added on first mention of related concepts (n/a)
- [ ] Existing articles updated to link back (if applicable) (n/a)
- [x] No smart/curly quotes or special characters from macOS
- [ ] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]` (n/a)

## Review

- [ ] Second expert tagged for feature/product knowledge
- [ ] Customer Success tagged (required for substantial updates)


---

## Update: ALIAS cross-list now ships working (2026-09-08)

The category page is built from each article's frontmatter `categories`, not from the category YAML (`lib/categories.rb`). Listing `"How ALIAS Records Resolve with Secondary DNS"` under Explanation therefore did nothing on its own: `alias-and-secondary-dns.md` was still `categories: [DNS]`, so the article was not in the Secondary DNS item set and the YAML string stayed unmatched. Unmatched titles render as an HTML comment in `layouts/category_index.html`, so a broken listing does not fail the build and CI will not catch it.

Added `- Secondary DNS` to that article's frontmatter in this PR so the cross-list is live when this merges, rather than invisible until #2124 lands.

This is a deliberate, narrow exception to the YAML-only rule on dnsimple/dnsimple-customer-success#243: frontmatter `categories` is category structure, not article content. No body text changed.

**Note for #2124:** that PR also adds the same `- Secondary DNS` line as part of its frontmatter pass. Identical addition on both sides, so keep the line when merging.
