### PR TITLE
Document the pillar page convention

### DIFF
--- a/.cursor/rules/article-structure.mdc
+++ b/.cursor/rules/article-structure.mdc
@@ -183,6 +183,26 @@ Concrete, citable facts make an article more useful to a reader and more quotabl
 - Include natural-language variations of key terms — people ask AI assistants in full sentences, not keyword fragments. Think "How do I renew an SSL certificate in DNSimple?" not just "renew SSL certificate."
 - Use the `excerpt` for user-facing summaries and `meta` for search/AI-facing descriptions. Both should contain the primary keyword.
 
+## Pillar pages
+
+A **pillar page** is a category's hub: the article listed under `Getting started` in the category YAML. It orients the reader and links out to the rest of the category. A pillar does not restate what the articles it links to already say.
+
+A pillar page has:
+
+- `categories` in its frontmatter naming its own category. Without it, the `Getting started` YAML section does not render.
+- Sections that group the category's articles by what the reader is trying to do, not by Diataxis label. Concepts first, then tasks, with Reference and Troubleshooting near the end.
+- Link text that is the target article's exact frontmatter `title`, followed by ` - ` and a one-line gloss saying what the reader gets from it.
+- A `## Related articles {#related}` section, second to last. It points at articles in **other** categories that come up alongside this one, in the same title-plus-gloss format. Links within the category belong in the sections above, not here.
+- The standard `## Have more questions?` closing CTA, last.
+
+Use `content/articles/domain-contacts-at-dnsimple.md` as the reference implementation.
+
+### Keeping a pillar current
+
+When you add an article to a category, add it to that category's pillar page in the same PR. An article that is reachable only through the category listing is easy to miss, and a pillar that is missing entries stops being a reliable entry point.
+
+This applies to articles still in open PRs. If two branches each add an article to the same category, the pillar needs both, and the category YAML will conflict where both branches appended to it. Resolve by keeping both sides.
+
 ## Category YAML
 
 When creating a new article, add it to the appropriate category YAML file in `categories/`. Articles not listed in a YAML file are grouped under "Other."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,14 @@ After making changes:
 rake run
 ```
 
+### Pillar pages
+
+Each category's `Getting started` entry is its pillar page: the hub that orients a reader and links out to the rest of the category.
+
+When you add an article to a category, add it to that category's pillar page in the same PR, including when the article is still in an open PR of its own. An article reachable only through the category listing is easy to miss.
+
+For the required structure of a pillar page, see the `Pillar pages` section of `.cursor/rules/article-structure.mdc`.
+
 ## Git and PR Guidelines
 
 ### Branching


### PR DESCRIPTION
## Summary

Documents the pillar page convention. No article content changes.

Companion to #2136, which brought the pillar pages themselves into line. This writes down the convention so it holds for the next one.

## Why

The word `pillar` appears nowhere in `.cursor/rules/`, `AGENTS.md`, or `CONTRIBUTING.md`. The shape of a pillar page existed only as precedent inside the pages themselves, which is how it drifted:

- Five of thirteen pillars had a `Related articles` section. The four that established the pattern were all created on 2026-07-31 in the same batch (#2062 to #2065). Nothing written down carried it forward.
- Three of thirteen had no `Have more questions?` closing CTA, even though that one **is** in the documented page skeleton.
- The Secondary DNS pillar in #2129 was missing three articles that were sitting in open draft PRs (#2130, #2131, #2132), because nothing said a new article has to be added to its pillar.

Each of those was found by hand. A rule turns that into something reviewable.

## Changes

**`.cursor/rules/article-structure.mdc`** - new `## Pillar pages` section, placed before `## Category YAML` since a pillar is the `Getting started` entry in that YAML. It records what the current pillars already do:

- own category in frontmatter `categories`, without which the `Getting started` YAML section does not render
- sections grouped by reader task, concepts first, Reference and Troubleshooting near the end
- link text is the target's exact frontmatter `title`, plus a one-line gloss
- `## Related articles {#related}` second to last, pointing **out** of the category
- `## Have more questions?` last

It names `content/articles/domain-contacts-at-dnsimple.md` as the reference implementation. That page has every element and is already on `main`, so the rule points at something real rather than at a description.

A `### Keeping a pillar current` subsection adds the one genuinely new requirement: adding an article to a category means adding it to that category's pillar in the same PR, including when the article is still in an open PR of its own.

**`CONTRIBUTING.md`** - short `### Pillar pages` subsection under `Managing Content`, next to the existing `Categories` and `Sub-categories` entries. It points at the rule file rather than restating it, so there is one source of truth.

`CLAUDE.md` needs no change: it `@`-includes the rule files, and Cursor reads `.cursor/rules/` directly.

## Scope note

You asked for the `Related articles` rule specifically. I wrote the surrounding pillar page convention instead, because a rule saying "a pillar page needs a Related articles section" would be the only mention of pillar pages in the entire repo, with nothing defining what a pillar page is. The `Related articles` requirement is one bullet inside it.

Two judgment calls worth a look:

- `### Keeping a pillar current` is the only genuinely **new** requirement here. Everything else describes what the pages already do. Cut it if it is more process than you want.
- I deliberately did not write down a title pattern. `<Topic> at DNSimple` covers most of them but not `One-click Services`, `SSL/TLS Certificates`, or `Your DNSimple Account`, and codifying it would either be wrong or force three renames plus redirects.

## Checklist

- [x] Only files related to this task are included
- [x] No smart/curly quotes or special characters from macOS

## Review

- [ ] Second expert tagged for feature/product knowledge
- [x] Customer Success tagged (required for substantial updates)
