### PR TITLE
Align pillar pages with the current pillar conventions

### DIFF
--- a/content/articles/dns.md
+++ b/content/articles/dns.md
@@ -183,3 +183,7 @@ These live in other categories but come up often alongside DNS:
 - [Email Services at DNSimple](/articles/emails/) - The MX, SPF, DKIM, and DMARC records that carry and authenticate mail.
 - [DNS Templates at DNSimple](/articles/dns-templates-at-dnsimple/) - Reusable record sets you can apply across many zones.
 - [One-click Services](/articles/services/) - Prebuilt record sets for known providers, applied in one step.
+
+## Have more questions?
+
+If you have any questions about DNS at DNSimple, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/dns.md
+++ b/content/articles/dns.md
@@ -173,3 +173,13 @@ Technical specifications, formats, and reference documentation:
 - [Understand DNSimple's Record Editors Simple vs. Field-Specific](/articles/record-editor-simple-field/) - Reference guide explaining the differences between simple and field-specific record editors.
 - [IPv6 Domain Resolution Reference](/articles/ipv6-support/) - Technical reference for IPv6 domain resolution and AAAA records.
 - [Resolving with DNSimple](/articles/resolving-with-us/) - Technical reference for displaying and embedding a "Resolving with DNSimple" badge on websites.
+
+## Related articles {#related}
+
+These live in other categories but come up often alongside DNS:
+
+- [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/) - Delegation decides which provider answers for the zone you manage here.
+- [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/) - Sign the zone so resolvers can verify the records it returns.
+- [Email Services at DNSimple](/articles/emails/) - The MX, SPF, DKIM, and DMARC records that carry and authenticate mail.
+- [DNS Templates at DNSimple](/articles/dns-templates-at-dnsimple/) - Reusable record sets you can apply across many zones.
+- [One-click Services](/articles/services/) - Prebuilt record sets for known providers, applied in one step.

--- a/content/articles/dnssec.md
+++ b/content/articles/dnssec.md
@@ -60,3 +60,9 @@ Dive deeper into the specifics of DNSSEC with our comprehensive reference materi
 
 - [DNSSEC Management in DNSimple](/articles/dnssec-management-in-dnsimple/): A detailed look at the DNSSEC management interface within your DNSimple account, including available settings and information.
 - [DNSSEC Glossary](/articles/dnssec-glossary/): Familiarize yourself with common terms and definitions related to DNSSEC.
+
+## Related articles {#related}
+
+- [DNS at DNSimple](/articles/dns/) - The zone and the records that DNSSEC signs.
+- [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/) - Moving DNS to another provider means updating the DS records at the registry.
+- [SSL/TLS Certificates](/articles/ssl-certificates/) - DANE uses DNSSEC-signed records to authenticate TLS certificates.

--- a/content/articles/dnssec.md
+++ b/content/articles/dnssec.md
@@ -66,3 +66,7 @@ Dive deeper into the specifics of DNSSEC with our comprehensive reference materi
 - [DNS at DNSimple](/articles/dns/) - The zone and the records that DNSSEC signs.
 - [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/) - Moving DNS to another provider means updating the DS records at the registry.
 - [SSL/TLS Certificates](/articles/ssl-certificates/) - DANE uses DNSSEC-signed records to authenticate TLS certificates.
+
+## Have more questions?
+
+If you have any questions about DNSSEC, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/emails.md
+++ b/content/articles/emails.md
@@ -113,6 +113,12 @@ DNSimple provides email forwarding and DNS-based email authentication (SPF, DKIM
 - [DKIM Record Reference](/articles/dkim-record-reference/) - DKIM record structure and technical details.
 - [DMARC Record Reference](/articles/dmarc-record-reference/) - DMARC record structure, tags, and technical details.
 
+## Related articles {#related}
+
+- [DNS at DNSimple](/articles/dns/) - Email authentication is published as records in your zone.
+- [One-click Services](/articles/services/) - One-step setup for Google Workspace, Fastmail, Postmark, and other mail providers.
+- [Name Server Management at DNSimple](/articles/name-server-management-in-dnsimple/) - Mail can stop arriving after a delegation change, and this covers how to check.
+
 ## Have more questions?
 
 If you have additional questions or need assistance with email services, [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/name-server-management-in-dnsimple.md
+++ b/content/articles/name-server-management-in-dnsimple.md
@@ -61,6 +61,12 @@ DNSimple provides full control over name server delegation for domains registere
 - [NS Record Format](/articles/ns-record-format/) - The RDATA structure, canonical zone file representation, and DNSimple fields for NS records.
 - [DNSimple Interface Reference for Name Server Management](/articles/name-servers-interface-reference/) - Reference for the Edit Delegation, Name Server Sets, Vanity Name Servers, and Zone NS Records interfaces.
 
+## Related articles {#related}
+
+- [DNS at DNSimple](/articles/dns/) - The records DNSimple serves once a domain is delegated here.
+- [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/) - DS records have to be updated when you move DNS to another provider.
+- [Domains and Transfers at DNSimple](/articles/domains-and-transfers/) - Registration and transfer at the registrar that publishes your delegation.
+
 ## Have more questions?
 
 If you have any questions about name server management at DNSimple, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/services.md
+++ b/content/articles/services.md
@@ -105,6 +105,13 @@ Services are defined in an open-source repository on GitHub. You can fork and up
 
 Visit [our github repository](https://github.com/dnsimple/dnsimple-services) for full instructions.
 
+## Related articles {#related}
+
+- [DNS at DNSimple](/articles/dns/) - The records a service creates, and where to edit them afterward.
+- [DNS Templates at DNSimple](/articles/dns-templates-at-dnsimple/) - Your own reusable record sets, built on the same mechanism as services.
+- [Connectors at DNSimple](/articles/connectors-at-dnsimple/) - When to connect a domain to a Heroku app or Netlify site instead of applying a service.
+- [Email Services at DNSimple](/articles/emails/) - Mail provider setup, including the email services listed above.
+
 ## Have more questions?
 
 If you have additional questions or need any assistance with our One-click Services, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/ssl-certificates.md
+++ b/content/articles/ssl-certificates.md
@@ -99,6 +99,12 @@ From the certificate section you can [purchase a new SSL certificate](/articles/
 
 The [SSL Certificate frequently asked questions](/articles/faq-ssl-certificates/) page contains the most common questions about DNSimple SSL certificates.
 
+## Related articles {#related}
+
+- [DNS at DNSimple](/articles/dns/) - CAA records control which certificate authorities may issue for your domain.
+- [DNS Security Extensions (DNSSEC) at DNSimple](/articles/dnssec/) - DANE publishes certificate constraints in DNSSEC-signed records.
+- [Domains and Transfers at DNSimple](/articles/domains-and-transfers/) - A domain has to be in your account before you can order a certificate for it.
+
 ## Have more questions?
 
 If you have any questions or need assistance, [contact support](https://dnsimple.com/feedback), and we will be happy to help.

--- a/content/articles/tlds.md
+++ b/content/articles/tlds.md
@@ -95,3 +95,7 @@ For the full list of TLDs supported for registration and transfer, see [dnsimple
 - [Domains and Transfers at DNSimple](/articles/domains-and-transfers/) - Registering, transferring, and renewing domains under any of these TLDs.
 - [Domain Contacts at DNSimple](/articles/domain-contacts-at-dnsimple/) - The registrant details registries require, including the local presence some TLDs ask for.
 - [WHOIS Privacy at DNSimple](/articles/whois-privacy-at-dnsimple/) - Whether privacy is available at all depends on the TLD's registry.
+
+## Have more questions?
+
+If you have any questions about TLDs, just [contact support](https://dnsimple.com/feedback), and we'll be happy to help.

--- a/content/articles/tlds.md
+++ b/content/articles/tlds.md
@@ -89,3 +89,9 @@ Requirements, eligibility, registration and transfer rules, and any special step
 - [.ZA Domains](/articles/domains-za/) - Requirements and procedures for .ZA domain names.
 
 For the full list of TLDs supported for registration and transfer, see [dnsimple.com/tlds](https://dnsimple.com/tlds). TLDs not supported for registration or transfer can often still be [added to your account](/articles/adding-domain/) for DNS hosting or other services such as [SSL certificates](https://dnsimple.com/ssl-certificates).
+
+## Related articles {#related}
+
+- [Domains and Transfers at DNSimple](/articles/domains-and-transfers/) - Registering, transferring, and renewing domains under any of these TLDs.
+- [Domain Contacts at DNSimple](/articles/domain-contacts-at-dnsimple/) - The registrant details registries require, including the local presence some TLDs ask for.
+- [WHOIS Privacy at DNSimple](/articles/whois-privacy-at-dnsimple/) - Whether privacy is available at all depends on the TLD's registry.

--- a/content/articles/your-dnsimple-account.md
+++ b/content/articles/your-dnsimple-account.md
@@ -94,6 +94,12 @@ For a guided first login, see [First Steps With Your DNSimple Account](/articles
 - [Subscription Renewals](/articles/subscription-renewals/#failed-renewal) - What happens when a renewal payment fails and how retries work.
 - [Account Invoice History](/articles/account-invoice-history/#retrying) - Retry a failed or dunned invoice payment.
 
+## Related articles {#related}
+
+- [Domain Contacts at DNSimple](/articles/domain-contacts-at-dnsimple/) - Contacts belong to the account, and adding one grants no account access.
+- [Domains and Transfers at DNSimple](/articles/domains-and-transfers/) - The domains your subscription and account balance pay for.
+- [SSL/TLS Certificates](/articles/ssl-certificates/) - Some certificate options depend on the plan the account is on.
+
 ## Have more questions?
 
 If you have questions about your DNSimple account, [contact support](https://dnsimple.com/feedback), and we will be happy to help.


### PR DESCRIPTION
## Summary

Brings the pillar pages in line with the conventions the current pillars use. Two changes:

1. A `Related articles` section on the eight pillar pages that did not have one.
2. A `Have more questions?` closing CTA on the three that did not have one.

Follow-up to the Secondary DNS pillar work in #2129, where the question came up of what the convention actually is.

## Where the convention comes from

Of the 13 pages listed under `Getting started` in the category YAMLs, five had a Related section: Connectors, Domain Contacts, DNS Templates, WHOIS Privacy, and the Secondary DNS pillar in #2129. The first four were all created in the same batch on 2026-07-31 (#2062 through #2065), and they agree on the shape:

- heading is `## Related articles {#related}`
- it points at articles in **other** categories that come up alongside this one
- link text is the exact article title
- each link carries a one-line gloss saying why it is related

The eight pages here had no such section. They are older: Email Services, One-click Services, and SSL/TLS Certificates date to April, DNSSEC to 2024, Name Server Management to May. None of them used an alternative name like `See also` either, so nothing was renamed or moved.

## Files changed

| Page | Links added |
|---|---|
| `content/articles/dns.md` | Name Servers, DNSSEC, Email, Templates, Services |
| `content/articles/dnssec.md` | DNS, Name Servers, SSL |
| `content/articles/emails.md` | DNS, Services, Name Servers |
| `content/articles/name-server-management-in-dnsimple.md` | DNS, DNSSEC, Domains and Transfers |
| `content/articles/tlds.md` | Domains and Transfers, Contacts, WHOIS Privacy |
| `content/articles/your-dnsimple-account.md` | Contacts, Domains and Transfers, SSL |
| `content/articles/services.md` | DNS, Templates, Connectors, Email |
| `content/articles/ssl-certificates.md` | DNS, DNSSEC, Domains and Transfers |

53 insertions, no deletions. Nothing existing was changed.

## Verification

- [x] All 27 link targets exist in `content/articles/`
- [x] All 27 link labels match the target article's frontmatter `title` exactly
- [x] Every gloss checked against the linked article rather than written from memory. For example the WHOIS Privacy gloss on `tlds.md` reflects the `Check whether your TLD supports it` section, which says a registry that does not support privacy blocks it for every domain under that TLD; the SSL gloss on `your-dnsimple-account.md` reflects the plan gating stated on Let's Encrypt wildcard certificates
- [x] No self-links, no link repeated elsewhere in the same page, no duplicate `{#related}` anchors
- [x] Links use `/articles/slug/` with a trailing slash, per the `Links` tests in `_test/posts_test.rb`
- [x] No em dashes, no smart quotes

Could not run `rake test` locally: no Ruby or Bundler in this environment. Both link tests in `_test/posts_test.rb` were checked by hand against their regexes.

## Notes for review

Two of these are not really hub pages, and I left them as they are rather than restructuring:

- `services.md` still contains its own step-by-step for adding and removing a service, with screenshots, so it is a how-to with a directory embedded in it rather than a hub that links out. `categories/services.yaml` has no Diataxis structure either, just `Getting started` plus provider groupings. It also has the most inbound internal links of the eight, around 50.
- `ssl-certificates.md` duplicates content that already exists elsewhere. The product descriptions and pricing are also in `ssl-certificate-product-specs.md`, including the same `$20/year`, `$100/year`, and 200-day validity figures, and the orientation walkthrough is also in `getting-started-ssl-certificates.md`. Pricing living in two places is a drift risk worth a separate look.

`dns.md`, `dnssec.md`, and `tlds.md` are the only pillars whose `Related articles` section required renumbering around a missing closer, which is what surfaced the second change below.

## The closing CTA

`dns.md`, `dnssec.md`, and `tlds.md` had no `## Have more questions?` section. They are the three oldest pillars of the thirteen:

| Pillar | Closer before this PR | Created |
|---|---|---|
| Connectors, Domain Contacts, DNS Templates, WHOIS Privacy | yes | 2026-07-31 |
| Your DNSimple Account | yes | 2026-07-22 |
| Name Server Management | yes | 2026-05-27 |
| Email Services | yes | 2026-04-17 |
| One-click Services, SSL/TLS Certificates, Getting Started with SSL | yes | 2024-02-20 |
| TLDs | **no** | 2026-02-19 |
| DNS | **no** | 2025-12-02 |
| DNSSEC | **no** | 2024-02-20 |

Every pillar written since has kept it, including the whole 2026-07-31 batch, and 476 of 522 articles across the site have it. The section is also in the documented page skeleton in `.cursor/rules/article-structure.mdc`, and again in that file's anchor-exceptions list. These three read as oversights rather than a decision, so all thirteen pillars now have it.

Wording follows the majority form from the 2026-07-31 batch: `If you have any questions about <topic>, just [contact support](...), and we'll be happy to help.` The contraction is deliberate; the writing rules allow contractions in the closing CTA specifically. No `{#have-more-questions}` anchor, per the rule about doubled fragment IDs.

## Checklist

- [x] Only files related to this task are included
- [x] Cross-links added on first mention of related concepts
- [x] No smart/curly quotes or special characters from macOS

## Review

- [ ] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)