### PR TITLE
Fix infinite redirect loop on missing article and category paths

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -218,5 +218,5 @@
 /articles/domains-pt/                                                     /articles/tlds/
 /articles/domains-pt/index.html                                           /articles/tlds/
 /dnsimple.com/contact                                                     https://dnsimple.com/contact
-/articles/:slug                                                           /articles/:slug/    301
-/categories/:slug                                                         /categories/:slug/  301
+/articles/dns-ttl                                                         /articles/what-is-ttl/
+/articles/dns-ttl/                                                        /articles/what-is-ttl/


### PR DESCRIPTION
## Summary

Search Console flagged six URLs on support.dnsimple.com under Page indexing > Redirect error. Three of them are in genuine infinite redirect loops, and the cause is in `_redirects`.

The last two rules in the file were self-referential:

```
/articles/:slug      /articles/:slug/    301
/categories/:slug    /categories/:slug/  301
```

Netlify's `:slug` placeholder also matches the trailing-slash form, so `/articles/dns-ttl/` matches with slug = `dns-ttl` and redirects to `/articles/dns-ttl/`. Forever.

Real articles are unaffected, because a file exists at their path and is served before the rule is reached. The rules only fire when nothing exists there, so the actual effect is that **every 404 under `/articles/` and `/categories/` is an infinite redirect loop instead of the 404 page.** Confirmed against production:

| Path | Result today |
|---|---|
| `/articles/zzz-does-not-exist/` | 301 loop |
| `/categories/zzz/` | 301 loop |
| `/questions/zzz/`, `/files/zzz/`, `/nope` | 404 correctly |

The rules are also unnecessary. `/404` is not covered by either one and still 301s to `/404/`, so Netlify already normalizes trailing slashes without help. Removing them restores 404s without losing anything, and the explicit renamed-slug redirects above them are matched first and keep working.

These rules came in on 2026-05-26 in #1956, which matches the crawl dates on the affected URLs.

Of the six URLs Search Console listed, the three that loop are exactly the three with no page behind them: `spf-`, `url-record,` and `dns-ttl`. The first two are mangled inbound links from elsewhere (a truncated slug and a trailing comma) and are not worth redirect entries; once the loop is gone they will 404, which is the correct signal. `dns-ttl` was never a slug of ours, but something is linking it, so this adds a redirect to `what-is-ttl`. The other three URLs already resolve in one hop and should clear on their own.

## Files changed

- `_redirects` - removed the two self-referential `:slug` rules, added `/articles/dns-ttl` to `/articles/what-is-ttl/`

## Verifying on the deploy preview

Netlify rule precedence is worth confirming on the preview rather than trusting the reasoning:

1. `/articles/zzz-does-not-exist/` returns the 404 page, not a redirect
2. `/categories/zzz/` returns the 404 page
3. `/articles/announcement-ns2-ns4-ip-addresses/` still lands on `/articles/announcement-ns1-ns3-ip-addresses/`
4. `/articles/spf-record` (no trailing slash) still 301s to `/articles/spf-record/`
5. `/articles/dns-ttl/` lands on `/articles/what-is-ttl/`

## Checklist

- [x] Branch created from up-to-date `main`
- [x] Only files related to this task are included
- [ ] Frontmatter has `title`, `excerpt`, `meta`, and `categories` - n/a, no content changes
- [ ] Opening paragraph directly answers the article's core question (SEO/GEO) - n/a
- [ ] Cross-links added on first mention of related concepts - n/a
- [ ] Existing articles updated to link back (if applicable) - n/a
- [x] No smart/curly quotes or special characters from macOS
- [ ] Callouts use correct types - n/a

## Review

- [ ] Second expert tagged for feature/product knowledge - n/a, redirect config only, no engineering review needed
- [ ] Customer Success tagged (required for substantial updates) - n/a
