### PR TITLE
Update Secondary DNS How-to: multi-provider without AXFR

### DIFF
--- a/content/articles/secondary-dns.md
+++ b/content/articles/secondary-dns.md
@@ -141,13 +141,11 @@ Please prefer the host name whenever possible. If any of these IP addresses shou
 
     Secondary DNS is when you use a special protocol called AXFR to automatically transfer your zones to a secondary DNS provider whenever they change. This allows you to use DNSimple's name servers and another DNS provider's name servers at the same time.
 
-    This lets you have an active redundancy in your domain name resolution. If an issue came up with DNSimple, you'd still have active resolution with your other provider. This disaster prevention is very valuable to any products that need high uptime. When secondary DNS is enabled, those name servers may be used at any time by resolvers - not just when an issue arises resolving names through our name servers.
+    This lets you have an active redundancy in your domain name resolution. If an issue came up with DNSimple, you'd still have active resolution with your other provider. This disaster prevention is very valuable to any products that need high uptime. When secondary DNS is enabled, those name servers may be used at any time by resolvers – not just when an issue arises resolving names through our name servers.
 
 1.  #### Can DNSimple serve as a secondary DNS provider?
 
-    Yes. DNSimple can pull your zone from an external primary over AXFR. See [Add DNSimple as a secondary DNS server](/articles/secondary-dns-dnsimple-as-secondary/), or [Add DNSimple as Secondary DNS with a Hidden Primary](/articles/secondary-dns-dnsimple-with-hidden-primary/) if your primary is not publicly listed.
-
-    If you prefer not to use zone transfers, you can run both providers in parallel and keep the zones in sync yourself. See [Using DNSimple alongside other DNS providers](/articles/secondary-dnsimple/).
+    DNSimple can't synchronize zone changes from other name servers using AXFR. But you can combine our secondary DNS feature with our API or UI to have zone redundancy with other DNS providers. See [DNSimple as a Secondary DNS provider](/articles/secondary-dnsimple/).
 
 1.  #### How can I check that my secondary DNS configuration is correct?
 

--- a/content/articles/secondary-dns.md
+++ b/content/articles/secondary-dns.md
@@ -141,11 +141,13 @@ Please prefer the host name whenever possible. If any of these IP addresses shou
 
     Secondary DNS is when you use a special protocol called AXFR to automatically transfer your zones to a secondary DNS provider whenever they change. This allows you to use DNSimple's name servers and another DNS provider's name servers at the same time.
 
-    This lets you have an active redundancy in your domain name resolution. If an issue came up with DNSimple, you'd still have active resolution with your other provider. This disaster prevention is very valuable to any products that need high uptime. When secondary DNS is enabled, those name servers may be used at any time by resolvers – not just when an issue arises resolving names through our name servers.
+    This lets you have an active redundancy in your domain name resolution. If an issue came up with DNSimple, you'd still have active resolution with your other provider. This disaster prevention is very valuable to any products that need high uptime. When secondary DNS is enabled, those name servers may be used at any time by resolvers - not just when an issue arises resolving names through our name servers.
 
 1.  #### Can DNSimple serve as a secondary DNS provider?
 
-    DNSimple can't synchronize zone changes from other name servers using AXFR. But you can combine our secondary DNS feature with our API or UI to have zone redundancy with other DNS providers. See [DNSimple as a Secondary DNS provider](/articles/secondary-dnsimple/).
+    Yes. DNSimple can pull your zone from an external primary over AXFR. See [Add DNSimple as a secondary DNS server](/articles/secondary-dns-dnsimple-as-secondary/), or [Add DNSimple as Secondary DNS with a Hidden Primary](/articles/secondary-dns-dnsimple-with-hidden-primary/) if your primary is not publicly listed.
+
+    If you prefer not to use zone transfers, you can run both providers in parallel and keep the zones in sync yourself. See [Using DNSimple alongside other DNS providers](/articles/secondary-dnsimple/).
 
 1.  #### How can I check that my secondary DNS configuration is correct?
 

--- a/content/articles/secondary-dnsimple.md
+++ b/content/articles/secondary-dnsimple.md
@@ -1,7 +1,7 @@
 ---
 title: Using DNSimple alongside other DNS providers
-excerpt: Run DNSimple next to another DNS provider without AXFR by keeping both zones in sync yourself.
-meta: Use DNSimple with another DNS provider without zone transfers. Keep zones in sync with the record editor, zone import, API, or infrastructure-as-code tools.
+excerpt: Run DNSimple next to another DNS provider without automatic zone transfers by keeping both zones in sync yourself.
+meta: Use DNSimple with another DNS provider without AXFR zone transfers. Keep zones in sync with the record editor, zone import, API, or infrastructure-as-code tools.
 categories:
 - Secondary DNS
 - Enterprise
@@ -18,8 +18,8 @@ categories:
 
 You can run DNSimple next to another DNS provider **without** automatic zone transfers. You are responsible for keeping both zones in sync. This is not inbound or outbound secondary DNS via AXFR.
 
-> [!WARNING]
-> For automatic AXFR between DNSimple and another provider, use [Add a secondary DNS server to DNSimple](/articles/secondary-dns/) (DNSimple as primary) or [Add DNSimple as a secondary DNS server](/articles/secondary-dns-dnsimple-as-secondary/) (DNSimple as secondary). See [What is Secondary DNS?](/articles/what-is-secondary-dns/) for the difference.
+> [!NOTE]
+> For automatic AXFR between DNSimple and another provider, use [Add a secondary DNS server to DNSimple](/articles/secondary-dns/) (DNSimple as primary) or [Add DNSimple as a secondary DNS server](/articles/secondary-dns-dnsimple-as-secondary/) (DNSimple as secondary). See [DNS Redundancy Options at DNSimple](/articles/dns-redundancy/) for the difference.
 
 Ways to keep zones aligned:
 
@@ -30,13 +30,13 @@ Ways to keep zones aligned:
 
 This diagram shows how zone changes must be applied to both providers:
 
-![Externally managed Secondary DNS diagram](/files/secondary_dns_externally_managed.jpg)
+![Zone changes applied to both DNSimple and another DNS provider](/files/secondary_dns_externally_managed.jpg)
 
-## Hosted domain {#hosted}
+## Adding another provider's name servers to a hosted zone {#hosted}
 
 To publish name servers from both providers on a hosted zone, follow [Updating Zone NS Records for a Hosted Domain](/articles/zone-ns-records/).
 
-## Registered domain {#registered}
+## Adding another provider's name servers to a registered domain {#registered}
 
 To publish name servers from both providers for a domain registered with DNSimple, follow [Change delegation to another DNS provider](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider).
 

--- a/content/articles/secondary-dnsimple.md
+++ b/content/articles/secondary-dnsimple.md
@@ -1,7 +1,7 @@
 ---
 title: Using DNSimple alongside other DNS providers
-excerpt: How to use DNSimple along with other DNS providers.
-meta: Learn how to seamlessly integrate DNSimple as a secondary DNS provider, along with your primary DNS provider for enhanced domain redundancy.
+excerpt: Run DNSimple next to another DNS provider without AXFR by keeping both zones in sync yourself.
+meta: Use DNSimple with another DNS provider without zone transfers. Keep zones in sync with the record editor, zone import, API, or infrastructure-as-code tools.
 categories:
 - Secondary DNS
 - Enterprise
@@ -9,29 +9,37 @@ categories:
 
 # Using DNSimple alongside other DNS providers
 
+### Table of Contents {#toc}
+
+* TOC
+{:toc}
+
+---
+
+You can run DNSimple next to another DNS provider **without** automatic zone transfers. You are responsible for keeping both zones in sync. This is not inbound or outbound secondary DNS via AXFR.
+
 > [!WARNING]
-> If you want to set up automatic zone transfers (AXFR) between DNSimple and another DNS service provider, head to the [Add a secondary DNS server to DNSimple](/articles/secondary-dns/) and [Add DNSimple as a secondary DNS server](/articles/secondary-dns-dnsimple-as-secondary/) articles.
+> For automatic AXFR between DNSimple and another provider, use [Add a secondary DNS server to DNSimple](/articles/secondary-dns/) (DNSimple as primary) or [Add DNSimple as a secondary DNS server](/articles/secondary-dns-dnsimple-as-secondary/) (DNSimple as secondary). See [What is Secondary DNS?](/articles/what-is-secondary-dns/) for the difference.
 
-You can use our API or UI to have zone redundancy with other DNS providers. You're responsible for keeping the zones in sync between other DNS providers and DNSimple. There are several ways to do this:
+Ways to keep zones aligned:
 
-- [Adding the records](/articles/record-editor/) manually through our UI.
-- [Importing a zone file](/articles/import-records-zone-file/) from your primary provider.
-- [Using our API](https://developer.dnsimple.com/v2/).
-- Use "infrastructure as code" tools such as our [Terraform provider](/articles/terraform-provider/) ([registry docs](https://registry.terraform.io/providers/dnsimple/dnsimple/latest/docs)), [OctoDNS](https://github.com/octodns/octodns), and [DNSControl](https://github.com/StackExchange/dnscontrol)
+- [Add records](/articles/record-editor/) manually in the DNSimple UI
+- [Import a zone file](/articles/import-records-zone-file/) from your other provider
+- Use the [DNSimple API](https://developer.dnsimple.com/v2/)
+- Use infrastructure-as-code tools such as the [Terraform provider](/articles/terraform-provider/) ([registry docs](https://registry.terraform.io/providers/dnsimple/dnsimple/latest/docs)), [OctoDNS](https://github.com/octodns/octodns), or [DNSControl](https://github.com/StackExchange/dnscontrol)
 
-This diagram shows how zone changes are propagated to both DNS service providers:
+This diagram shows how zone changes must be applied to both providers:
 
 ![Externally managed Secondary DNS diagram](/files/secondary_dns_externally_managed.jpg)
 
-## Configuring DNSimple alongside another DNS provider (hosted domain)
+## Hosted domain {#hosted}
 
-To set up zone redundancy with another DNS provider on your zone, follow the steps detailed in [Updating Zone NS Records for a Hosted Domain](/articles/zone-ns-records/).
+To publish name servers from both providers on a hosted zone, follow [Updating Zone NS Records for a Hosted Domain](/articles/zone-ns-records/).
 
+## Registered domain {#registered}
 
-## Configuring DNSimple alongside another DNS provider (registered domain)
-
-To set up zone redundancy with another DNS provider on your domain, follow the steps in [Change delegation to another DNS provider](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider).
+To publish name servers from both providers for a domain registered with DNSimple, follow [Change delegation to another DNS provider](/articles/setting-name-servers/#pointing-the-name-servers-to-another-provider).
 
 ## Have more questions?
 
-If you have additional questions or need assistance setting up zone redundancy, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.
+If you have questions about multi-provider DNS without AXFR, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.


### PR DESCRIPTION
## Summary

Rules and accuracy pass for multi-provider DNS **without** zone transfers.

Closes dnsimple/dnsimple-customer-success#249

Part of dnsimple/dnsimple-customer-success#243

## Files changed

- `content/articles/secondary-dnsimple.md` - clarify non-AXFR scope; fix misleading meta; anchors; voice; cross-links

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [x] Frontmatter has `title`, `excerpt`, `meta`, and `categories`
- [x] Opening paragraph directly answers the article's core question (SEO/GEO)
- [x] Cross-links added on first mention of related concepts
- [x] No smart/curly quotes or special characters from macOS
- [x] Callouts use correct types: `[!NOTE]`, `[!TIP]`, or `[!WARNING]`

## Review

- [ ] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)


---

## Review notes from repo audit (2026-09-08)

### Rename scope

`"Using DNSimple alongside other DNS providers"` is listed in `categories/enterprise.yaml` (Infra) as well as `categories/secondary_dns.yaml`. The linked issue flags the meta and excerpt as confusing, so a title rename is plausible here. If one is added, update frontmatter `title`, the H1, and **both** YAML files in the same PR. Unmatched titles render as an HTML comment in `layouts/category_index.html`, so a broken listing does not fail the build and CI will not catch it.

### If the diagram is replaced

`secondary-dnsimple.md` embeds `/files/secondary_dns_externally_managed.jpg`. `_test/images_test.rb` fails if any file under `content/files` is unreferenced, so a replaced diagram must be deleted in the same PR. Images are capped at 500 KB.
